### PR TITLE
CI: re-enable TSC build on Windows

### DIFF
--- a/.ci/templates/windows-devtools.yml
+++ b/.ci/templates/windows-devtools.yml
@@ -170,12 +170,13 @@ jobs:
             -C $(Build.SourcesDirectory)/swift-build/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}-swift-flags.cmake
             -D CMAKE_BUILD_TYPE=Release
             -D CMAKE_INSTALL_PREFIX=$(platform.directory)/Developer/Library/TSC-$(tsc.version)/usr
+            -D SQLite3_LIBRARY=$(sqlite.directory)/usr/lib/SQLite3.lib
+            -D SQLite3_INCLUDE_DIR=$(sqlite.directory)/usr/include
             -G Ninja
             -S $(Build.SourcesDirectory)/swift-tools-support-core
 
       - task: CMake@1
         displayName: Build swift-tools-support-core
-        enabled: false
         inputs:
           cmakeArgs: --build $(Build.BinariesDirectory)/tsc
 


### PR DESCRIPTION
This PR re-enables the Swift TSC build on Windows which is fixed in https://github.com/apple/swift-tools-support-core/pull/98.

Since TSC depends on SQLite3 now, this PR also adds the required CMake arguments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/255)
<!-- Reviewable:end -->
