### PR TITLE
CI: remove hardcoded python handling

### DIFF
--- a/.ci/templates/toolchain.yml
+++ b/.ci/templates/toolchain.yml
@@ -278,12 +278,13 @@ jobs:
         condition: eq( variables['Agent.OS'], 'Windows_NT' )
         displayName: Configure SDK
 
-      - task: UsePythonVersion@0
-        condition: not( eq( variables['Agent.Name'], 'swift-ci' ) )
-        continueOnError: true
-        inputs:
-          versionSpec: 2.7.x
-        name: python
+      - ${{ if not( eq(parameters.VERSION, 'master') ) }}:
+        - task: UsePythonVersion@0
+          condition: not( eq( variables['Agent.Name'], 'swift-ci' ) )
+          continueOnError: true
+          inputs:
+            versionSpec: 2.7.x
+          name: python
 
       - script: |
           echo ##vso[task.setvariable variable=LLVM_TABLEGEN]$(Build.BinariesDirectory)\llvm-tools\bin\llvm-tblgen.exe

--- a/.ci/vs2017-facebook.yml
+++ b/.ci/vs2017-facebook.yml
@@ -141,7 +141,7 @@ stages:
           triple: x86_64-unknown-windows-msvc
 
           ICU_VERSION: 67
-          LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=8 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
 
           RUN_TESTS: true
@@ -164,7 +164,7 @@ stages:
           proc: arm
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
       - template: templates/windows-sdk.yml
         parameters:
@@ -180,7 +180,7 @@ stages:
           proc: arm64
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
       - template: templates/windows-sdk.yml
         parameters:
@@ -196,7 +196,7 @@ stages:
           proc: amd64
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
       - template: templates/windows-sdk.yml
         parameters:
@@ -212,4 +212,4 @@ stages:
           proc: i686
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib

--- a/.ci/vs2017.yml
+++ b/.ci/vs2017.yml
@@ -145,7 +145,7 @@ stages:
           triple: x86_64-unknown-windows-msvc
 
           ICU_VERSION: 64
-          LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
 
           RUN_TESTS: true

--- a/.ci/vs2019-facebook.yml
+++ b/.ci/vs2019-facebook.yml
@@ -143,7 +143,7 @@ stages:
           triple: x86_64-unknown-windows-msvc
 
           ICU_VERSION: 67
-          LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=8 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
 
           RUN_TESTS: true
@@ -166,7 +166,7 @@ stages:
           proc: arm
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
       - template: templates/windows-sdk.yml
         parameters:
@@ -182,7 +182,7 @@ stages:
           proc: arm64
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
       - template: templates/windows-sdk.yml
         parameters:
@@ -198,7 +198,7 @@ stages:
           proc: amd64
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
       - template: templates/windows-sdk.yml
         parameters:
@@ -214,4 +214,4 @@ stages:
           proc: i686
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib

--- a/.ci/vs2019-google.yml
+++ b/.ci/vs2019-google.yml
@@ -139,7 +139,7 @@ stages:
           triple: x86_64-unknown-windows-msvc
 
           ICU_VERSION: 67
-          LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=YES
+          LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2 -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=YES
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
 
           RUN_TESTS: true
@@ -157,7 +157,7 @@ stages:
 
           ICU_VERSION: 67
           # NOTE(compnerd) DIA does not contain ARM64 diaguids.lib
-          LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_ENABLE_DIA_SDK=NO -DLLVM_INCLUDE_TESTS=NO -DCLANG_INCLUDE_TESTS=NO -DLLD_INCLUDE_TESTS=NO -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=YES
+          LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_ENABLE_DIA_SDK=NO -DLLVM_INCLUDE_TESTS=NO -DCLANG_INCLUDE_TESTS=NO -DLLD_INCLUDE_TESTS=NO -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=YES
           # NOTE(compnerd) disable python support as we need an ARM64 build of
           # python to support this.
           LLDB_OPTIONS: -DLLDB_ENABLE_PYTHON=NO
@@ -187,7 +187,7 @@ stages:
           proc: arm
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
       - template: templates/windows-sdk.yml
         parameters:
@@ -203,7 +203,7 @@ stages:
           proc: arm64
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
       - template: templates/windows-sdk.yml
         parameters:
@@ -219,7 +219,7 @@ stages:
           proc: amd64
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
       - template: templates/windows-sdk.yml
         parameters:
@@ -235,7 +235,7 @@ stages:
           proc: i686
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
   - stage: devtools
     dependsOn: windows_sdk

--- a/.ci/vs2019-master-next.yml
+++ b/.ci/vs2019-master-next.yml
@@ -121,7 +121,7 @@ stages:
           triple: x86_64-unknown-windows-msvc
 
           ICU_VERSION: 67
-          LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
+          LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
 
           RUN_TESTS: true
@@ -139,7 +139,7 @@ stages:
 
           ICU_VERSION: 67
           # NOTE(compnerd) DIA does not contain ARM64 diaguids.lib
-          LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_ENABLE_DIA_SDK=NO -DLLVM_INCLUDE_TESTS=NO -DCLANG_INCLUDE_TESTS=NO -DLLD_INCLUDE_TESTS=NO -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
+          LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_ENABLE_DIA_SDK=NO -DLLVM_INCLUDE_TESTS=NO -DCLANG_INCLUDE_TESTS=NO -DLLD_INCLUDE_TESTS=NO
           # NOTE(compnerd) disable python as we need an ARM64 build of python to
           # build the support.
           LLDB_OPTIONS: -DLLDB_ENABLE_PYTHON=NO
@@ -169,7 +169,7 @@ stages:
           proc: arm
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
       - template: templates/windows-sdk.yml
         parameters:
@@ -185,7 +185,7 @@ stages:
           proc: arm64
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
       - template: templates/windows-sdk.yml
         parameters:
@@ -201,7 +201,7 @@ stages:
           proc: amd64
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
       - template: templates/windows-sdk.yml
         parameters:
@@ -217,7 +217,7 @@ stages:
           proc: i686
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=C:/Python27amd64/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
   - stage: devtools
     dependsOn: windows_sdk

--- a/.ci/vs2019.yml
+++ b/.ci/vs2019.yml
@@ -145,7 +145,7 @@ stages:
           triple: x86_64-unknown-windows-msvc
 
           ICU_VERSION: 67
-          LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          LLVM_OPTIONS: -DLLVM_ENABLE_LIBEDIT=NO -DLLVM_PARALLEL_LINK_JOBS=2
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
 
           RUN_TESTS: true
@@ -171,7 +171,7 @@ stages:
           proc: armv7
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -D ICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -D ICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D ICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -D ICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_armv7_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_armv7_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D PYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -D ICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -D ICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D ICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -D ICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_armv7_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_armv7_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so
 
       - template: templates/android-sdk.yml
         parameters:
@@ -187,7 +187,7 @@ stages:
           proc: arm64
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -D ICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -D ICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D ICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -D ICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_aarch64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_aarch64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D PYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -D ICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -D ICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D ICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -D ICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_aarch64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_aarch64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so
 
       - template: templates/android-sdk.yml
         parameters:
@@ -203,7 +203,7 @@ stages:
           proc: amd64
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -D ICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -D ICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D ICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -D ICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_x86_64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_x86_64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D PYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -D ICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -D ICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D ICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -D ICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_x86_64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_x86_64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so
 
       - template: templates/android-sdk.yml
         parameters:
@@ -219,7 +219,7 @@ stages:
           proc: i686
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -D ICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -D ICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D ICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -D ICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_i686_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_i686_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D PYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -D ICU_UC_INCLUDE_DIRS=$(icu.directory)/usr/include/unicode -D ICU_UC_LIBRARIES=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D ICU_I18N_INCLUDE_DIRS=$(icu.directory)/usr/include -D ICU_I18N_LIBRARIES=$(icu.directory)/usr/lib/libicuin$(icu.version).so -D SWIFT_ANDROID_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -D SWIFT_ANDROID_i686_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).so -D SWIFT_ANDROID_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -D SWIFT_ANDROID_i686_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).so
 
   - stage: windows_sdk
     dependsOn: toolchain
@@ -241,7 +241,7 @@ stages:
           proc: arm
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
       - template: templates/windows-sdk.yml
         parameters:
@@ -257,7 +257,7 @@ stages:
           proc: arm64
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
       - template: templates/windows-sdk.yml
         parameters:
@@ -273,7 +273,7 @@ stages:
           proc: amd64
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
       - template: templates/windows-sdk.yml
         parameters:
@@ -289,7 +289,7 @@ stages:
           proc: i686
 
           ICU_VERSION: 67
-          SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+          SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib
 
   - stage: devtools
     dependsOn: windows_sdk


### PR DESCRIPTION
The build system now can properly handle multi-versioned python, remove
the workarounds in the CI configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/275)
<!-- Reviewable:end -->
