### PR TITLE
gitignore installer files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 # *~
 
 .*.sw[nop]
-utilities/installer.exe*
+installer.exe*

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 # *~
 
 .*.sw[nop]
-
+utilities/installer.exe*


### PR DESCRIPTION
Add `installer.exe` and `installer.exe.zip` to the gitignore list to prevent them from being accidentally committed to the repo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/311)
<!-- Reviewable:end -->
