### PR TITLE
WIX: move tensorflow headers to `usr/include`

### DIFF
--- a/wix/windows-sdk.wixproj
+++ b/wix/windows-sdk.wixproj
@@ -77,7 +77,7 @@
     <ItemGroup Condition=" '$(TENSORFLOW)' == 'true' ">
       <HarvestDirectory Include="$(SDK_ROOT)\usr\lib\swift\tensorflow">
         <ComponentGroupName>TENSORFLOW_HEADERS</ComponentGroupName>
-        <DirectoryRefId>WINDOWS_SDK_USR_LIB_SWIFT_TENSORFLOW</DirectoryRefId>
+        <DirectoryRefId>WINDOWS_SDK_USR_INCLUDE_TENSORFLOW</DirectoryRefId>
         <PreprocessorVariable>var.SDK_ROOT_USR_LIB_SWIFT_TENSORFLOW</PreprocessorVariable>
       </HarvestDirectory>
     </ItemGroup>

--- a/wix/windows-sdk.wxs
+++ b/wix/windows-sdk.wxs
@@ -70,6 +70,10 @@
                             <Directory Id="WINDOWS_SDK_USR_INCLUDE_COREFOUNDATION" Name="CoreFoundation">
                             </Directory>
                           <?endif?>
+                          <?if $(var.TENSORFLOW) = true ?>
+                            <Directory Id="WINDOWS_SDK_USR_INCLUDE_TENSORFLOW" Name="tensorflow">
+                            </Directory>
+                          <?endif?>
                         </Directory>
                         <Directory Id="WINDOWS_SDK_USR_LIB" Name="lib">
                           <Directory Id="WINDOWS_SDK_USR_LIB_SWIFT" Name="swift">


### PR DESCRIPTION
This allows the headers to be picked up implicitly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/314)
<!-- Reviewable:end -->
