### PR TITLE
Enable compiler-rt

### DIFF
--- a/.ci/templates/toolchain.yml
+++ b/.ci/templates/toolchain.yml
@@ -228,7 +228,7 @@ jobs:
             -D LLVM_ENABLE_ASSERTIONS=NO
             -D LLVM_ENABLE_LIBEDIT=NO
             -D LLVM_ENABLE_LIBXML2=NO
-            -D LLVM_ENABLE_PROJECTS="clang;lldb"
+            -D LLVM_ENABLE_PROJECTS="clang;compiler-rt;lldb"
             -D LLVM_EXTERNAL_PROJECTS="cmark;swift"
             -D LLVM_EXTERNAL_CMARK_SOURCE_DIR=$(Build.SourcesDirectory)/swift-cmark
             -D LLVM_EXTERNAL_SWIFT_SOURCE_DIR=$(Build.SourcesDirectory)/swift
@@ -260,6 +260,11 @@ jobs:
         displayName: Build LLDB Build Tools
         inputs:
           cmakeArgs: --build $(Build.BinariesDirectory)/llvm-tools --target lldb-tblgen
+
+      - task: CMake@1
+        displayName: Build TSan Runtime
+        inputs:
+          cmakeArgs: --build $(Build.BinariesDirectory)/llvm-tools --target compiler-rt
 
       - task: CMake@1
         condition: ${{ eq(parameters.VERSION, 'master') }}

--- a/cmake/caches/org.compnerd.dt.cmake
+++ b/cmake/caches/org.compnerd.dt.cmake
@@ -4,6 +4,7 @@
 set(LLVM_ENABLE_PROJECTS
       clang
       clang-tools-extra
+      compiler-rt
       lld
       lldb
     CACHE STRING "")


### PR DESCRIPTION
`compiler-rt` is necessary for `swift-driver` to find `clang_rt` libs.

Related PRs: apple/swift-driver#252 & apple/swift#33952

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/289)
<!-- Reviewable:end -->
