### PR TITLE
CI: remove devtools stage from 5.3 builds

### DIFF
--- a/.ci/vs2019-swift-5.3.yml
+++ b/.ci/vs2019-swift-5.3.yml
@@ -226,37 +226,6 @@ stages:
           ICU_VERSION: 67
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
-  - stage: devtools
-    dependsOn: windows_sdk
-    pool:
-      vmImage: 'windows-2019'
-    jobs:
-      - template: templates/windows-devtools.yml
-        parameters:
-          VisualStudio: 2019/Enterprise
-
-          arch: aarch64
-          host: arm64
-          platform: windows
-
-          os: Windows
-          proc: arm64
-
-          ICU_VERSION: 67
-
-      - template: templates/windows-devtools.yml
-        parameters:
-          VisualStudio: 2019/Enterprise
-
-          arch: x86_64
-          host: x64
-          platform: windows
-
-          os: Windows
-          proc: amd64
-
-          ICU_VERSION: 67
-
   - stage: package_toolchain
     dependsOn: toolchain
     displayName: package Toolchain


### PR DESCRIPTION
Unfortunately, the developer tools work never was completed sufficiently
for a 5.3 release.  Remove the unnecessary stage from the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/281)
<!-- Reviewable:end -->
