### PR TITLE
VS2019: add additional variables for Android SDK builds

### DIFF
--- a/.ci/vs2019.yml
+++ b/.ci/vs2019.yml
@@ -173,7 +173,7 @@ stages:
           os: Android
           proc: armv7
 
-          SWIFT_OPTIONS: -D SWIFT_ANDROID_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_armv7_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_armv7_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -DICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -DICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -DICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -DICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_armv7_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_armv7_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/android-sdk.yml
         parameters:
@@ -188,7 +188,7 @@ stages:
           os: Android
           proc: arm64
 
-          SWIFT_OPTIONS: -D SWIFT_ANDROID_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_aarch64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_aarch64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -DICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -DICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -DICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -DICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_aarch64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_aarch64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/android-sdk.yml
         parameters:
@@ -203,7 +203,7 @@ stages:
           os: Android
           proc: amd64
 
-          SWIFT_OPTIONS: -D SWIFT_ANDROID_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_x86_64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_x86_64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -DICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -DICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -DICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -DICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_x86_64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_x86_64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/android-sdk.yml
         parameters:
@@ -218,7 +218,7 @@ stages:
           os: Android
           proc: i686
 
-          SWIFT_OPTIONS: -D SWIFT_ANDROID_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_i686_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_i686_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -DICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -DICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -DICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -DICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_i686_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_i686_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
   - stage: windows_sdk
     dependsOn: toolchain


### PR DESCRIPTION
Repair the Android SDK build which requires additional variables to find
ICU.