### PR TITLE
Windows: avoid `CURL_DIR` to repair the build

### DIFF
--- a/.ci/templates/windows-sdk.yml
+++ b/.ci/templates/windows-sdk.yml
@@ -463,7 +463,6 @@ jobs:
             -D LIBXML2_LIBRARY=$(xml2.directory)/usr/lib/libxml2s.lib
             -D LIBXML2_INCLUDE_DIR=$(xml2.directory)/usr/include/libxml2
             -D dispatch_DIR=$(Build.BinariesDirectory)/libdispatch/cmake/modules
-            -D CURL_DIR=$(curl.directory)/usr/lib/cmake/CURL
             -D ENABLE_TESTING=YES
             -D XCTest_DIR=$(Build.BinariesDirectory)/xctest/cmake/modules
 


### PR DESCRIPTION
The `CURL_DIR` will reference the build tree potentially which may be
different than this tree.  Use the manually specified paths instead.