### PR TITLE
build: add a workaround symlink for 5.3 builds

### DIFF
--- a/.ci/templates/windows-sdk.yml
+++ b/.ci/templates/windows-sdk.yml
@@ -36,6 +36,10 @@ parameters:
   - name: ICU_VERSION
     type: string
 
+  - name: VERSION
+    type: string
+    default: 'master'
+
 jobs:
   - job: ${{ parameters.host }}
     # NOTE(compnerd) disable non-x64 builds as they are currently broken :(
@@ -246,6 +250,10 @@ jobs:
             ${{ parameters.SWIFT_OPTIONS }}
             -G Ninja
             -S $(Build.SourcesDirectory)/swift
+
+      - ${{ if eq(parameters.VERSION,'5.3') }}:
+        - script: |
+            mklink "$(Build.BinariesDirectory)/swift-stdlib/bin/swiftc" "$(toolchain.directory)/usr/bin/swiftc.exe"
 
       - task: CMake@1
         displayName: Build Swift Standard Library

--- a/.ci/vs2019-swift-5.3.yml
+++ b/.ci/vs2019-swift-5.3.yml
@@ -180,6 +180,8 @@ stages:
           ICU_VERSION: 67
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_armv7_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_armv7_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_armv7_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_armv7_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
+          VERSION: 5.3
+
       - template: templates/windows-sdk.yml
         parameters:
           VisualStudio: 2019/Enterprise
@@ -196,6 +198,8 @@ stages:
 
           ICU_VERSION: 67
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_aarch64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_aarch64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+
+          VERSION: 5.3
 
       - template: templates/windows-sdk.yml
         parameters:
@@ -214,6 +218,8 @@ stages:
           ICU_VERSION: 67
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
 
+          VERSION: 5.3
+
       - template: templates/windows-sdk.yml
         parameters:
           VisualStudio: 2019/Enterprise
@@ -230,6 +236,8 @@ stages:
 
           ICU_VERSION: 67
           SWIFT_OPTIONS: -DSWIFT_WINDOWS_i686_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_i686_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_i686_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+
+          VERSION: 5.3
 
   - stage: package_toolchain
     dependsOn: toolchain


### PR DESCRIPTION
This adds a symbolic link for the swiftc that is attempted to be
executed due to the incorrect extension check in the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/290)
<!-- Reviewable:end -->
