### PR TITLE
Clarify the purpose of swift-build in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # **//swift/build**
 
+The swift-build project provides a CI configuration for [Azure 
+Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) that allows 
+building Swift for multiple platforms. Thanks to modular packaging, with swift-build 
+you can easily cross-compile your Swift code for Android and Windows targets, or build 
+on Windows natively without cross-compilation.
+
 ## Table of Contents
 
 - [**//swift/build**](#--swift-build---)


### PR DESCRIPTION
I don't know if I'm alone in this opinion, but it was hard for me to understand what exactly swift-build does. At least the available project description "Alternate Swift Builds" doesn't tell me much about it, `README.md` only contains links to packages and "Getting started" guides (getting started with what exactly?), but there is no detailed description in `README.md` itself. Was its purpose just to provide packages for Windows (it probably was in the past)? How is Android or TensorFlow packaging related then? Why are there references to Debian packaging?

Now after I was pointed to the way that CI is set up for swift-build, I think it makes a bit more sense to me. This PR is primarily meant to start a discussion on how front facing documentation of swift-build could be improved. I look forward to any feedback, for example I'm still not sure if I should use `swift-build` or `//swift/build` when referring to the project?

I still haven't tried using Docker with the supplied Debian packages, will probably be able to add a sentence or a paragraph about that, after I have a bit more experience with that side of things.