### PR TITLE
CI: continue on error when rebuilding foundation for testing

### DIFF
--- a/.ci/templates/windows-sdk.yml
+++ b/.ci/templates/windows-sdk.yml
@@ -478,6 +478,7 @@ jobs:
 
       - task: CMake@1
         condition: eq( variables['Agent.OSArchitecture'], '${{ parameters.host }}' )
+        continueOnError: true
         displayName: Rebuild Foundation
         inputs:
           cmakeArgs: --build $(Build.BinariesDirectory)/foundation


### PR DESCRIPTION
This is currently failing on older Windows releases due to a missing
DLL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/264)
<!-- Reviewable:end -->
