### PR TITLE
WIX: duplicate CF headers for flag handling

### DIFF
--- a/wix/windows-sdk.wixproj
+++ b/wix/windows-sdk.wixproj
@@ -60,8 +60,15 @@
     </ItemGroup>
     <ItemGroup>
       <HarvestDirectory Include="$(SDK_ROOT)\usr\lib\swift\CoreFoundation">
-        <ComponentGroupName>COREFOUNDATION_HEADERS</ComponentGroupName>
+        <ComponentGroupName>COREFOUNDATION_HEADERS_RESOURCE</ComponentGroupName>
         <DirectoryRefId>WINDOWS_SDK_USR_LIB_SWIFT_COREFOUNDATION</DirectoryRefId>
+        <PreprocessorVariable>var.SDK_ROOT_USR_LIB_SWIFT_COREFOUNDATION</PreprocessorVariable>
+      </HarvestDirectory>
+    </ItemGroup>
+    <ItemGroup>
+      <HarvestDirectory Include="$(SDK_ROOT)\usr\lib\swift\CoreFoundation">
+        <ComponentGroupName>COREFOUNDATION_HEADERS_INCLUDE</ComponentGroupName>
+        <DirectoryRefId>WINDOWS_SDK_USR_INCLUDE_COREFOUNDATION</DirectoryRefId>
         <PreprocessorVariable>var.SDK_ROOT_USR_LIB_SWIFT_COREFOUNDATION</PreprocessorVariable>
       </HarvestDirectory>
     </ItemGroup>

--- a/wix/windows-sdk.wxs
+++ b/wix/windows-sdk.wxs
@@ -62,6 +62,12 @@
                           </Directory>
                           <Directory Id="WINDOWS_SDK_USR_INCLUDE_BLOCK" Name="Block">
                           </Directory>
+                          <Directory Id="WINDOWS_SDK_USR_INCLUDE_CFURLSESSIONINTERFACE" Name="CFURLSessionInterface">
+                          </Directory>
+                          <Directory Id="WINDOWS_SDK_USR_INCLUDE_CFXMLINTERFACE" Name="CFXMLInterface">
+                          </Directory>
+                          <Directory Id="WINDOWS_SDK_USR_INCLUDE_COREFOUNDATION" Name="CoreFoundation">
+                          </Directory>
                         </Directory>
                         <Directory Id="WINDOWS_SDK_USR_LIB" Name="lib">
                           <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT" Name="swift">
@@ -322,15 +328,29 @@
       <?endif?>
     </DirectoryRef>
 
+    <DirectoryRef Id="WINDOWS_SDK_USR_INCLUDE_CFURLSESSIONINTERFACE">
+      <Component Id="CFURLSESSIONINTERFACE_HEADERS_INCLUDE" Guid="8a356808-a8ce-4660-820f-0cbecc349b27">
+        <File Id="_CFURLSESSIONINTERFACE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\CFURLSessionInterface\CFURLSessionInterface.h" Checksum="yes" />
+        <File Id="_CFURLSESSIONINTERFACE_MODULE_MODULEMAP" Source="$(var.SDK_ROOT)\usr\lib\swift\CFURLSessionInterface\module.map" Checksum="yes" />
+      </Component>
+    </DirectoryRef>
+
+    <DirectoryRef Id="WINDOWS_SDK_USR_INCLUDE_CFXMLINTERFACE">
+      <Component Id="CFXMLINTERFACE_HEADERS_INCLUDE" Guid="7c7571a8-2bbb-458a-bb28-6b2995afa599">
+        <File Id="_CFXMLINTERFACE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\CFXMLInterface\CFXMLInterface.h" Checksum="yes" />
+        <File Id="_CFXMLINTERFACE_MODULE_MODULEMAP" Source="$(var.SDK_ROOT)\usr\lib\swift\CFXMLInterface\module.map" Checksum="yes" />
+      </Component>
+    </DirectoryRef>
+
     <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_CFURLSESSIONINTERFACE">
-      <Component Id="CFURLSESSIONINTERFACE_HEADERS" Guid="d908f6f0-066a-4c9f-9af6-870009ff7744">
+      <Component Id="CFURLSESSIONINTERFACE_HEADERS_RESOURCE" Guid="d908f6f0-066a-4c9f-9af6-870009ff7744">
         <File Id="CFURLSESSIONINTERFACE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\CFURLSessionInterface\CFURLSessionInterface.h" Checksum="yes" />
         <File Id="CFURLSESSIONINTERFACE_MODULE_MODULEMAP" Source="$(var.SDK_ROOT)\usr\lib\swift\CFURLSessionInterface\module.map" Checksum="yes" />
       </Component>
     </DirectoryRef>
 
     <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_CFXMLINTERFACE">
-      <Component Id="CFXMLINTERFACE_HEADERS" Guid="5450a487-2d3f-4390-9f3c-52a545569636">
+      <Component Id="CFXMLINTERFACE_HEADERS_RESOURCE" Guid="5450a487-2d3f-4390-9f3c-52a545569636">
         <File Id="CFXMLINTERFACE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\CFXMLInterface\CFXMLInterface.h" Checksum="yes" />
         <File Id="CFXMLINTERFACE_MODULE_MODULEMAP" Source="$(var.SDK_ROOT)\usr\lib\swift\CFXMLInterface\module.map" Checksum="yes" />
       </Component>
@@ -389,9 +409,12 @@
       <ComponentRef Id="DISPATCH_IMPORT_LIBS" />
 
       <ComponentRef Id="FOUNDATION" />
-      <ComponentGroupRef Id="COREFOUNDATION_HEADERS" />
-      <ComponentRef Id="CFURLSESSIONINTERFACE_HEADERS" />
-      <ComponentRef Id="CFXMLINTERFACE_HEADERS" />
+      <ComponentGroupRef Id="COREFOUNDATION_HEADERS_RESOURCE" />
+      <ComponentRef Id="CFXMLINTERFACE_HEADERS_RESOURCE" />
+      <ComponentRef Id="CFURLSESSIONINTERFACE_HEADERS_RESOURCE" />
+      <ComponentGroupRef Id="COREFOUNDATION_HEADERS_INCLUDE" />
+      <ComponentRef Id="CFXMLINTERFACE_HEADERS_INCLUDE" />
+      <ComponentRef Id="CFURLSESSIONINTERFACE_HEADERS_INCLUDE" />
       <ComponentRef Id="FOUNDATION_IMPORT_LIBS" />
 
       <?if $(var.CORE_OLD_LAYOUT) = true ?>


### PR DESCRIPTION
This is a workaround for the 5.3 release to make `-sdk %SDKROOT%` be
sufficient for using the Swift compiler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/296)
<!-- Reviewable:end -->
