### PR TITLE
android: force configuration

### DIFF
--- a/.ci/templates/android-sdk.yml
+++ b/.ci/templates/android-sdk.yml
@@ -189,7 +189,6 @@ jobs:
           workingDirectory: $(Build.BinariesDirectory)/foundation
           cmakeArgs:
             -G Ninja
-            -S $(Build.SourcesDirectory)/swift-corelibs-foundation
             -B $(Build.BinariesDirectory)/foundation
             -C $(Build.SourcesDirectory)/swift-build/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}.cmake
             -D CMAKE_Swift_SDK=$(sdk.directory)
@@ -211,6 +210,8 @@ jobs:
             -D LIBXML2_INCLUDE_DIR=$(xml2.directory)/usr/include/libxml2
             -D dispatch_DIR=$(Build.BinariesDirectory)/libdispatch/cmake/modules
             -D CMAKE_BUILD_WITH_INSTALL_RPATH=YES
+            -D CMAKE_HAVE_LIBC_PTHREAD=YES
+            -S $(Build.SourcesDirectory)/swift-corelibs-foundation
 
       - task: CMake@1
         displayName: Build Foundation


### PR DESCRIPTION
For some reason the `CMAKE_HAVE_LIBC_PTHREAD` is failing on the builder.
Force the setting to repair the build.