### PR TITLE
TensorFlow: attempt to repair the swift-apis build

### DIFF
--- a/.ci/templates/windows-sdk.yml
+++ b/.ci/templates/windows-sdk.yml
@@ -356,6 +356,7 @@ jobs:
               -D CMAKE_INSTALL_PREFIX=$(install.directory)
               -D BUILD_X10=YES
               -D X10_LIBRARY=$(tensorflow.directory)/usr/lib/x10.lib
+              -D X10_INCLUDE_DIRS=$(tensorflow.directory)/usr/include
               -G Ninja
               -S $(Build.SourcesDirectory)/tensorflow-swift-apis
 


### PR DESCRIPTION
The swift-apis build requires an additional parameter to find the
TensorFlow headers for the `CTensorFlow` module.