### PR TITLE
Match the repository usage in both stages of the build.

### DIFF
--- a/.ci/templates/toolchain.yml
+++ b/.ci/templates/toolchain.yml
@@ -100,12 +100,18 @@ jobs:
         condition: eq( variables['Agent.OS'], 'Windows_NT' )
         displayName: Enable symbolic links, disable line ending conversion
 
+      # The checkout list has to match with the windows-sdk.yml checkout list.
+      # Otherwise Azure will create different directories for each build.
       - checkout: self
         displayName: checkout compnerd/swift-build
 
       - checkout: apple/llvm-project
         displayName: checkout apple/llvm-project
         path: s/toolchain
+
+      - checkout: apple/swift
+        displayName: checkout apple/swift
+        path: s/toolchain/swift
 
       - checkout: apple/swift-cmark
         displayName: checkout apple/swift-cmark
@@ -114,9 +120,16 @@ jobs:
       - checkout: apple/swift-corelibs-libdispatch
         displayName: checkout apple/swift-corelibs-libdispatch
 
-      - checkout: apple/swift
-        displayName: checkout apple/swift
-        path: s/toolchain/swift
+      - checkout: apple/swift-corelibs-foundation
+        displayName: checkout apple/swift-corelibs-foundation
+
+      - checkout: apple/swift-corelibs-xctest
+        displayName: checkout apple/swift-corelibs-xctest
+
+      - ${{ if eq(parameters.TENSORFLOW, true) }}:
+        - checkout: tensorflow/swift-apis
+          displayName: checkout tensorflow/swift-apis
+          path: s/tensorflow-swift-apis
 
       - script: |
           git config --global user.name builder

--- a/.ci/templates/windows-sdk.yml
+++ b/.ci/templates/windows-sdk.yml
@@ -87,6 +87,8 @@ jobs:
         condition: eq( variables['Agent.OS'], 'Windows_NT' )
         displayName: Enable symbolic links, disable line ending conversion
 
+      # The checkout list has to match with the windows-sdk.yml checkout list.
+      # Otherwise Azure will create different directories for each build.
       - checkout: self
         displayName: checkout compnerd/swift-build
 
@@ -95,6 +97,10 @@ jobs:
 
       - checkout: apple/swift
         displayName: checkout apple/swift
+
+      - checkout: apple/swift-cmark
+        displayName: checkout apple/swift-cmark
+        path: s/toolchain/cmark
 
       - checkout: apple/swift-corelibs-libdispatch
         displayName: checkout apple/swift-corelibs-libdispatch


### PR DESCRIPTION
Seems that in a multi-stage pipeline, the collectionId and the definitionId in each of the stages is shared. Azure uses those to find out which repository to look for a manifest file. When the two stages have different repository lists, it seems that the previous work directory is discarded. Since both stages had different repository lists, one stage was overriding the other all the time. Since GC doesn't happen (because there's no maintenance), the file system was being filled all the time.

In theory.
