### PR TITLE
toolchain: try cloning with depth 1 for builds

### DIFF
--- a/.ci/templates/toolchain.yml
+++ b/.ci/templates/toolchain.yml
@@ -118,9 +118,11 @@ jobs:
 
       - checkout: apple/llvm-project
         displayName: checkout apple/llvm-project
+        fetchDepth: 1
 
       - checkout: apple/swift
         displayName: checkout apple/swift
+        fetchDepth: 1
 
       - checkout: apple/swift-cmark
         displayName: checkout apple/swift-cmark


### PR DESCRIPTION
This should speed up the checkout and hopefully reduce disk space usage.