### PR TITLE
Use correct property name in PATH setter

### DIFF
--- a/wix/windows-runtime.wxs
+++ b/wix/windows-runtime.wxs
@@ -94,7 +94,7 @@
 
     <DirectoryRef Id="TARGETDIR">
       <Component Id="ENV_VARS" Guid="879f2029-84e0-4c64-9595-c11c499ff340">
-        <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]\Library\Swift-development\bin" />
+        <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[TARGETDIR]\Library\Swift-development\bin" />
       </Component>
     </DirectoryRef>
 

--- a/wix/windows-toolchain.wxs
+++ b/wix/windows-toolchain.wxs
@@ -313,7 +313,7 @@
 
     <DirectoryRef Id="TARGETDIR">
       <Component Id="ENV_VARS" Guid="0697d5fa-75ed-491d-8e7e-e6584a362382">
-        <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" />
+        <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[TARGETDIR]\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" />
       </Component>
     </DirectoryRef>
 


### PR DESCRIPTION
Without this change, the value added to the PATH will not be property rooted (i.e. it is missing the "C:" part at the beginning). This prevents the computer from finding either `swiftc.exe` or the Swift runtime binaries, making the files installed by these packages rather useless. Manually fixing the PATH using System Properties will work, but I wouldn’t recommend it as then the uninstaller will be unable to correctly remove the problematic entries (as the exact values it searches for will no longer exist).

I ran into this problem after installing the 5.2 compile release from this repo, and trying to compile the HelloWorld example project in swift-build-examples. I am not 100% positive that this is the correct fix, because I don’t (yet) know how to build the installers from scratch myself, but I’m pretty certain that these changes are correct. Thanks!