### PR TITLE
installer: add LLDB python scripts to installer

### DIFF
--- a/wix/windows-toolchain.wxs
+++ b/wix/windows-toolchain.wxs
@@ -57,6 +57,16 @@
                   <Directory Id="USR_LIB" Name="lib">
                     <Directory Id="USR_LIB_CLANG" Name="clang">
                     </Directory>
+                    <Directory Id="USR_LIB_SITE_PACKAGES" Name="site-packages">
+                      <Directory Id="USR_LIB_SITE_PACKAGES_LLDB" Name="lldb">
+                        <Directory Id="USR_LIB_SITE_PACKAGES_LLDB_FORMATTERS" Name="formatters">
+                          <Directory Id="USR_LIB_SITE_PACKAGES_LLDB_FORMATTERS_CPP" Name="cpp">
+                          </Directory>
+                        </Directory>
+                        <Directory Id="USR_LIB_SITE_PACKAGES_LLDB_UTILS" Name="utils">
+                        </Directory>
+                      </Directory>
+                    </Directory>
                     <Directory Id="USR_LIB_SWIFT" Name="swift">
                       <Directory Id="USR_LIB_SWIFT_MIGRATOR" Name="migrator">
                       </Directory>
@@ -225,6 +235,42 @@
       </Component>
     </DirectoryRef>
 
+    <DirectoryRef Id="USR_LIB_SITE_PACKAGES_LLDB">
+      <Component Id="LLDB_PYTHON_SCRIPTS" Guid="9205b430-21b1-4b50-ac91-cd41f3a0e050">
+        <File Id="LLDB___INIT___PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\__init__.py" Checksum="yes" />
+        <File Id="LLDB__LLDB_PYD" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\_lldb.pyd" Checksum="yes" />
+        <File Id="LLDB_EMBEDDED_INTERPRETER_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\embedded_interpreter.py" Checksum="yes" />
+        <File Id="LLDB_LLDB_ARGDUMPER_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\lldb-argdumper.exe" Checksum="yes" />
+      </Component>
+    </DirectoryRef>
+
+    <DirectoryRef Id="USR_LIB_SITE_PACKAGES_LLDB_FORMATTERS">
+      <Component Id="LLDB_PYTHON_SCRIPTS_FORMATTERS" Guid="54a46be0-3f9e-45aa-822d-0bbccedaecd3">
+        <File Id="LLDB_FORMATTER_LOGGER_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\Logger.py" Checksum="yes" />
+        <File Id="LLDB_FORMATTER___INIT___PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\__init__.py" Checksum="yes" />
+        <File Id="LLDB_FORMATTER_ATTRIB_FROMDICT_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\attrib_fromdict.py" Checksum="yes" />
+        <File Id="LLDB_FORMATTER_CACHE_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cache.py" Checksum="yes" />
+        <File Id="LLDB_FORMATTER_METRICS_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\metrics.py" Checksum="yes" />
+        <File Id="LLDB_FORMATTER_SYNTH_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\synth.py" Checksum="yes" />
+      </Component>
+    </DirectoryRef>
+
+    <DirectoryRef Id="USR_LIB_SITE_PACKAGES_LLDB_FORMATTERS_CPP">
+      <Component Id="LLDB_PYTHON_SCRIPTS_FORMATTERS_CPP" Guid="57b95077-a327-4f29-b923-81ea36ca0d04">
+        <File Id="LLDB_FORMATTER_CPP___INIT___PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\__init__.py" Checksum="yes" />
+        <File Id="LLDB_FORMATTER_CPP__GNU_LIBSTDCPP_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\gnu_libstdcpp.py" Checksum="yes" />
+        <File Id="LLDB_FORMATTER_CPP_LIBCXX_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\formatters\cpp\libcxx.py" Checksum="yes" />
+      </Component>
+    </DirectoryRef>
+
+    <DirectoryRef Id="USR_LIB_SITE_PACKAGES_LLDB_UTILS">
+      <Component Id="LLDB_PYTHON_SCRIPTS_UTILS" Guid="8181ff51-cd31-4e6b-9800-a718d17c12e7">
+        <File Id="LLDB_UTILS___INIT___PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\__init__.py" Checksum="yes" />
+        <File Id="LLDB_UTILS_IN_CALL_STACK_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\in_call_stack.py" Checksum="yes" />
+        <File Id="LLDB_UTILS_SYMBOLICATION_PY" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\site-packages\lldb\utils\symbolication.py" Checksum="yes" />
+      </Component>
+    </DirectoryRef>
+
     <!-- TODO: install the block headers from Swift -->
     <!--
     <DirectoryRef Id="USR_INCLUDE">
@@ -336,6 +382,11 @@
       <!--
       <ComponentGroupRef Id="SWIFT_SHIMS" />
       -->
+      <ComponentRef Id="LLDB_PYTHON_SCRIPTS" />
+      <ComponentRef Id="LLDB_PYTHON_SCRIPTS_FORMATTERS" />
+      <ComponentRef Id="LLDB_PYTHON_SCRIPTS_FORMATTERS_CPP" />
+      <ComponentRef Id="LLDB_PYTHON_SCRIPTS_UTILS" />
+
       <ComponentRef Id="ENV_VARS" />
     </Feature>
 


### PR DESCRIPTION
Add the lldb site-package for Python bindings to the installed image.
This was pointed out as missing by @mikkeyboi which prevents the use of
the installer image for setting up a jupyter notebook.