### PR TITLE
WIX: include Yams in devtools MSI

### DIFF
--- a/wix/windows-devtools.wxs
+++ b/wix/windows-devtools.wxs
@@ -171,6 +171,19 @@
         <File Id="TSC_UTILITY_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\TSCUtility.pdb" Checksum="yes" />
       </Component>
       <?endif?>
+
+      <!--- Yams -->
+      <Component Id="YAMS_BINS" Guid="">
+        <File Id="CYAML_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\CYaml.dll" Checksum="yes" />
+        <File Id="YAMS_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.dll" Checksum="yes" />
+      </Component>
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Component Id="YAMS_DEBUGINFO" Guid="">
+        <File Id="CYAML_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\CYaml.pdb" Checksum="yes" />
+        <File Id="YAMS_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Yams.pdb" Checksum="yes" />
+      </COmponent>
+      <?endif?>
     </DirectoryRef>
 
     <DirectoryRef Id="USR_LIB_SWIFT_PM_4">
@@ -213,6 +226,7 @@
       <ComponentRef Id="SWIFT_TOOLS_SUPPORT_CORE_BINS" />
       <ComponentRef Id="SWIFT_PD_4" />
       <ComponentRef Id="SWIFT_PD_4_2" />
+      <ComponentRef Id="YAMS_BINS" />
     </Feature>
 
     <?ifdef INCLUDE_DEBUG_INFO ?>
@@ -225,6 +239,7 @@
       <ComponentRef Id="SWIFT_TOOLS_SUPPORT_CORE_DEBUGINFO" />
       <ComponentRef Id="SWIFT_PD_4_DEBUGINFO" />
       <ComponentRef Id="SWIFT_PD_4_2_DEBUGINFO" />
+      <ComponentRef Id="YAMS_DEBUGINFO" />
     </Feature>
     <?endif?>
 


### PR DESCRIPTION
Add the Yams binaries to the MSI image which is required for s-p-m.

Fixes: #282

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/283)
<!-- Reviewable:end -->
