### PR TITLE
TensorFlow: update rules for TensorFlow 2.2.0-rc1

### DIFF
--- a/.ci/macOS-tensorflow.yml
+++ b/.ci/macOS-tensorflow.yml
@@ -14,7 +14,6 @@ resources:
 
     - pipeline: tensorflow
       source: tensorflow
-      version: 26053
 
   repositories:
     - repository: apple/llvm-project

--- a/.ci/templates/macos-sdk.yml
+++ b/.ci/templates/macos-sdk.yml
@@ -36,7 +36,7 @@ jobs:
 
       curl.version: development
       icu.version: 64
-      tensorflow.version: 2.1.0-rc1
+      tensorflow.version: 2.2.0-rc1
       xml2.version: development
       zlib.version: 1.2.11
 
@@ -334,7 +334,7 @@ jobs:
               -D CMAKE_BUILD_TYPE=Release
               -D CMAKE_INSTALL_PREFIX=$(install.directory)
               -D TensorFlow_INCLUDE_DIR=$(tensorflow.directory)/usr/include
-              -D TensorFlow_LIBRARY=$(tensorflow.directory)/usr/lib/libtensorflow.2.1.0.dylib
+              -D TensorFlow_LIBRARY=$(tensorflow.directory)/usr/lib/libtensorflow.2.2.0.dylib
               -G Ninja
               -S $(Build.SourcesDirectory)/tensorflow-swift-apis
 

--- a/.ci/templates/windows-sdk.yml
+++ b/.ci/templates/windows-sdk.yml
@@ -38,7 +38,7 @@ jobs:
 
       curl.version: development
       icu.version: 64
-      tensorflow.version: 2.1.0-rc1
+      tensorflow.version: 2.2.0-rc1
       xml2.version: development
       zlib.version: 1.2.11
 

--- a/.ci/templates/xctoolchain.yml
+++ b/.ci/templates/xctoolchain.yml
@@ -1,7 +1,7 @@
 jobs:
   - job: xctoolchain
     variables:
-      tensorflow.version: 2.1.0-rc1
+      tensorflow.version: 2.2.0-rc1
       tensorflow.directory: $(Pipeline.Workspace)/tensorflow/tensorflow-${{ parameters.platform }}-${{ parameters.host }}/Library/tensorflow-$(tensorflow.version)
 
       toolchain.directory: $(Build.StagingDirectory)/swift-toolchain/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
@@ -113,8 +113,8 @@ jobs:
             rsync -v -a -l $(Pipeline.Workspace)/sdk-darwin-${{ parameters.host }}/Library/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/swift/shims $(toolchain.directory)/usr/lib/swift
             rsync -v -a -l $(Pipeline.Workspace)/sdk-darwin-${{ parameters.host }}/Library/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/swift/tensorflow $(toolchain.directory)/usr/lib/swift
 
-            cp -v $(tensorflow.directory)/usr/lib/libtensorflow.2.1.0.dylib $(toolchain.directory)/usr/lib/swift/macosx
-            ln -v -s libtensorflow.2.1.0.dylib $(toolchain.directory)/usr/lib/swift/macosx/libtensorflow.2.1.dylib
+            cp -v $(tensorflow.directory)/usr/lib/libtensorflow.2.2.0.dylib $(toolchain.directory)/usr/lib/swift/macosx
+            ln -v -s libtensorflow.2.2.0.dylib $(toolchain.directory)/usr/lib/swift/macosx/libtensorflow.2.1.dylib
             ln -v -s libtensorflow.2.1.dylib $(toolchain.directory)/usr/lib/swift/macosx/libtensorflow.2.dylib
             ln -v -s libtensorflow.2.dylib $(toolchain.directory)/usr/lib/swift/macosx/libtensorflow.dylib
           displayName: augment image

--- a/wix/windows-sdk.wxs
+++ b/wix/windows-sdk.wxs
@@ -156,7 +156,7 @@
       </Component>
 
       <Component Id="TENSORFLOW_IMPORT_LIBS" Guid="a8ed3372-8b8a-4f5a-af1c-dda6f316846b">
-        <File Id="TENSORFLOW_LIB" Source="$(var.TensorFlow_ROOT)\Library\tensorflow-2.1.0-rc1\usr\lib\tensorflow.lib" Checksum="yes" />
+        <File Id="TENSORFLOW_LIB" Source="$(var.TensorFlow_ROOT)\Library\tensorflow-2.2.0-rc1\usr\lib\tensorflow.lib" Checksum="yes" />
       </Component>
 
       <Component Id="TENSORFLOW_SWIFT_APIS_IMPORT_LIBS" Guid="1c16111f-bcbe-4943-bb84-9cb76f5ca6c3">

--- a/wix/windows-tensorflow.wixproj
+++ b/wix/windows-tensorflow.wixproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <ProjectGuid>d76e8f23-a30c-474d-9949-87c2b4b03fc7</ProjectGuid>
-    <ProductVersion>2.1.0-rc1</ProductVersion>
+    <ProductVersion>2.2.0-rc1</ProductVersion>
     <OutputName>tensorflow</OutputName>
     <OutputType>Package</OutputType>
   </PropertyGroup>

--- a/wix/windows-tensorflow.wxs
+++ b/wix/windows-tensorflow.wxs
@@ -5,7 +5,7 @@
            Manufacturer="dt.compnerd.org"
            Name="TensorFlow"
            UpgradeCode="c16b17e8-b3a3-4674-984e-deb1d1c3ed33"
-           Version="2.1.0.9999" >
+           Version="2.2.0.9999" >
   <Package Comments="Copyright 2020 Saleem Abdulrasool &lt;compnerd@compnerd.org&gt;"
            Compressed="yes"
            InstallScope="perMachine"
@@ -23,7 +23,7 @@
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="WINDOWSVOLUME">
         <Directory Id="LIBRARY" Name="Library">
-          <Directory Id="TENSORFLOW" Name="tensorflow-2.1.0-rc1">
+          <Directory Id="TENSORFLOW" Name="tensorflow-2.2.0-rc1">
             <Directory Id="TENSORFLOW_USR" Name="usr">
               <Directory Id="TENSORFLOW_USR_BIN" Name="bin">
               </Directory>
@@ -38,13 +38,13 @@
     <!-- Components -->
     <DirectoryRef Id="TENSORFLOW_USR_BIN">
       <Component Id="TENSORFLOW_RUNTIME" Guid="92056aaf-9b0d-437a-82da-24484380479a">
-        <File Id="TENSORFLOW_DLL" Source="$(var.TensorFlow_ROOT)\Library\tensorflow-2.1.0-rc1\usr\bin\tensorflow.dll" Checksum="yes" />
+        <File Id="TENSORFLOW_DLL" Source="$(var.TensorFlow_ROOT)\Library\tensorflow-2.2.0-rc1\usr\bin\tensorflow.dll" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
     <DirectoryRef Id="TARGETDIR">
       <Component Id="ENV_VARS" Guid="93a272cb-e23f-4263-85f5-f313bbb15500">
-        <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[WindowsVolume]Library\tensorflow-2.1.0-rc1\usr\bin" />
+        <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[WindowsVolume]Library\tensorflow-2.2.0-rc1\usr\bin" />
       </Component>
     </DirectoryRef>
 


### PR DESCRIPTION
Update the references to the TensorFlow version to 2.2.0-rc1.  This
update sets the stage for building the x10 library target.