### PR TITLE
caches: enable clangd builds

### DIFF
--- a/cmake/caches/org.compnerd.dt.cmake
+++ b/cmake/caches/org.compnerd.dt.cmake
@@ -124,7 +124,7 @@ set(LLVM_TOOLCHAIN_TOOLS
 
 set(CLANG_TOOLS
       clang
-      # clangd
+      clangd
       clang-format
       clang-resource-headers
       # clang-rename


### PR DESCRIPTION
This enables clangd in the toolchain as it is useful for IDE
integration.  If we are able to include this without exceeding the
timing on the azure hosts, a follow up change would be needed to package
that into the MSI and installer.

Resolves: #196