### PR TITLE
Add WiX signing support

### DIFF
--- a/wix/targets/CodeSigning.Tasks.targets
+++ b/wix/targets/CodeSigning.Tasks.targets
@@ -1,0 +1,201 @@
+<Project>
+  <UsingTask TaskName="CheckIfCertificateIsInstalled" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <CertificateThumbprint ParameterType="System.String" Required="true" />
+      <CertificateExists ParameterType="System.Boolean" Output="true" />
+      <CertificateStoreLocation ParameterType="System.String" />
+      <CertificateStoreName ParameterType="System.String" />
+    </ParameterGroup>
+
+    <Task>
+      <Using Namespace="System.Security.Cryptography.X509Certificates" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+        StoreName storeName = StoreName.My;
+        if (!string.IsNullOrEmpty(CertificateStoreName)) {
+          if (!Enum.TryParse(CertificateStoreName, ignoreCase: true, out storeName)) {
+            Log.LogError("Could not parse certificate store name '{0}'", CertificateStoreName);
+            return false;
+          }
+        }
+
+        StoreLocation storeLocation = StoreLocation.CurrentUser;
+        if (!string.IsNullOrEmpty(CertificateStoreLocation)) {
+          if (!Enum.TryParse(CertificateStoreLocation, ignoreCase: true, out storeLocation)) {
+            Log.LogError("Could not parse certificate store location '{0}'", CertificateStoreLocation);
+            return false;
+          }
+        }
+        
+        using (var store = new X509Store(storeName, storeLocation)) {
+          store.Open(OpenFlags.ReadOnly);
+          var certificates = store.Certificates.Find(X509FindType.FindByThumbprint, CertificateThumbprint, validOnly: false);
+          CertificateExists = certificates.Count > 0;
+        }
+
+        Success = true;
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <UsingTask TaskName="Sign" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <Task>
+      <Code Type="Class" Language="cs">
+        <![CDATA[
+using System;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+public sealed class Sign : ToolTask
+{
+	private const string SigntoolExeName = "signtool.exe";
+
+	[Required]
+	public string CertificateThumbprint
+	{
+		get;
+		set;
+	}
+
+	public string Description
+	{
+		get;
+		set;
+	}
+
+	public string ExecutablePath
+	{
+		get;
+		set;
+	}
+
+	public bool IgnoreExitCode
+	{
+		get;
+		set;
+	}
+
+	public string InformationUrl
+	{
+		get;
+		set;
+	}
+
+	[Required]
+	public ITaskItem[] ItemsToSign
+	{
+		get;
+		set;
+	}
+
+	public string TimestampingProvider
+	{
+		get;
+		set;
+	}
+
+	protected override string ToolName => "signtool.exe";
+
+	protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands)
+	{
+		try
+		{
+			foreach (ITaskItem itemToSign in ItemsToSign)
+			{
+				string fileFullPath = itemToSign.GetMetadata("FullPath");
+				string fileName = itemToSign.GetMetadata("Filename");
+				string fileExtensions = itemToSign.GetMetadata("Extension");
+				if (!File.Exists(fileFullPath))
+				{
+					Log.LogError("File to sign doesn't exist -> " + fileFullPath, Array.Empty<object>());
+				}
+				else
+				{
+					commandLineCommands = GenerateSha1CommandLineCommands(fileFullPath);
+					int exitCode2 = base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
+					if (exitCode2 != 0 && !IgnoreExitCode)
+					{
+						return exitCode2;
+					}
+
+					if (fileExtensions != ".msi")
+					{
+						commandLineCommands = GenerateSha256CommandLineCommands(fileFullPath);
+						exitCode2 = base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
+						if (exitCode2 != 0 && !IgnoreExitCode)
+						{
+							return exitCode2;
+						}
+						Log.LogMessage(MessageImportance.High, fileName + fileExtensions + " signed file -> " + fileFullPath, Array.Empty<object>());
+					}
+				}
+			}
+		}
+		catch (Exception ex)
+		{
+			Log.LogErrorFromException(ex, true);
+			return 1;
+		}
+		return 0;
+	}
+
+	protected override string GenerateFullPathToTool()
+	{
+		if (!File.Exists(ExecutablePath))
+		{
+			Log.LogWarning("The file path set on ExecutablePath does not exist: '" + ExecutablePath + "'. Falling back to using the system PATH.", Array.Empty<object>());
+			return "signtool.exe";
+		}
+		return ExecutablePath;
+	}
+
+	protected override bool HandleTaskExecutionErrors()
+	{
+		if (!IgnoreExitCode)
+		{
+			return base.HandleTaskExecutionErrors();
+		}
+		return true;
+	}
+
+	private string GenerateSha1CommandLineCommands(string filePath)
+	{
+		CommandLineBuilder builder = (CommandLineBuilder)(object)new CommandLineBuilder();
+		builder.AppendSwitch("sign");
+		builder.AppendSwitchIfNotNull("/sha1 ", CertificateThumbprint);
+		builder.AppendSwitchIfNotNull("/d ", Description);
+		builder.AppendSwitchIfNotNull("/du ", InformationUrl);
+		builder.AppendSwitchIfNotNull("/t ", TimestampingProvider);
+		builder.AppendSwitch("/v");
+		builder.AppendFileNameIfNotNull(filePath);
+		string commands = builder.ToString();
+		this.LogToolCommand("[Sign] " + commands);
+		return commands;
+	}
+
+	private string GenerateSha256CommandLineCommands(string filePath)
+	{
+		CommandLineBuilder builder = (CommandLineBuilder)(object)new CommandLineBuilder();
+		builder.AppendSwitch("sign");
+		builder.AppendSwitchIfNotNull("/sha1 ", CertificateThumbprint);
+		builder.AppendSwitch("/fd sha256");
+		builder.AppendSwitch("/as");
+		builder.AppendSwitchIfNotNull("/d ", Description);
+		builder.AppendSwitchIfNotNull("/du ", InformationUrl);
+		builder.AppendSwitchIfNotNull("/tr ", TimestampingProvider);
+		builder.AppendSwitch("/td sha256");
+		builder.AppendSwitch("/v");
+		builder.AppendFileNameIfNotNull(filePath);
+		string commands = builder.ToString();
+		this.LogToolCommand("[Sign] " + commands);
+		return commands;
+	}
+
+}
+]]>
+      </Code>
+    </Task>
+  </UsingTask>
+</Project>

--- a/wix/targets/CodeSigning.props
+++ b/wix/targets/CodeSigning.props
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup Condition="'$(SigningEnabled)' == 'true'">
+    <SignOutput>true</SignOutput>
+    <SignToolVersion Condition="'$(SignToolVersion)' == ''">10.0.18362.0</SignToolVersion>
+    <SignToolPath Condition="'$(SignToolPath)' == ''">$(MSBuildProgramFiles32)\Windows Kits\10\bin\$(SignToolVersion)\x86\signtool.exe</SignToolPath>
+    <CertificateThumbprint>AAAAAAAAAABBBBBBBBBBCCCCCCCCCCDDDDDDDDDD</CertificateThumbprint>
+
+    <SignTimestampingProvider>http://timestamp.digicert.com</SignTimestampingProvider>
+    <SignDescription>Replace Me</SignDescription>
+    <SignInformationUrl>http://example.com/</SignInformationUrl>
+  </PropertyGroup>
+</Project>

--- a/wix/targets/CodeSigning.targets
+++ b/wix/targets/CodeSigning.targets
@@ -1,0 +1,68 @@
+<Project>
+  <Import Project="CodeSigning.Tasks.targets" />
+
+  <Target Name="BeforeSigning">
+    <CheckIfCertificateIsInstalled CertificateThumbprint="$(CertificateThumbprint)" CertificateStoreName="My" CertificateStoreLocation="CurrentUser">
+      <Output TaskParameter="CertificateExists" PropertyName="CertificateExists" />
+    </CheckIfCertificateIsInstalled>
+
+    <Error Text="Signing is enabled but certificate with thumbprint '$(CertificateThumbprint)' does not exist."
+           Condition=" '$(CertificateExists)' == 'false' and '$(SigningEnabled)' == 'true' " />
+  </Target>
+
+  <Target Name="SignMsm">
+    <Sign ExecutablePath="$(SignToolPath)"
+      CertificateThumbprint="$(CertificateThumbprint)"
+      Description="$(SignDescription)"
+      InformationUrl="$(SignInformationUrl)"
+      TimestampingProvider="$(SignTimestampingProvider)"
+      ItemsToSign="@(SignMsm)"
+      IgnoreExitCode="false" />
+  </Target>
+  <Target Name="SignCabs">
+    <Sign ExecutablePath="$(SignToolPath)"
+      CertificateThumbprint="$(CertificateThumbprint)"
+      Description="$(SignDescription)"
+      InformationUrl="$(SignInformationUrl)"
+      TimestampingProvider="$(SignTimestampingProvider)"
+      ItemsToSign="@(SignCabs)"
+      IgnoreExitCode="false" />
+  </Target>
+  <Target Name="SignMsi">
+    <Sign ExecutablePath="$(SignToolPath)"
+      CertificateThumbprint="$(CertificateThumbprint)"
+      Description="$(SignDescription)"
+      InformationUrl="$(SignInformationUrl)"
+      TimestampingProvider="$(SignTimestampingProvider)"
+      ItemsToSign="@(SignMsi)"
+      IgnoreExitCode="false" />
+  </Target>
+
+  <Target Name="SignContainers">
+    <Sign ExecutablePath="$(SignToolPath)"
+      CertificateThumbprint="$(CertificateThumbprint)"
+      Description="$(SignDescription)"
+      InformationUrl="$(SignInformationUrl)"
+      TimestampingProvider="$(SignTimestampingProvider)"
+      ItemsToSign="@(SignContainers)"
+      IgnoreExitCode="false" />
+  </Target>
+  <Target Name="SignBundleEngine">
+    <Sign ExecutablePath="$(SignToolPath)"
+      CertificateThumbprint="$(CertificateThumbprint)"
+      Description="$(SignDescription)"
+      InformationUrl="$(SignInformationUrl)"
+      TimestampingProvider="$(SignTimestampingProvider)"
+      ItemsToSign="@(SignBundleEngine)"
+      IgnoreExitCode="false" />
+  </Target>
+  <Target Name="SignBundle">
+    <Sign ExecutablePath="$(SignToolPath)"
+      CertificateThumbprint="$(CertificateThumbprint)"
+      Description="$(SignDescription)"
+      InformationUrl="$(SignInformationUrl)"
+      TimestampingProvider="$(SignTimestampingProvider)"
+      ItemsToSign="@(SignBundle)"
+      IgnoreExitCode="false" />
+  </Target>
+</Project>

--- a/wix/windows-bundle.wixproj
+++ b/wix/windows-bundle.wixproj
@@ -22,7 +22,9 @@
     <DefineSolutionProperties>false</DefineSolutionProperties>
   </PropertyGroup>
 
+  <Import Project="targets\CodeSigning.props" />
   <Import Project="$(WixTargetsPath)" />
+  <Import Project="targets\CodeSigning.targets" />
 
   <PropertyGroup>
     <MSI_LOCATION Condition=" '$(MSI_LOCATION)' == '' ">.</MSI_LOCATION>

--- a/wix/windows-icu.wixproj
+++ b/wix/windows-icu.wixproj
@@ -20,7 +20,9 @@
     <DefineSolutionProperties>false</DefineSolutionProperties>
   </PropertyGroup>
 
+  <Import Project="targets\CodeSigning.props" />
   <Import Project="$(WixTargetsPath)" />
+  <Import Project="targets\CodeSigning.targets" />
 
   <PropertyGroup>
     <DefineConstants>ICU_ROOT=$(ICU_ROOT)</DefineConstants>

--- a/wix/windows-runtime.wixproj
+++ b/wix/windows-runtime.wixproj
@@ -26,7 +26,9 @@
     <TENSORFLOW Condition=" '$(TENSORFLOW)' == '' ">false</TENSORFLOW>
   </PropertyGroup>
 
+  <Import Project="targets\CodeSigning.props" />
   <Import Project="$(WixTargetsPath)" />
+  <Import Project="targets\CodeSigning.targets" />
 
   <PropertyGroup>
     <DefineConstants>PLATFORM_ROOT=$(PLATFORM_ROOT);SDK_ROOT=$(SDK_ROOT);$(INCLUDE_DEBUG_INFO);TENSORFLOW=$(TENSORFLOW)</DefineConstants>

--- a/wix/windows-sdk.wixproj
+++ b/wix/windows-sdk.wixproj
@@ -27,7 +27,9 @@
     <TENSORFLOW Condition=" '$(TENSORFLOW)' == '' ">false</TENSORFLOW>
   </PropertyGroup>
 
+  <Import Project="targets\CodeSigning.props" />
   <Import Project="$(WixTargetsPath)" />
+  <Import Project="targets\CodeSigning.targets" />
 
   <PropertyGroup>
     <DefineConstants>PLATFORM_ROOT=$(PLATFORM_ROOT);SDK_ROOT=$(SDK_ROOT);SWIFT_SOURCE_DIR=$(SWIFT_SOURCE_DIR);SDK_ROOT_USR_LIB_SWIFT_SHIMS=$(SDK_ROOT)\usr\lib\swift\shims;SDK_ROOT_USR_LIB_SWIFT_COREFOUNDATION=$(SDK_ROOT)\usr\lib\swift\CoreFoundation;SDK_ROOT_USR_LIB_SWIFT_TENSORFLOW=$(SDK_ROOT)\usr\lib\swift\tensorflow;TENSORFLOW=$(TENSORFLOW);TensorFlow_ROOT=$(TensorFlow_ROOT)</DefineConstants>

--- a/wix/windows-tensorflow.wixproj
+++ b/wix/windows-tensorflow.wixproj
@@ -20,7 +20,9 @@
     <DefineSolutionProperties>false</DefineSolutionProperties>
   </PropertyGroup>
 
+  <Import Project="targets\CodeSigning.props" />
   <Import Project="$(WixTargetsPath)" />
+  <Import Project="targets\CodeSigning.targets" />
 
   <PropertyGroup>
     <DefineConstants>TensorFlow_ROOT=$(TensorFlow_ROOT)</DefineConstants>

--- a/wix/windows-toolchain.wixproj
+++ b/wix/windows-toolchain.wixproj
@@ -22,7 +22,9 @@
     <DefineSolutionProperties>false</DefineSolutionProperties>
   </PropertyGroup>
 
+  <Import Project="targets\CodeSigning.props" />
   <Import Project="$(WixTargetsPath)" />
+  <Import Project="targets\CodeSigning.targets" />
 
   <PropertyGroup>
     <DefineConstants>TOOLCHAIN_ROOT=$(TOOLCHAIN_ROOT);TOOLCHAIN_ROOT_USR_LIB_CLANG=$(TOOLCHAIN_ROOT)\usr\lib\clang;$(INCLUDE_DEBUG_INFO)</DefineConstants>


### PR DESCRIPTION
Does what the title says. Note that this is necessarily incomplete. For it to be production-ready, you’ll have to replace the `CertificateThumbprint`, `SignDescription`, and `SignInformationUrl` properties in CodeSigning.props with appropriate values. Then pass `/p:SigningEnabled=true` when building one of the WiX projects to sign all build artifacts as they are created.

Don’t forget to add the imports to `windows-runtime-msm.wixproj` and `windows-icu-msm.wixproj` once #192 is merged, or the merge modules will not be signed.

Fixes #151.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/193)
<!-- Reviewable:end -->
