### PR TITLE
CI: remove additional usage of `CURL_DIR`

### DIFF
--- a/.ci/templates/linux-sdk.yml
+++ b/.ci/templates/linux-sdk.yml
@@ -228,7 +228,6 @@ jobs:
           workingDirectory: $(Build.BinariesDirectory)/foundation
           cmakeArgs:
             -G Ninja
-            -S $(Build.SourcesDirectory)/swift-corelibs-foundation
             -B $(Build.BinariesDirectory)/foundation
             -C $(Build.SourcesDirectory)/swift-build/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}.cmake
             -D CMAKE_Swift_SDK=$(sdk.directory)
@@ -250,7 +249,9 @@ jobs:
             -D LIBXML2_LIBRARY=$(xml2.directory)/usr/lib/libxml2.a
             -D LIBXML2_INCLUDE_DIR=$(xml2.directory)/usr/include/libxml2
             -D dispatch_DIR=$(Build.BinariesDirectory)/libdispatch/cmake/modules
+            -D CURL_NO_CURL_CMAKE=YES
             -D CURL_DIR=$(curl.directory)/usr/lib/cmake/CURL
+            -S $(Build.SourcesDirectory)/swift-corelibs-foundation
 
       - task: CMake@1
         displayName: Build Foundation

--- a/.ci/templates/windows-sdk.yml
+++ b/.ci/templates/windows-sdk.yml
@@ -269,7 +269,6 @@ jobs:
           workingDirectory: $(Build.BinariesDirectory)/foundation
           cmakeArgs:
             -G Ninja
-            -S $(Build.SourcesDirectory)/swift-corelibs-foundation
             -B $(Build.BinariesDirectory)/foundation
             -C $(Build.SourcesDirectory)/swift-build/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}-clang.cmake
             -D SWIFT_STDLIB_DIR=$(Build.BinariesDirectory)/swift-stdlib
@@ -288,8 +287,10 @@ jobs:
             -D LIBXML2_LIBRARY=$(xml2.directory)/usr/lib/libxml2s.lib
             -D LIBXML2_INCLUDE_DIR=$(xml2.directory)/usr/include/libxml2
             -D dispatch_DIR=$(Build.BinariesDirectory)/libdispatch/cmake/modules
+            -D CURL_NO_CURL_CMAKE=YES
             -D CURL_DIR=$(curl.directory)/usr/lib/cmake/CURL
             -D ENABLE_TESTING=NO
+            -S $(Build.SourcesDirectory)/swift-corelibs-foundation
 
       - task: CMake@1
         displayName: Build Foundation


### PR DESCRIPTION
This should hopefully restore the 5.2 windows builds.