### PR TITLE
CI: attempt to package devtools into a MSI

### DIFF
--- a/.ci/templates/devtools-msi.yml
+++ b/.ci/templates/devtools-msi.yml
@@ -1,0 +1,111 @@
+jobs:
+  - job: ${{ parameters.host }}
+
+    # NOTE(compnerd) disable non-x64 builds as they are currently broken :(
+    condition: eq( '${{ parameters.host }}', 'x64' )
+
+    variables:
+      devtools.directory: $(Pipeline.Workspace)/devtools-windows-${{ parameters.host }}/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
+
+    steps:
+      - ${{ if eq(parameters.USE_PREBUILT_TOOLCHAIN, true) }}:
+        - task: DownloadPipelineArtifact@2
+          displayName: download devtools
+          inputs:
+            buildType: specific
+            project: 3133d6ab-80a8-4996-ac4f-03df25cd3224
+            definition: 7
+            buildVersionToDownload: latest
+            allowPartiallySucceededBuilds: true
+            specificBuildWithTriggering: true
+            artifact: devtools-${{ parameters.platform }}-${{ parameters.host }}
+            targetPath: $(Pipeline.Workspace)/devtools-${{ parameters.platform }}-${{ parameters.host }}
+      - ${{ if not(eq(parameters.USE_PREBUILT_TOOLCHAIN, true)) }}:
+        - download: current
+          artifact: devtools-${{ parameters.platform }}-${{ parameters.host }}
+          displayName: download devtools
+
+      - script: |
+          git config --global --add core.autocrlf false
+          git config --global --add core.symlinks true
+        condition: eq( variables['Agent.OS'], 'Windows_NT' )
+        displayName: Enabel symbolic links, disable line ending conversion
+
+      # The checkout list has to match with the windows-sdk.yml checkout list.
+      # Otherwise Azure will create different directories for each build.
+      - checkout: self
+        displayName: checkout compnerd/swift-build
+
+      - checkout: apple/llvm-project
+        displayName: checkout apple/llvm-project
+
+      - checkout: apple/swift
+        displayName: checkout apple/swift
+
+      - checkout: apple/swift-cmark
+        displayName: checkout apple/swift-cmark
+
+      - checkout: apple/swift-corelibs-libdispatch
+        displayName: checkout apple/swift-corelibs-libdispatch
+
+      - checkout: apple/swift-corelibs-foundation
+        displayName: checkout apple/swift-corelibs-foundation
+
+      - checkout: apple/swift-corelibs-xctest
+        displayName: checkout apple/swift-corelibs-xctest
+
+      - checkout: apple/swift-llbuild
+        displayName: checkout apple/swift-llbuild
+
+      - checkout: apple/swift-tools-support-core
+        displayName: checkout apple/swift-tools-support-core
+
+      - checkout: jpsim/Yams
+        displayName: checkout jpsim/Yams
+
+      - checkout: apple/swift-argument-parser
+        displayName: checkout apple/swift-argument-parser
+
+      - checkout: apple/swift-driver
+        displayName: checkout apple/swift-driver
+
+      - checkout: apple/swift-package-manager
+        displayName: checkout apple/swift-package-manager
+
+      - checkout: apple/indexstore-db
+        displayName: checkout apple/indexstore-db
+
+      - ${{ if eq(parameters.TENSORFLOW, true) }}:
+        - checkout: tensorflow/swift-apis
+          displayName: checkout tensorflow/swift-apis
+
+        - checkout: pvieito/PythonKit
+          displayName: checkout pvieito/PythonKit
+
+      - task: BatchScript@1
+        condition: eq( variables['Agent.OS'], 'Windows_NT' )
+        displayName: VsDevCmd.bat
+        inputs:
+          filename: C:/Program Files (x86)/Microsoft Visual Studio/${{ parameters.VisualStudio }}/Common7/Tools/VsDevCmd.bat
+          arguments: -no_logo -arch=x64 -host_arch=x64
+          modifyEnvironment: true
+
+      - task: DownloadSecureFile@1
+        name: certificate
+        inputs:
+          secureFile: dt.compnerd.org.p12
+
+      - task: MSBuild@1
+        displayName: ${{ parameters.platform }}-devtools-${{ parameters.proc }}.msi
+        inputs:
+          solution: $(Build.SourcesDirectory)/swift-build/wix/windows-devtools.wixproj
+          msbuildArguments: /p:RunWixToolsOutOfProc=true -p:OutputPath=$(Build.BinariesDirectory)\devtools-msi\ -p:IntermediateOutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:DEVTOOLS_ROOT=$(devtools.directory) -p:TENSORFLOW=${{ parameters.tensorflow }}
+
+      - script: |
+          signtool sign /f $(certificate.secureFilePath) /p $(CERTIFICATE_PASSWORD) /tr http://timestamp.digicert.com /fd sha256 /td sha256 $(Build.BinariesDirectory)/devtools-msi/devtools.msi
+        displayName: Sign ${{ parameters.platform }}-devtools-${{ parameters.proc }}.msi
+
+      - publish: $(Build.BinariesDirectory)/devtools-msi/devtools.msi
+        artifact: ${{ parameters.platform }}-devtools-${{ parameters.proc }}.msi
+
+

--- a/.ci/vs2019-google.yml
+++ b/.ci/vs2019-google.yml
@@ -299,6 +299,22 @@ stages:
           os: Windows
           proc: amd64
 
+  - stage: package_windows_devtools
+    dependsOn: devtools
+    displayName: package devtools
+    pool: Google
+    jobs:
+      - template: templates/devtools-msi.yml
+        parameters:
+          VisualStudio: 2019/Community
+
+          arch: x86_64
+          host: x64
+          platform: windows
+
+          os: Windows
+          proc: amd64
+
   - stage: package_icu
     dependsOn: []
     displayName: package ICU
@@ -318,6 +334,7 @@ stages:
   - stage: package_bundle
     dependsOn:
       - package_windows_toolchain
+      - package_windows_devtools
       - package_windows_sdk
       - package_icu
     displayName: package

--- a/.ci/vs2019.yml
+++ b/.ci/vs2019.yml
@@ -356,6 +356,23 @@ stages:
           os: Windows
           proc: amd64
 
+  - stage: package_devtools
+    dependsOn: devtools
+    displayName: package Developer Tools
+    pool:
+      vmImage: 'windows-2019'
+    jobs:
+      - template: templates/devtools-msi.yml
+        parameters:
+          VisualStudio: 2019/Enterprise
+
+          arch: x86_64
+          host: x64
+          platform: windows
+
+          os: Windows
+          proc: amd64
+
   - stage: package_icu
     dependsOn: []
     displayName: package ICU
@@ -377,6 +394,7 @@ stages:
     dependsOn:
       - package_toolchain
       - package_windows_sdk
+      - package_devtools
       - package_icu
     displayName: package Installer
     pool:


### PR DESCRIPTION
Now that we have s-p-m working sufficiently on Windows, attempt to
package that into an MSI for inclusion into the toolchain image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/279)
<!-- Reviewable:end -->
