### PR TITLE
WIX: autogenerate component guids at compile time

### DIFF
--- a/wix/windows-devtools.wixproj
+++ b/wix/windows-devtools.wixproj
@@ -29,8 +29,8 @@
 
   <PropertyGroup>
     <DefineConstants>DEVTOOLS_ROOT=$(DEVTOOLS_ROOT)</DefineConstants>
-    <HarvestDirectoryAutogenerateGuids>false</HarvestDirectoryAutogenerateGuids>
-    <HarvestDirectoryGenerateGuidsNow>true</HarvestDirectoryGenerateGuidsNow>
+    <HarvestDirectoryAutogenerateGuids>true</HarvestDirectoryAutogenerateGuids>
+    <HarvestDirectoryGenerateGuidsNow>false</HarvestDirectoryGenerateGuidsNow>
     <HarvestDirectoryNoLogo>true</HarvestDirectoryNoLogo>
     <HarvestDirectorySuppressCom>true</HarvestDirectorySuppressCom>
     <HarvestDirectorySuppressFragments>true</HarvestDirectorySuppressFragments>

--- a/wix/windows-sdk.wixproj
+++ b/wix/windows-sdk.wixproj
@@ -32,8 +32,8 @@
 
   <PropertyGroup>
     <DefineConstants>PLATFORM_ROOT=$(PLATFORM_ROOT);SDK_ROOT=$(SDK_ROOT);SWIFT_SOURCE_DIR=$(SWIFT_SOURCE_DIR);SDK_ROOT_USR_LIB_SWIFT_SHIMS=$(SDK_ROOT)\usr\lib\swift\shims;SDK_ROOT_USR_LIB_SWIFT_COREFOUNDATION=$(SDK_ROOT)\usr\lib\swift\CoreFoundation;CORE_OLD_LAYOUT=$(CORE_OLD_LAYOUT);SDK_ROOT_USR_LIB_SWIFT_TENSORFLOW=$(SDK_ROOT)\usr\lib\swift\tensorflow;TENSORFLOW=$(TENSORFLOW);TensorFlow_ROOT=$(TensorFlow_ROOT)</DefineConstants>
-    <HarvestDirectoryAutogenerateGuids>false</HarvestDirectoryAutogenerateGuids>
-    <HarvestDirectoryGenerateGuidsNow>true</HarvestDirectoryGenerateGuidsNow>
+    <HarvestDirectoryAutogenerateGuids>true</HarvestDirectoryAutogenerateGuids>
+    <HarvestDirectoryGenerateGuidsNow>false</HarvestDirectoryGenerateGuidsNow>
     <HarvestDirectoryNoLogo>true</HarvestDirectoryNoLogo>
     <HarvestDirectorySuppressCom>true</HarvestDirectorySuppressCom>
     <HarvestDirectorySuppressFragments>true</HarvestDirectorySuppressFragments>

--- a/wix/windows-toolchain.wixproj
+++ b/wix/windows-toolchain.wixproj
@@ -30,8 +30,8 @@
 
   <PropertyGroup>
     <DefineConstants>TOOLCHAIN_ROOT=$(TOOLCHAIN_ROOT);TOOLCHAIN_ROOT_USR_LIB_CLANG=$(TOOLCHAIN_ROOT)\usr\lib\clang;$(INCLUDE_DEBUG_INFO);INCLUDE_LLDB_PYTHON_SCRIPTS=$(INCLUDE_LLDB_PYTHON_SCRIPTS)</DefineConstants>
-    <HarvestDirectoryAutogenerateGuids>false</HarvestDirectoryAutogenerateGuids>
-    <HarvestDirectoryGenerateGuidsNow>true</HarvestDirectoryGenerateGuidsNow>
+    <HarvestDirectoryAutogenerateGuids>true</HarvestDirectoryAutogenerateGuids>
+    <HarvestDirectoryGenerateGuidsNow>false</HarvestDirectoryGenerateGuidsNow>
     <HarvestDirectoryNoLogo>true</HarvestDirectoryNoLogo>
     <HarvestDirectorySuppressCom>true</HarvestDirectorySuppressCom>
     <HarvestDirectorySuppressFragments>true</HarvestDirectorySuppressFragments>


### PR DESCRIPTION
Adjust the GUID generation to be compile time computation rather than
immediate.  This should allow installing over in future versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/298)
<!-- Reviewable:end -->
