### PR TITLE
build: Fix parameter for "check-swift"

### DIFF
--- a/.ci/templates/toolchain.yml
+++ b/.ci/templates/toolchain.yml
@@ -337,7 +337,7 @@ jobs:
             -D CLANG_TABLEGEN=$(CLANG_TABLEGEN)
             -D LLDB_TABLEGEN=$(LLDB_TABLEGEN)
             -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE=$(Build.SourcesDirectory)/swift-corelibs-libdispatch
-            -D SWIFT_NATIVE_SWIFT_TOOLS_PATH=$(Build.BinariesDirectory)/llvm-tools/bin
+            -D SWIFT_NATIVE_LLVM_TOOLS_PATH=$(Build.BinariesDirectory)/llvm-tools/bin
             -D LLVM_EXTERNAL_SWIFT_SOURCE_DIR=$(Build.SourcesDirectory)/swift
             -D LLVM_EXTERNAL_CMARK_SOURCE_DIR=$(Build.SourcesDirectory)/swift-cmark
             ${{ parameters.LLVM_OPTIONS }}


### PR DESCRIPTION
Finally fixed (hopefully) `check-swift` failure by fixing a typo in build parameters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/292)
<!-- Reviewable:end -->
