### PR TITLE
Cache CMAKE_Swift_LINK_LIBRARY_FLAG

### DIFF
--- a/cmake/caches/windows-x86_64-swift-flags.cmake
+++ b/cmake/caches/windows-x86_64-swift-flags.cmake
@@ -1,4 +1,3 @@
-
 set(CMAKE_Swift_COMPILER_TARGET x86_64-unknown-windows-msvc CACHE STRING "")
 set(CMAKE_Swift_FLAGS "-resource-dir \"${CMAKE_Swift_SDK}/usr/lib/swift\" -L${CMAKE_Swift_SDK}/usr/lib/swift/windows" CACHE STRING "")
 set(CMAKE_Swift_LINK_FLAGS "-resource-dir \"${CMAKE_Swift_SDK}/usr/lib/swift\" -L${CMAKE_Swift_SDK}/usr/lib/swift/windows" CACHE STRING "")
@@ -7,5 +6,5 @@ set(CMAKE_SWIFT_FLAGS "-resource-dir \"${CMAKE_Swift_SDK}/usr/lib/swift\"" CACHE
 set(CMAKE_SWIFT_LINK_FLAGS "-resource-dir \"${CMAKE_Swift_SDK}/usr/lib/swift\"" CACHE STRING "")
 
 if(CMAKE_VERSION VERSION_LESS 3.16.0)
-  set(CMAKE_Swift_LINK_LIBRARY_FLAG "-l")
+  set(CMAKE_Swift_LINK_LIBRARY_FLAG "-l" CACHE STRING "")
 endif()


### PR DESCRIPTION
`CMAKE_Swift_LINK_LIBRARY_FLAG` is not cached without `CACHE` directive.