### PR TITLE
WIX: exclude CF headers for newer toolchains

### DIFF
--- a/.ci/templates/sdk-msi.yml
+++ b/.ci/templates/sdk-msi.yml
@@ -104,14 +104,14 @@ jobs:
           displayName: ${{ parameters.platform }}-sdk-${{ parameters.proc }}.msi
           inputs:
             solution: $(Build.SourcesDirectory)/swift-build/wix/windows-sdk.wixproj
-            msbuildArguments: /p:RunWixToolsOutOfProc=true -p:OutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:IntermediateOutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:PLATFORM_ROOT=$(platform.directory) -p:SDK_ROOT=$(sdk.directory) -p:SWIFT_SOURCE_DIR=$(Build.SourcesDirectory)/swift -p:CORE_OLD_LAYOUT=true -p:TensorFlow_ROOT=$(Pipeline.Workspace)/tensorflow/tensorflow-${{ parameters.platform }}-${{ parameters.host }} -p:TENSORFLOW=${{ parameters.tensorflow }}
+            msbuildArguments: /p:RunWixToolsOutOfProc=true -p:OutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:IntermediateOutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:PLATFORM_ROOT=$(platform.directory) -p:SDK_ROOT=$(sdk.directory) -p:SWIFT_SOURCE_DIR=$(Build.SourcesDirectory)/swift -p:CORE_OLD_LAYOUT=true -p:INCLUDE_CF_HEADERS=YES -p:TensorFlow_ROOT=$(Pipeline.Workspace)/tensorflow/tensorflow-${{ parameters.platform }}-${{ parameters.host }} -p:TENSORFLOW=${{ parameters.tensorflow }}
 
       - ${{ if ne(parameters.VERSION, '5.3') }}:
         - task: MSBuild@1
           displayName: ${{ parameters.platform }}-sdk-${{ parameters.proc }}.msi
           inputs:
             solution: $(Build.SourcesDirectory)/swift-build/wix/windows-sdk.wixproj
-            msbuildArguments: /p:RunWixToolsOutOfProc=true -p:OutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:IntermediateOutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:PLATFORM_ROOT=$(platform.directory) -p:SDK_ROOT=$(sdk.directory) -p:SWIFT_SOURCE_DIR=$(Build.SourcesDirectory)/swift -p:CORE_OLD_LAYOUT=false -p:TensorFlow_ROOT=$(Pipeline.Workspace)/tensorflow/tensorflow-${{ parameters.platform }}-${{ parameters.host }} -p:TENSORFLOW=${{ parameters.tensorflow }}
+            msbuildArguments: /p:RunWixToolsOutOfProc=true -p:OutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:IntermediateOutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:PLATFORM_ROOT=$(platform.directory) -p:SDK_ROOT=$(sdk.directory) -p:SWIFT_SOURCE_DIR=$(Build.SourcesDirectory)/swift -p:CORE_OLD_LAYOUT=false -p:INCLUDE_CF_HEADERS=NO -p:TensorFlow_ROOT=$(Pipeline.Workspace)/tensorflow/tensorflow-${{ parameters.platform }}-${{ parameters.host }} -p:TENSORFLOW=${{ parameters.tensorflow }}
 
       - script: |
           signtool sign /f $(certificate.secureFilePath) /p $(CERTIFICATE_PASSWORD) /tr http://timestamp.digicert.com /fd sha256 /td sha256 $(Build.BinariesDirectory)/sdk-msi/sdk.msi

--- a/wix/windows-sdk.wixproj
+++ b/wix/windows-sdk.wixproj
@@ -26,12 +26,13 @@
     <SWIFT_SOURCE_DIR Condition=" '$(SWIFT_SOURCE_DIR)' == '' ">S:\SourceCache\llvm-project\swift</SWIFT_SOURCE_DIR>
     <TENSORFLOW Condition=" '$(TENSORFLOW)' == '' ">false</TENSORFLOW>
     <CORE_OLD_LAYOUT Condition=" '$(CORE_OLD_LAYOUT)' == '' ">false</CORE_OLD_LAYOUT>
+    <INCLUDE_CF_HEADERS Condition=" '$(INCLUDE_CF_HEADERS)' == '' ">false</INCLUDE_CF_HEADERS>
   </PropertyGroup>
 
   <Import Project="$(WixTargetsPath)" />
 
   <PropertyGroup>
-    <DefineConstants>PLATFORM_ROOT=$(PLATFORM_ROOT);SDK_ROOT=$(SDK_ROOT);SWIFT_SOURCE_DIR=$(SWIFT_SOURCE_DIR);SDK_ROOT_USR_LIB_SWIFT_SHIMS=$(SDK_ROOT)\usr\lib\swift\shims;SDK_ROOT_USR_LIB_SWIFT_COREFOUNDATION=$(SDK_ROOT)\usr\lib\swift\CoreFoundation;CORE_OLD_LAYOUT=$(CORE_OLD_LAYOUT);SDK_ROOT_USR_LIB_SWIFT_TENSORFLOW=$(SDK_ROOT)\usr\lib\swift\tensorflow;TENSORFLOW=$(TENSORFLOW);TensorFlow_ROOT=$(TensorFlow_ROOT)</DefineConstants>
+    <DefineConstants>PLATFORM_ROOT=$(PLATFORM_ROOT);SDK_ROOT=$(SDK_ROOT);SWIFT_SOURCE_DIR=$(SWIFT_SOURCE_DIR);SDK_ROOT_USR_LIB_SWIFT_SHIMS=$(SDK_ROOT)\usr\lib\swift\shims;SDK_ROOT_USR_LIB_SWIFT_COREFOUNDATION=$(SDK_ROOT)\usr\lib\swift\CoreFoundation;CORE_OLD_LAYOUT=$(CORE_OLD_LAYOUT);INCLUDE_CF_HEADERS=$(INCLUDE_CF_HEADERS);SDK_ROOT_USR_LIB_SWIFT_TENSORFLOW=$(SDK_ROOT)\usr\lib\swift\tensorflow;TENSORFLOW=$(TENSORFLOW);TensorFlow_ROOT=$(TensorFlow_ROOT)</DefineConstants>
     <HarvestDirectoryAutogenerateGuids>false</HarvestDirectoryAutogenerateGuids>
     <HarvestDirectoryGenerateGuidsNow>true</HarvestDirectoryGenerateGuidsNow>
     <HarvestDirectoryNoLogo>true</HarvestDirectoryNoLogo>

--- a/wix/windows-sdk.wxs
+++ b/wix/windows-sdk.wxs
@@ -62,21 +62,25 @@
                           </Directory>
                           <Directory Id="WINDOWS_SDK_USR_INCLUDE_BLOCK" Name="Block">
                           </Directory>
-                          <Directory Id="WINDOWS_SDK_USR_INCLUDE_CFURLSESSIONINTERFACE" Name="CFURLSessionInterface">
-                          </Directory>
-                          <Directory Id="WINDOWS_SDK_USR_INCLUDE_CFXMLINTERFACE" Name="CFXMLInterface">
-                          </Directory>
-                          <Directory Id="WINDOWS_SDK_USR_INCLUDE_COREFOUNDATION" Name="CoreFoundation">
-                          </Directory>
+                          <?if $(var.INCLUDE_CF_HEADERS) = true ?>
+                            <Directory Id="WINDOWS_SDK_USR_INCLUDE_CFURLSESSIONINTERFACE" Name="CFURLSessionInterface">
+                            </Directory>
+                            <Directory Id="WINDOWS_SDK_USR_INCLUDE_CFXMLINTERFACE" Name="CFXMLInterface">
+                            </Directory>
+                            <Directory Id="WINDOWS_SDK_USR_INCLUDE_COREFOUNDATION" Name="CoreFoundation">
+                            </Directory>
+                          <?endif?>
                         </Directory>
                         <Directory Id="WINDOWS_SDK_USR_LIB" Name="lib">
                           <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT" Name="swift">
-                            <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_CFURLSESSIONINTERFACE" Name="CFURLSessionInterface">
-                            </Directory>
-                            <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_CFXMLINTERFACE" Name="CFXMLInterface">
-                            </Directory>
-                            <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_COREFOUNDATION" Name="CoreFoundation">
-                            </Directory>
+                            <?if $(var.INCLUDE_CF_HEADERS) = true ?>
+                              <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_CFURLSESSIONINTERFACE" Name="CFURLSessionInterface">
+                              </Directory>
+                              <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_CFXMLINTERFACE" Name="CFXMLInterface">
+                              </Directory>
+                              <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_COREFOUNDATION" Name="CoreFoundation">
+                              </Directory>
+                            <?endif?>
                             <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_TENSORFLOW" Name="tensorflow">
                             </Directory>
                             <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT_SHIMS" Name="shims">
@@ -328,33 +332,35 @@
       <?endif?>
     </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_INCLUDE_CFURLSESSIONINTERFACE">
-      <Component Id="CFURLSESSIONINTERFACE_HEADERS_INCLUDE" Guid="8a356808-a8ce-4660-820f-0cbecc349b27">
-        <File Id="_CFURLSESSIONINTERFACE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\CFURLSessionInterface\CFURLSessionInterface.h" Checksum="yes" />
-        <File Id="_CFURLSESSIONINTERFACE_MODULE_MODULEMAP" Source="$(var.SDK_ROOT)\usr\lib\swift\CFURLSessionInterface\module.map" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
+    <?if $(var.INCLUDE_CF_HEADERS) = true ?>
+      <DirectoryRef Id="WINDOWS_SDK_USR_INCLUDE_CFURLSESSIONINTERFACE">
+        <Component Id="CFURLSESSIONINTERFACE_HEADERS_INCLUDE" Guid="8a356808-a8ce-4660-820f-0cbecc349b27">
+          <File Id="_CFURLSESSIONINTERFACE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\CFURLSessionInterface\CFURLSessionInterface.h" Checksum="yes" />
+          <File Id="_CFURLSESSIONINTERFACE_MODULE_MODULEMAP" Source="$(var.SDK_ROOT)\usr\lib\swift\CFURLSessionInterface\module.map" Checksum="yes" />
+        </Component>
+      </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_INCLUDE_CFXMLINTERFACE">
-      <Component Id="CFXMLINTERFACE_HEADERS_INCLUDE" Guid="7c7571a8-2bbb-458a-bb28-6b2995afa599">
-        <File Id="_CFXMLINTERFACE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\CFXMLInterface\CFXMLInterface.h" Checksum="yes" />
-        <File Id="_CFXMLINTERFACE_MODULE_MODULEMAP" Source="$(var.SDK_ROOT)\usr\lib\swift\CFXMLInterface\module.map" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
+      <DirectoryRef Id="WINDOWS_SDK_USR_INCLUDE_CFXMLINTERFACE">
+        <Component Id="CFXMLINTERFACE_HEADERS_INCLUDE" Guid="7c7571a8-2bbb-458a-bb28-6b2995afa599">
+          <File Id="_CFXMLINTERFACE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\CFXMLInterface\CFXMLInterface.h" Checksum="yes" />
+          <File Id="_CFXMLINTERFACE_MODULE_MODULEMAP" Source="$(var.SDK_ROOT)\usr\lib\swift\CFXMLInterface\module.map" Checksum="yes" />
+        </Component>
+      </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_CFURLSESSIONINTERFACE">
-      <Component Id="CFURLSESSIONINTERFACE_HEADERS_RESOURCE" Guid="d908f6f0-066a-4c9f-9af6-870009ff7744">
-        <File Id="CFURLSESSIONINTERFACE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\CFURLSessionInterface\CFURLSessionInterface.h" Checksum="yes" />
-        <File Id="CFURLSESSIONINTERFACE_MODULE_MODULEMAP" Source="$(var.SDK_ROOT)\usr\lib\swift\CFURLSessionInterface\module.map" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
+      <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_CFURLSESSIONINTERFACE">
+        <Component Id="CFURLSESSIONINTERFACE_HEADERS_RESOURCE" Guid="d908f6f0-066a-4c9f-9af6-870009ff7744">
+          <File Id="CFURLSESSIONINTERFACE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\CFURLSessionInterface\CFURLSessionInterface.h" Checksum="yes" />
+          <File Id="CFURLSESSIONINTERFACE_MODULE_MODULEMAP" Source="$(var.SDK_ROOT)\usr\lib\swift\CFURLSessionInterface\module.map" Checksum="yes" />
+        </Component>
+      </DirectoryRef>
 
-    <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_CFXMLINTERFACE">
-      <Component Id="CFXMLINTERFACE_HEADERS_RESOURCE" Guid="5450a487-2d3f-4390-9f3c-52a545569636">
-        <File Id="CFXMLINTERFACE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\CFXMLInterface\CFXMLInterface.h" Checksum="yes" />
-        <File Id="CFXMLINTERFACE_MODULE_MODULEMAP" Source="$(var.SDK_ROOT)\usr\lib\swift\CFXMLInterface\module.map" Checksum="yes" />
-      </Component>
-    </DirectoryRef>
+      <DirectoryRef Id="WINDOWS_SDK_USR_LIB_SWIFT_CFXMLINTERFACE">
+        <Component Id="CFXMLINTERFACE_HEADERS_RESOURCE" Guid="5450a487-2d3f-4390-9f3c-52a545569636">
+          <File Id="CFXMLINTERFACE_H" Source="$(var.SDK_ROOT)\usr\lib\swift\CFXMLInterface\CFXMLInterface.h" Checksum="yes" />
+          <File Id="CFXMLINTERFACE_MODULE_MODULEMAP" Source="$(var.SDK_ROOT)\usr\lib\swift\CFXMLInterface\module.map" Checksum="yes" />
+        </Component>
+      </DirectoryRef>
+    <?endif?>
 
     <DirectoryRef Id="WINDOWS_SDK_USR_SHARE">
       <Component Id="WINDOWS_MODULE_MAPS_AND_APINOTES" Guid="4b02494d-d425-45f1-8b38-da0c247f1491">
@@ -409,12 +415,14 @@
       <ComponentRef Id="DISPATCH_IMPORT_LIBS" />
 
       <ComponentRef Id="FOUNDATION" />
-      <ComponentGroupRef Id="COREFOUNDATION_HEADERS_RESOURCE" />
-      <ComponentRef Id="CFXMLINTERFACE_HEADERS_RESOURCE" />
-      <ComponentRef Id="CFURLSESSIONINTERFACE_HEADERS_RESOURCE" />
-      <ComponentGroupRef Id="COREFOUNDATION_HEADERS_INCLUDE" />
-      <ComponentRef Id="CFXMLINTERFACE_HEADERS_INCLUDE" />
-      <ComponentRef Id="CFURLSESSIONINTERFACE_HEADERS_INCLUDE" />
+      <?if $(var.INCLUDE_CF_HEADERS) = true ?>
+        <ComponentGroupRef Id="COREFOUNDATION_HEADERS_RESOURCE" />
+        <ComponentRef Id="CFXMLINTERFACE_HEADERS_RESOURCE" />
+        <ComponentRef Id="CFURLSESSIONINTERFACE_HEADERS_RESOURCE" />
+        <ComponentGroupRef Id="COREFOUNDATION_HEADERS_INCLUDE" />
+        <ComponentRef Id="CFXMLINTERFACE_HEADERS_INCLUDE" />
+        <ComponentRef Id="CFURLSESSIONINTERFACE_HEADERS_INCLUDE" />
+      <?endif?>
       <ComponentRef Id="FOUNDATION_IMPORT_LIBS" />
 
       <?if $(var.CORE_OLD_LAYOUT) = true ?>


### PR DESCRIPTION
Remove the CoreFoundation headers from the installation as they are no
longer required for mainline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/297)
<!-- Reviewable:end -->
