### PR TITLE
CI: externalize ICU configuration

### DIFF
--- a/.ci/macOS-tensorflow.yml
+++ b/.ci/macOS-tensorflow.yml
@@ -118,8 +118,8 @@ stages:
 
           triple: x86_64-apple-macosx10.14
 
+          ICU_VERSION: 0
           LLVM_OPTIONS: -DLLVM_INCLUDE_TESTS=NO
-
           LLDB_OPTIONS: -DLLDB_USE_SYSTEM_DEBUGSERVER=ON -DLLDB_INCLUDE_TESTS=NO -DLLDB_BUILD_FRAMEWORK=YES -DLLDB_DISABLE_PYTHON=YES
           SWIFT_OPTIONS: -DTF_LIBRARY=$(tensorflow.directory)/usr/lib/libtensorflow.dylib -DTF_INCLUDE_DIR=$(tensorflow.directory)/usr/include -DSWIFT_ENABLE_TENSORFLOW=YES
 
@@ -140,6 +140,7 @@ stages:
 
           triple: x86_64-apple-macosx10.14
 
+          ICU_VERSION: 0
           SWIFT_OPTIONS: -D CMAKE_CXX_FLAGS="-isystem /Applications/Xcode_11.2.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1" -DSWIFT_ENABLE_TENSORFLOW=YES -DSWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING=YES
 
           os: MacOSX

--- a/.ci/macOS.yml
+++ b/.ci/macOS.yml
@@ -114,8 +114,8 @@ stages:
 
           triple: x86_64-apple-macosx10.14
 
+          ICU_VERSION: 0
           LLVM_OPTIONS: -DLLVM_INCLUDE_TESTS=NO
-
           LLDB_OPTIONS: -DLLDB_USE_SYSTEM_DEBUGSERVER=ON -DLLDB_INCLUDE_TESTS=NO -DLLDB_BUILD_FRAMEWORK=YES
           SWIFT_OPTIONS: -DSWIFT_INCLUDE_TESTS=NO -DSWIFT_BUILD_STDLIB_EXTRA_TOOLCHAIN_CONTENT=NO
 
@@ -134,6 +134,7 @@ stages:
 
           triple: x86_64-apple-macosx10.14
 
+          ICU_VERSION: 0
           SWIFT_OPTIONS: -D CMAKE_CXX_FLAGS="-isystem /Applications/Xcode_11.2.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1"
 
           os: MacOSX

--- a/.ci/templates/android-sdk.yml
+++ b/.ci/templates/android-sdk.yml
@@ -25,13 +25,16 @@ parameters:
   - name: proc
     type: string
 
+  - name: ICU_VERSION
+    type: string
+
 jobs:
   - job: ${{ parameters.host }}
     variables:
       toolchain.directory: $(Pipeline.Workspace)/toolchain-windows-x64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
 
       curl.version: development
-      icu.version: 64
+      icu.version: ${{ parameters.ICU_VERSION }}
       xml2.version: development
       zlib.version: 1.2.11
 

--- a/.ci/templates/icu-deb.yml
+++ b/.ci/templates/icu-deb.yml
@@ -1,7 +1,7 @@
 jobs:
   - job: swift_icu__${{ parameters.proc }}_deb
     variables:
-      icu.version: 64
+      icu.version: ${{ parameters.ICU_VERSION }}
     steps:
       - download: icu
         artifact: icu-linux-${{ parameters.host }}

--- a/.ci/templates/linux-sdk.yml
+++ b/.ci/templates/linux-sdk.yml
@@ -29,13 +29,16 @@ parameters:
   - name: proc
     type: string
 
+  - name: ICU_VERSION
+    type: string
+
 jobs:
   - job: ${{ parameters.host }}
     variables:
       toolchain.directory: $(Pipeline.Workspace)/toolchain-linux-x64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
 
       curl.version: development
-      icu.version: 64
+      icu.version: ${{ parameters.ICU_VERSION }}
       xml2.version: development
       zlib.version: 1.2.11
 

--- a/.ci/templates/macos-sdk.yml
+++ b/.ci/templates/macos-sdk.yml
@@ -29,13 +29,16 @@ parameters:
   - name: proc
     type: string
 
+  - name: ICU_VERSION
+    type: string
+
 jobs:
   - job: ${{ parameters.host }}
     variables:
       toolchain.directory: $(Pipeline.Workspace)/toolchain-darwin-x64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
 
       curl.version: development
-      icu.version: 64
+      icu.version: ${{ parameters.ICU_VERSION }}
       tensorflow.version: 2.2.0-rc1
       xml2.version: development
       zlib.version: 1.2.11

--- a/.ci/templates/toolchain.yml
+++ b/.ci/templates/toolchain.yml
@@ -43,11 +43,14 @@ parameters:
   - name: triple
     type: string
 
+  - name: ICU_VERSION
+    type: string
+
 jobs:
   - job: ${{ parameters.host }}
     timeoutInMinutes: 0
     variables:
-      icu.version: 64
+      icu.version: ${{ parameters.ICU_VERSION }}
       icu.directory: $(Pipeline.Workspace)/icu/icu-${{ parameters.platform }}-${{ parameters.host }}/Library/icu-$(icu.version)
 
       tensorflow.directory: $(Pipeline.Workspace)/tensorflow-${{ parameters.platform }}-${{ parameters.host }}/Library

--- a/.ci/templates/windows-sdk.yml
+++ b/.ci/templates/windows-sdk.yml
@@ -29,6 +29,9 @@ parameters:
   - name: proc
     type: string
 
+  - name: ICU_VERSION
+    type: string
+
 jobs:
   - job: ${{ parameters.host }}
     # NOTE(compnerd) disable non-x64 builds as they are currently broken :(
@@ -37,7 +40,7 @@ jobs:
       toolchain.directory: $(Pipeline.Workspace)/toolchain-windows-x64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
 
       curl.version: development
-      icu.version: 64
+      icu.version: ${{ parameters.ICU_VERSION }}
       tensorflow.version: 2.2.0-rc1
       xml2.version: development
       zlib.version: 1.2.11

--- a/.ci/ubuntu-18.04-flowkey.yml
+++ b/.ci/ubuntu-18.04-flowkey.yml
@@ -121,6 +121,7 @@ stages:
 
           triple: x86_64-unknown-linux-gnu
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -DICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -DICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -DICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DSWIFT_LINUX_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_LINUX_x86_64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -DSWIFT_LINUX_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_LINUX_x86_64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
 
           RUN_TESTS: false
@@ -140,7 +141,8 @@ stages:
           os: Linux
           proc: amd64
 
-          SWIFT_OPTIONS: -DICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -DICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -DICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -DICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DSWIFT_LINUX_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_LINUX_x86_64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -DSWIFT_LINUX_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_LINUX_x86_64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so
+          ICU_VERSION: 64
+          SWIFT_OPTIONS: -D ICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -D ICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D ICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -D ICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_LINUX_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_LINUX_x86_64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_LINUX_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_LINUX_x86_64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so
 
   - stage: devtools
     pool: FlowKey
@@ -174,6 +176,8 @@ stages:
 
           os: Linux
           proc: amd64
+
+          ICU_VERSION: 64
 
       - template: templates/sdk-deb.yml
         parameters:

--- a/.ci/ubuntu-18.04-google.yml
+++ b/.ci/ubuntu-18.04-google.yml
@@ -122,6 +122,7 @@ stages:
 
           triple: x86_64-unknown-linux-gnu
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_LINUX_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_LINUX_x86_64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -DSWIFT_LINUX_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_LINUX_x86_64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
 
           RUN_TESTS: false

--- a/.ci/vs2017-facebook.yml
+++ b/.ci/vs2017-facebook.yml
@@ -122,6 +122,7 @@ stages:
 
           triple: x86_64-unknown-windows-msvc
 
+          ICU_VERSION: 64
           LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=8 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
 
@@ -144,6 +145,7 @@ stages:
           os: Windows
           proc: arm
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/windows-sdk.yml
@@ -159,6 +161,7 @@ stages:
           os: Windows
           proc: arm64
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/windows-sdk.yml
@@ -174,6 +177,7 @@ stages:
           os: Windows
           proc: amd64
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/windows-sdk.yml
@@ -189,4 +193,5 @@ stages:
           os: Windows
           proc: i686
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe

--- a/.ci/vs2017.yml
+++ b/.ci/vs2017.yml
@@ -126,6 +126,7 @@ stages:
 
           triple: x86_64-unknown-windows-msvc
 
+          ICU_VERSION: 64
           LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
 
@@ -144,3 +145,5 @@ stages:
           host: x64
           platform: windows
           proc: amd64
+
+          ICU_VERSION: 64

--- a/.ci/vs2019-facebook.yml
+++ b/.ci/vs2019-facebook.yml
@@ -122,6 +122,7 @@ stages:
 
           triple: x86_64-unknown-windows-msvc
 
+          ICU_VERSION: 64
           LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=8 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
 
@@ -144,6 +145,7 @@ stages:
           os: Windows
           proc: arm
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/windows-sdk.yml
@@ -159,6 +161,7 @@ stages:
           os: Windows
           proc: arm64
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/windows-sdk.yml
@@ -174,6 +177,7 @@ stages:
           os: Windows
           proc: amd64
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/windows-sdk.yml
@@ -189,4 +193,5 @@ stages:
           os: Windows
           proc: i686
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe

--- a/.ci/vs2019-google.yml
+++ b/.ci/vs2019-google.yml
@@ -120,6 +120,7 @@ stages:
 
           triple: x86_64-unknown-windows-msvc
 
+          ICU_VERSION: 64
           LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
 
@@ -136,6 +137,7 @@ stages:
 
           triple: aarch64-unknown-windows-msvc
 
+          ICU_VERSION: 64
           # NOTE(compnerd) DIA does not contain ARM64 diaguids.lib
           LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_ENABLE_DIA_SDK=NO -DLLVM_INCLUDE_TESTS=NO -DCLANG_INCLUDE_TESTS=NO -DLLD_INCLUDE_TESTS=NO -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
           # NOTE(compnerd) disable python support as we need an ARM64 build of
@@ -166,6 +168,7 @@ stages:
           os: Windows
           proc: arm
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
 
       - template: templates/windows-sdk.yml
@@ -181,6 +184,7 @@ stages:
           os: Windows
           proc: arm64
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
 
       - template: templates/windows-sdk.yml
@@ -196,6 +200,7 @@ stages:
           os: Windows
           proc: amd64
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
 
       - template: templates/windows-sdk.yml
@@ -211,6 +216,7 @@ stages:
           os: Windows
           proc: i686
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
 
   - stage: devtools

--- a/.ci/vs2019-master-next.yml
+++ b/.ci/vs2019-master-next.yml
@@ -102,6 +102,7 @@ stages:
 
           triple: x86_64-unknown-windows-msvc
 
+          ICU_VERSION: 64
           LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
 
@@ -118,6 +119,7 @@ stages:
 
           triple: aarch64-unknown-windows-msvc
 
+          ICU_VERSION: 64
           # NOTE(compnerd) DIA does not contain ARM64 diaguids.lib
           LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_ENABLE_DIA_SDK=NO -DLLVM_INCLUDE_TESTS=NO -DCLANG_INCLUDE_TESTS=NO -DLLD_INCLUDE_TESTS=NO -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
           # NOTE(compnerd) disable python as we need an ARM64 build of python to
@@ -148,6 +150,7 @@ stages:
           os: Windows
           proc: arm
 
+          ICU_VERISON: 67
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
 
       - template: templates/windows-sdk.yml
@@ -163,6 +166,7 @@ stages:
           os: Windows
           proc: arm64
 
+          ICU_VERISON: 67
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
 
       - template: templates/windows-sdk.yml
@@ -178,6 +182,7 @@ stages:
           os: Windows
           proc: amd64
 
+          ICU_VERISON: 67
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
 
       - template: templates/windows-sdk.yml
@@ -193,6 +198,7 @@ stages:
           os: Windows
           proc: i686
 
+          ICU_VERISON: 67
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
 
   - stage: devtools

--- a/.ci/vs2019-swift-5.2.yml
+++ b/.ci/vs2019-swift-5.2.yml
@@ -9,7 +9,7 @@ pr:
 resources:
   pipelines:
     - pipeline: icu
-      source: 'ICU'
+      source: ICU
 
     - pipeline: xml2
       source: 'XML2'
@@ -123,6 +123,7 @@ stages:
 
           triple: aarch64-unknown-windows-msvc
 
+          ICU_VERSION: 64
           # NOTE(compnerd) DIA does not contain ARM64 diaguids.lib
           LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_ENABLE_DIA_SDK=NO -DLLVM_INCLUDE_TESTS=NO -DCLANG_INCLUDE_TESTS=NO -DLLD_INCLUDE_TESTS=NO
           LLDB_OPTIONS: -DLLDB_DISABLE_PYTHON=YES -DLLDB_INCLUDE_TESTS=NO
@@ -143,6 +144,7 @@ stages:
 
           triple: x86_64-unknown-windows-msvc
 
+          ICU_VERSION: 64
           LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
           LLDB_OPTIONS: -DLLDB_DISABLE_PYTHON=YES
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
@@ -171,7 +173,8 @@ stages:
           os: Android
           proc: armv7
 
-          SWIFT_OPTIONS: -D SWIFT_ANDROID_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_armv7_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_armv7_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          ICU_VERSION: 64
+          SWIFT_OPTIONS: -D SWIFT_ANDROID_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_armv7_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_armv7_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D PYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/android-sdk.yml
         parameters:
@@ -186,7 +189,8 @@ stages:
           os: Android
           proc: arm64
 
-          SWIFT_OPTIONS: -D SWIFT_ANDROID_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_aarch64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_aarch64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          ICU_VERSION: 64
+          SWIFT_OPTIONS: -D SWIFT_ANDROID_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_aarch64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_aarch64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D PYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/android-sdk.yml
         parameters:
@@ -201,7 +205,8 @@ stages:
           os: Android
           proc: amd64
 
-          SWIFT_OPTIONS: -D SWIFT_ANDROID_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_x86_64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_x86_64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          ICU_VERSION: 64
+          SWIFT_OPTIONS: -D SWIFT_ANDROID_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_x86_64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_x86_64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D PYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/android-sdk.yml
         parameters:
@@ -216,7 +221,8 @@ stages:
           os: Android
           proc: i686
 
-          SWIFT_OPTIONS: -D SWIFT_ANDROID_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_i686_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_i686_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          ICU_VERSION: 64
+          SWIFT_OPTIONS: -D SWIFT_ANDROID_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_i686_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_i686_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D PYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
   - stage: windows_sdk
     dependsOn: toolchain
@@ -237,6 +243,7 @@ stages:
           os: Windows
           proc: arm
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/windows-sdk.yml
@@ -252,6 +259,7 @@ stages:
           os: Windows
           proc: arm64
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/windows-sdk.yml
@@ -267,6 +275,7 @@ stages:
           os: Windows
           proc: amd64
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/windows-sdk.yml
@@ -282,6 +291,7 @@ stages:
           os: Windows
           proc: i686
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
   - stage: package_toolchain

--- a/.ci/vs2019-swift-5.3.yml
+++ b/.ci/vs2019-swift-5.3.yml
@@ -10,7 +10,7 @@ pr:
 resources:
   pipelines:
     - pipeline: icu
-      source: 'ICU'
+      source: ICU
 
     - pipeline: xml2
       source: XML2
@@ -129,6 +129,7 @@ stages:
 
           triple: aarch64-unknown-windows-msvc
 
+          ICU_VERSION: 64
           # NOTE(compnerd) DIA does not contain ARM64 diaguids.lib
           LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_ENABLE_DIA_SDK=NO -DLLVM_INCLUDE_TESTS=NO -DCLANG_INCLUDE_TESTS=NO -DLLD_INCLUDE_TESTS=NO
           # NOTE(compnerd) disable python support as we need an ARM64 build of
@@ -151,6 +152,7 @@ stages:
 
           triple: x86_64-unknown-windows-msvc
 
+          ICU_VERSION: 64
           LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
 
@@ -176,6 +178,7 @@ stages:
           os: Android
           proc: armv7
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -D SWIFT_ANDROID_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_armv7_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_armv7_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/android-sdk.yml
@@ -191,6 +194,7 @@ stages:
           os: Android
           proc: arm64
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -D SWIFT_ANDROID_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_aarch64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_aarch64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/android-sdk.yml
@@ -206,6 +210,7 @@ stages:
           os: Android
           proc: amd64
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -D SWIFT_ANDROID_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_x86_64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_x86_64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/android-sdk.yml
@@ -221,6 +226,7 @@ stages:
           os: Android
           proc: i686
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -D SWIFT_ANDROID_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_i686_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_i686_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
   - stage: windows_sdk
@@ -242,6 +248,7 @@ stages:
           os: Windows
           proc: arm
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/windows-sdk.yml
@@ -257,6 +264,7 @@ stages:
           os: Windows
           proc: arm64
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/windows-sdk.yml
@@ -272,6 +280,7 @@ stages:
           os: Windows
           proc: amd64
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/windows-sdk.yml
@@ -287,6 +296,7 @@ stages:
           os: Windows
           proc: i686
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
   - stage: devtools

--- a/.ci/vs2019-tensorflow.yml
+++ b/.ci/vs2019-tensorflow.yml
@@ -131,6 +131,7 @@ stages:
 
           triple: x86_64-unknown-windows-msvc
 
+          ICU_VERSION: 64
           LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DTF_LIBRARY=$(tensorflow.directory)/usr/lib/tensorflow.lib -DTF_INCLUDE_DIR=$(tensorflow.directory)/usr/include -DSWIFT_ENABLE_TENSORFLOW=YES
 
@@ -157,6 +158,7 @@ stages:
           os: Windows
           proc: amd64
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_ENABLE_TENSORFLOW=YES -DSWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING=YES
 
           TENSORFLOW: true

--- a/.ci/vs2019.yml
+++ b/.ci/vs2019.yml
@@ -126,6 +126,7 @@ stages:
 
           triple: x86_64-unknown-windows-msvc
 
+          ICU_VERSION: 64
           LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
 
@@ -142,6 +143,7 @@ stages:
 
           triple: aarch64-unknown-windows-msvc
 
+          ICU_VERSION: 64
           # NOTE(compnerd) DIA does not contain ARM64 diaguids.lib
           LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_ENABLE_DIA_SDK=NO -DLLVM_INCLUDE_TESTS=NO -DCLANG_INCLUDE_TESTS=NO -DLLD_INCLUDE_TESTS=NO
           # NOTE(compnerd) disable python support as we need an ARM64 build of
@@ -173,7 +175,8 @@ stages:
           os: Android
           proc: armv7
 
-          SWIFT_OPTIONS: -DICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -DICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -DICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -DICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_armv7_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_armv7_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          ICU_VERSION: 64
+          SWIFT_OPTIONS: -D ICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -D ICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D ICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -D ICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_armv7_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_armv7_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D PYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/android-sdk.yml
         parameters:
@@ -188,7 +191,8 @@ stages:
           os: Android
           proc: arm64
 
-          SWIFT_OPTIONS: -DICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -DICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -DICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -DICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_aarch64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_aarch64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          ICU_VERSION: 64
+          SWIFT_OPTIONS: -D ICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -D ICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D ICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -D ICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_aarch64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_aarch64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D PYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/android-sdk.yml
         parameters:
@@ -203,7 +207,8 @@ stages:
           os: Android
           proc: amd64
 
-          SWIFT_OPTIONS: -DICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -DICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -DICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -DICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_x86_64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_x86_64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          ICU_VERSION: 64
+          SWIFT_OPTIONS: -D ICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -D ICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D ICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -D ICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_x86_64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_x86_64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D PYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/android-sdk.yml
         parameters:
@@ -218,7 +223,8 @@ stages:
           os: Android
           proc: i686
 
-          SWIFT_OPTIONS: -DICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -DICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -DICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -DICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_i686_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_i686_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          ICU_VERSION: 64
+          SWIFT_OPTIONS: -D ICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -D ICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D ICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -D ICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_i686_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_i686_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D PYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
   - stage: windows_sdk
     dependsOn: toolchain
@@ -239,6 +245,7 @@ stages:
           os: Windows
           proc: arm
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/windows-sdk.yml
@@ -254,6 +261,7 @@ stages:
           os: Windows
           proc: arm64
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/windows-sdk.yml
@@ -269,6 +277,7 @@ stages:
           os: Windows
           proc: amd64
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
       - template: templates/windows-sdk.yml
@@ -284,6 +293,7 @@ stages:
           os: Windows
           proc: i686
 
+          ICU_VERSION: 64
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
   - stage: devtools


### PR DESCRIPTION
Hoist the ICU version selection to metadata on the branch.  This allows
us to use different versions of ICU for different builds.  This is
required in order to bump to ICU 67.