### PR TITLE
sdk, windows: workaround for Foundation crashes

### DIFF
--- a/.ci/templates/windows-sdk.yml
+++ b/.ci/templates/windows-sdk.yml
@@ -269,6 +269,7 @@ jobs:
             -B $(Build.BinariesDirectory)/foundation
             -C $(Build.SourcesDirectory)/swift-build/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}-clang.cmake
             -D SWIFT_STDLIB_DIR=$(Build.BinariesDirectory)/swift-stdlib
+            -D CMAKE_Swift_FLAGS="-Xfrontend -enable-spec-devirt -resource-dir \"$(Build.BinariesDirectory)/swift-stdlib/lib/swift\" -L$(Build.BinariesDirectory)/swift-stdlib/lib/swift/windows"
             -C $(Build.SourcesDirectory)/swift-build/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}-swift-flags.cmake
             -D CMAKE_BUILD_TYPE=Release
             -D CMAKE_INSTALL_PREFIX=$(install.directory)
@@ -418,6 +419,7 @@ jobs:
             -B $(Build.BinariesDirectory)/foundation
             -C $(Build.SourcesDirectory)/swift-build/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}-clang.cmake
             -D SWIFT_STDLIB_DIR=$(Build.BinariesDirectory)/swift-stdlib
+            -D CMAKE_Swift_FLAGS="-Xfrontend -enable-spec-devirt -resource-dir \"$(Build.BinariesDirectory)/swift-stdlib/lib/swift\" -L$(Build.BinariesDirectory)/swift-stdlib/lib/swift/windows"
             -C $(Build.SourcesDirectory)/swift-build/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}-swift-flags.cmake
             -D CMAKE_BUILD_TYPE=Release
             -D CMAKE_INSTALL_PREFIX=$(install.directory)


### PR DESCRIPTION
This enables speculative devirtualization for Foundation builds.

Speculative devirtualization was disabled by default in [5285bf7200d2999812a79df35ff2eebd41cc7ee7](https://github.com/apple/swift/commit/5285bf7200d2999812a79df35ff2eebd41cc7ee7), and since then Foundation tests crash rate noticeably increased.

Unfortunately, CMake has no way to append to `CMAKE_Swift_FLAGS` using only command line arguments. I had to specify some additional flags from caches file. Hope it didn't ruin quotes.