### PR TITLE
Adopt renamed CURL CMake option

### DIFF
--- a/cmake/caches/curl-windows.cmake
+++ b/cmake/caches/curl-windows.cmake
@@ -1,3 +1,3 @@
 # NOTE(compnerd) enable Windows' native SSL by default on Windows
-set(CMAKE_USE_WINSSL YES CACHE BOOL "")
+set(CMAKE_USE_SCHANNEL YES CACHE BOOL "")
 


### PR DESCRIPTION
`CMAKE_USE_WINSSL` was renamed to `CMAKE_USE_SCHANNEL`. Providing old option is considered an error now.

https://github.com/curl/curl/pull/5795

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/257)
<!-- Reviewable:end -->
