### PR TITLE
build: further tweak layout

### DIFF
--- a/wix/windows-sdk.wxs
+++ b/wix/windows-sdk.wxs
@@ -76,17 +76,17 @@
                             <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_SHIMS" Name="shims">
                             </Directory>
                             <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS" Name="windows">
-                              <?if $(var.CORE_OLD_LAYOUT) = false?>
-                                <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_MSVCRT_SWIFTMODULE" Name="MSVCRT.swiftmodule">
-                                </Directory>
-                                <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_SWIFTONONESUPPORT_SWIFTMODULE" Name="SwiftOnoneSupport.swiftmodule">
-                                </Directory>
-                                <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_SWIFT_SWIFTMODULE" Name="Swift.swiftmodule">
-                                </Directory>
-                                <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_WINSDK_SWIFTMODULE" Name="WinSDK.swiftmodule">
-                                </Directory>
-                              <?endif?>
                               <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64" Name="x86_64">
+                                <?if $(var.CORE_OLD_LAYOUT) = false?>
+                                  <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_MSVCRT_SWIFTMODULE" Name="MSVCRT.swiftmodule">
+                                  </Directory>
+                                  <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_SWIFTONONESUPPORT_SWIFTMODULE" Name="SwiftOnoneSupport.swiftmodule">
+                                  </Directory>
+                                  <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_SWIFT_SWIFTMODULE" Name="Swift.swiftmodule">
+                                  </Directory>
+                                  <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_WINSDK_SWIFTMODULE" Name="WinSDK.swiftmodule">
+                                  </Directory>
+                                <?endif?>
                               </Directory>
                             </Directory>
                           </Directory>
@@ -168,8 +168,8 @@
       </Component>
     </DirectoryRef>
 
-    <?if $(var.CORE_OLD_LAYOUT) = false?>
-      <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_MSVCRT_SWIFTMODULE">
+    <?if $(var.CORE_OLD_LAYOUT) = false ?>
+      <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_MSVCRT_SWIFTMODULE">
         <Component Id="MSVCRT_SWIFTMODULE" Guid="2b69958d-0dfa-497e-8093-f7aa44986564">
           <File Id="MSVCRT_SWIFTMODULE_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\MSVCRT.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
           <File Id="MSVCRT_SWIFTMODULE_SWIFTINTERFACE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\MSVCRT.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
@@ -177,7 +177,7 @@
         </Component>
       </DirectoryRef>
 
-      <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_SWIFTONONESUPPORT_SWIFTMODULE">
+      <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_SWIFTONONESUPPORT_SWIFTMODULE">
         <Component Id="SWIFT_ONONE_SUPPORT_SWIFTMODULE" Guid="99c68468-ac15-4acb-9d78-509511615273">
           <File Id="SWIFT_ONONE_SUPPORT_SWIFTMODULE_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
           <File Id="SWIFT_ONONE_SUPPORT_SWIFTMODULE_SWIFTINTERFACE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
@@ -185,7 +185,7 @@
         </Component>
       </DirectoryRef>
 
-      <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_SWIFT_SWIFTMODULE">
+      <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_SWIFT_SWIFTMODULE">
         <Component Id="SWIFT_SWIFTMODULE" Guid="284781f1-21ee-48f6-995b-c263a5efab49">
           <File Id="SWIFT_SWIFTMODULE_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
           <File Id="SWIFT_SWIFTMODULE_SWIFTINTERFACE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
@@ -193,7 +193,7 @@
         </Component>
       </DirectoryRef>
 
-      <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_WINSDK_SWIFTMODULE">
+      <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64_WINSDK_SWIFTMODULE">
         <Component Id="WINSDK_SWIFTMODULE" Guid="9b7f1f86-5956-4ddb-92f9-da105dcb996c">
           <File Id="WINSDK_SWIFTMODULE_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" Checksum="yes" />
           <File Id="WINSDK_SWIFTMODULE_SWIFTINTERFACE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftinterface" Checksum="yes" />
@@ -202,10 +202,22 @@
       </DirectoryRef>
     <?endif?>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS">
+    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64">
+      <Component Id="REGISTRAR" Guid="a42e4007-33b4-4392-92a3-4ffaaee66e32">
+        <File Id="SWIFTRT_OBJ" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftrt.obj" Checksum="yes" />
+      </Component>
+
       <Component Id="DISPATCH" Guid="b2817a08-7fb3-4adc-8dc5-a6e950e5df39">
         <File Id="DISPATCH_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Dispatch.swiftdoc" Checksum="yes" />
         <File Id="DISPATCH_SWIFTMODULE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\Dispatch.swiftmodule" Checksum="yes" />
+      </Component>
+      <Component Id="DISPATCH_IMPORT_LIBS" Guid="95063ff6-c2d2-4892-bc0f-b046a8abce79">
+        <File Id="DISPATCH_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\dispatch.lib" Checksum="yes" />
+        <File Id="SWIFT_DISPATCH_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\swiftDispatch.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="BLOCKS_RUNTIME_IMPORT_LIBS" Guid="8eb97bfc-2559-4f4d-a3d6-864097f6dfb4">
+        <File Id="BLOCKS_RUNTIME_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\BlocksRuntime.lib" Checksum="yes" />
       </Component>
 
       <Component Id="FOUNDATION" Guid="66a6b1d6-f3a5-4894-baa7-1ae45894895a">
@@ -215,6 +227,11 @@
         <File Id="FOUNDATION_NETWORKING_SWIFTMODULE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationNetworking.swiftmodule" Checksum="yes" />
         <File Id="FOUNDATION_XML_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationXML.swiftdoc" Checksum="yes" />
         <File Id="FOUNDATION_XML_SWIFTMODULE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\FoundationXML.swiftmodule" Checksum="yes" />
+      </Component>
+      <Component Id="FOUNDATION_IMPORT_LIBS" Guid="5eeb293f-19dd-4131-982b-8c7f0331e2e2">
+        <File Id="FOUNDATION_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Foundation.lib" Checksum="yes" />
+        <File Id="FOUNDATION_NETWORKING_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationNetworking.lib" Checksum="yes" />
+        <File Id="FOUNDATION_XML_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationXML.lib" Checksum="yes" />
       </Component>
 
       <?if $(var.CORE_OLD_LAYOUT) = true ?>
@@ -238,6 +255,19 @@
           <File Id="WINSDK_SWIFTMODULE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\WinSDK.swiftmodule" Checksum="yes" />
         </Component>
       <?endif?>
+      <Component Id="SWIFT_IMPORT_LIBS" Guid="0823f52b-1e2a-4eb5-a180-dc2ca61aecf9">
+        <File Id="SWIFT_CORE_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftCore.lib" Checksum="yes" />
+        <File Id="SWIFT_SWIFT_ONONE_SUPPORT_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftSwiftOnoneSupport.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="SDK_OVERLAY_IMPORT_LIBS" Guid="ffba6437-f4c2-4ea6-876e-241579541535">
+        <File Id="SWIFT_MSVCRT_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftMSVCRT.lib" Checksum="yes" />
+        <File Id="SWIFT_WINSDK_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftWinSDK.lib" Checksum="yes" />
+      </Component>
+
+      <Component Id="SWIFT_REMOTE_MIRROR_IMPORT_LIBS" Guid="5332801b-499e-4818-ad33-265337631c68">
+        <File Id="SWIFT_REMOTE_MIRROR_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftRemoteMirror.lib" Checksum="yes" />
+      </Component>
 
       <?if $(var.TENSORFLOW) = true ?>
         <Component Id="_DIFFERENTIATION" Guid="f9d5b1a5-df8c-4b3e-8f67-075e6c66bd9e">
@@ -245,10 +275,20 @@
           <File Id="_DIFFERENTIATION_SWIFTINTERFACE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\_Differentiation.swiftinterface" Checksum="yes" />
           <File Id="_DIFFERENTIATION_SWIFTMODULE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\_Differentiation.swiftmodule" Checksum="yes" />
         </Component>
+        <Component Id="_DIFFERENTIATION_IMPORT_LIBS" Guid="f919479b-f945-45ed-b7b1-a063bf964e04">
+          <File Id="SWIFT_DIFFERENTIATION_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swift_Differentiation.lib" Checksum="yes" />
+        </Component>
 
         <Component Id="PYTHONKIT" Guid="deb2aca7-403b-4ade-ba5c-6b9f40502a69">
           <File Id="PYTHONKIT_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\PythonKit.swiftdoc" Checksum="yes" />
           <File Id="PYTHONKIT_SWIFTMODULE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\PythonKit.swiftmodule" Checksum="yes" />
+        </Component>
+        <Component Id="PYTHONKIT_IMPORT_LIBS" Guid="4f2cb4c7-6acf-42a0-a347-22e5560089c9">
+          <File Id="PYTHONKIT_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\PythonKit.lib" Checksum="yes" />
+        </Component>
+
+        <Component Id="TENSORFLOW_IMPORT_LIBS" Guid="a8ed3372-8b8a-4f5a-af1c-dda6f316846b">
+          <File Id="TENSORFLOW_LIB" Source="$(var.TensorFlow_ROOT)\Library\tensorflow-2.3.0\usr\lib\x10.lib" Checksum="yes" />
         </Component>
 
         <Component Id="TENSORFLOW_SWIFT_APIS" Guid="8ff21496-2fa0-4acf-a384-9c6a1e16d0f5">
@@ -272,56 +312,6 @@
           <File Id="X10_TRAINING_LOOP_SWIFTDOC" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\x10_training_loop.swiftdoc" Checksum="yes" />
           <File Id="X10_TRAINING_LOOP_SWIFTMODULE" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\x10_training_loop.swiftmodule" Checksum="yes" />
         </Component>
-      <?endif?>
-    </DirectoryRef>
-
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_WINDOWS_X86_64">
-      <Component Id="REGISTRAR" Guid="a42e4007-33b4-4392-92a3-4ffaaee66e32">
-        <File Id="SWIFTRT_OBJ" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftrt.obj" Checksum="yes" />
-      </Component>
-
-      <Component Id="BLOCKS_RUNTIME_IMPORT_LIBS" Guid="8eb97bfc-2559-4f4d-a3d6-864097f6dfb4">
-        <File Id="BLOCKS_RUNTIME_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\BlocksRuntime.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="FOUNDATION_IMPORT_LIBS" Guid="5eeb293f-19dd-4131-982b-8c7f0331e2e2">
-        <File Id="FOUNDATION_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Foundation.lib" Checksum="yes" />
-        <File Id="FOUNDATION_NETWORKING_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationNetworking.lib" Checksum="yes" />
-        <File Id="FOUNDATION_XML_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\FoundationXML.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="DISPATCH_IMPORT_LIBS" Guid="95063ff6-c2d2-4892-bc0f-b046a8abce79">
-        <File Id="DISPATCH_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\dispatch.lib" Checksum="yes" />
-        <File Id="SWIFT_DISPATCH_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\swiftDispatch.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="SWIFT_IMPORT_LIBS" Guid="0823f52b-1e2a-4eb5-a180-dc2ca61aecf9">
-        <File Id="SWIFT_CORE_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftCore.lib" Checksum="yes" />
-        <File Id="SWIFT_SWIFT_ONONE_SUPPORT_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftSwiftOnoneSupport.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="SDK_OVERLAY_IMPORT_LIBS" Guid="ffba6437-f4c2-4ea6-876e-241579541535">
-        <File Id="SWIFT_MSVCRT_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftMSVCRT.lib" Checksum="yes" />
-        <File Id="SWIFT_WINSDK_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftWinSDK.lib" Checksum="yes" />
-      </Component>
-
-      <Component Id="SWIFT_REMOTE_MIRROR_IMPORT_LIBS" Guid="5332801b-499e-4818-ad33-265337631c68">
-        <File Id="SWIFT_REMOTE_MIRROR_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swiftRemoteMirror.lib" Checksum="yes" />
-      </Component>
-
-      <?if $(var.TENSORFLOW) = true ?>
-        <Component Id="_DIFFERENTIATION_IMPORT_LIBS" Guid="f919479b-f945-45ed-b7b1-a063bf964e04">
-          <File Id="SWIFT_DIFFERENTIATION_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\x86_64\swift_Differentiation.lib" Checksum="yes" />
-        </Component>
-
-        <Component Id="PYTHONKIT_IMPORT_LIBS" Guid="4f2cb4c7-6acf-42a0-a347-22e5560089c9">
-          <File Id="PYTHONKIT_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\PythonKit.lib" Checksum="yes" />
-        </Component>
-
-        <Component Id="TENSORFLOW_IMPORT_LIBS" Guid="a8ed3372-8b8a-4f5a-af1c-dda6f316846b">
-          <File Id="TENSORFLOW_LIB" Source="$(var.TensorFlow_ROOT)\Library\tensorflow-2.3.0\usr\lib\x10.lib" Checksum="yes" />
-        </Component>
-
         <Component Id="TENSORFLOW_SWIFT_APIS_IMPORT_LIBS" Guid="1c16111f-bcbe-4943-bb84-9cb76f5ca6c3">
           <File Id="TENSOR_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\Tensor.lib" Checksum="yes" />
           <File Id="SWIFTTENSORFLOW_LIB" Source="$(var.SDK_ROOT)\usr\lib\swift\windows\swiftTensorFlow.lib" Checksum="yes" />


### PR DESCRIPTION
Adjust the layout to allow the default resource path to be sufficient to
find the modules.  This reduces the flags necessary for Windows to
`-sdk %SDKROOT%`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/295)
<!-- Reviewable:end -->
