### PR TITLE
repo: update default revision

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -2,50 +2,50 @@
 <manifest project="swift">
   <remote name="github" fetch="git://github.com" />
 
-  <default revision="master" sync-c="true" sync-tags="false" />
+  <default revision="main" sync-c="true" sync-tags="false" />
 
   <project remote="github" name="apple/llvm-project" path="llvm-project" revision="swift/main" />
-  <project remote="github" name="apple/indexstore-db" path="indexstore-db" revision="main" />
-  <project remote="github" name="apple/sourcekit-lsp" path="sourcekit-lsp" revision="main" />
-  <project remote="github" name="apple/swift" path="swift" revision="main" />
-  <project remote="github" name="apple/swift-argument-parser" path="swift-argument-parser" revision="main" />
-  <project remote="github" name="apple/swift-cmark" path="cmark" revision="main" />
-  <project remote="github" name="apple/swift-corelibs-libdispatch" path="swift-corelibs-libdispatch" revision="main" />
-  <project remote="github" name="apple/swift-corelibs-foundation" path="swift-corelibs-foundation" revision="main" />
-  <project remote="github" name="apple/swift-corelibs-xctest" path="swift-corelibs-xctest" revision="main" />
-  <project remote="github" name="apple/swift-driver" path="swift-driver" revision="main" />
-  <project remote="github" name="apple/swift-llbuild" path="llbuild" revision="main" />
-  <project remote="github" name="apple/swift-log" path="swift-log" revision="main" />
-  <project remote="github" name="apple/swift-nio" path="swift-nio" revision="main" />
-  <project remote="github" name="apple/swift-numerics" path="swift-numerics" revision="main" />
-  <project remote="github" name="apple/swift-package-manager" path="swift-package-manager" revision="main" />
-  <project remote="github" name="apple/swift-protobuf" path="swift-protobuf" />
-  <project remote="github" name="apple/swift-syntax" path="swift-syntax" revision="main" />
-  <project remote="github" name="apple/swift-system" path="swift-system" revision="main" />
-  <project remote="github" name="apple/swift-tools-support-core" path="swift-tools-support-core" revision="main" />
-  <project remote="github" name="apple/swift-xcode-playground-support" path="swift-xcode-playground-support" revision="main" />
+  <project remote="github" name="apple/indexstore-db" path="indexstore-db" />
+  <project remote="github" name="apple/sourcekit-lsp" path="sourcekit-lsp" />
+  <project remote="github" name="apple/swift" path="swift" />
+  <project remote="github" name="apple/swift-argument-parser" path="swift-argument-parser" />
+  <project remote="github" name="apple/swift-cmark" path="cmark" />
+  <project remote="github" name="apple/swift-corelibs-libdispatch" path="swift-corelibs-libdispatch" />
+  <project remote="github" name="apple/swift-corelibs-foundation" path="swift-corelibs-foundation" />
+  <project remote="github" name="apple/swift-corelibs-xctest" path="swift-corelibs-xctest" />
+  <project remote="github" name="apple/swift-driver" path="swift-driver" />
+  <project remote="github" name="apple/swift-llbuild" path="llbuild" />
+  <project remote="github" name="apple/swift-log" path="swift-log" />
+  <project remote="github" name="apple/swift-nio" path="swift-nio" />
+  <project remote="github" name="apple/swift-numerics" path="swift-numerics" />
+  <project remote="github" name="apple/swift-package-manager" path="swift-package-manager" />
+  <project remote="github" name="apple/swift-protobuf" path="swift-protobuf" revision="master" />
+  <project remote="github" name="apple/swift-syntax" path="swift-syntax" />
+  <project remote="github" name="apple/swift-system" path="swift-system" />
+  <project remote="github" name="apple/swift-tools-support-core" path="swift-tools-support-core" />
+  <project remote="github" name="apple/swift-xcode-playground-support" path="swift-xcode-playground-support" />
 
-  <project remote="github" name="compnerd/swift-build" path="swift-build" />
-  <project remote="github" name="compnerd/swift-win32" path="swift-win32" />
+  <project remote="github" name="compnerd/swift-build" path="swift-build" revision="trunk" />
+  <project remote="github" name="compnerd/swift-win32" path="swift-win32" revision="master" />
 
-  <project remote="github" name="curl/curl" path="curl" groups="nodefault,dependencies" />
+  <project remote="github" name="curl/curl" path="curl" groups="nodefault,dependencies" revision="master" />
 
-  <project remote="github" name="google/swift-benchmark" path="swift-benchmark" groups="nodefault,tensorflow" />
-  <project remote="github" name="google/swift-jupyter" path="swift-jupyter" groups="nodefault,tensorflow" />
+  <project remote="github" name="google/swift-benchmark" path="swift-benchmark" groups="nodefault,tensorflow" revision="master" />
+  <project remote="github" name="google/swift-jupyter" path="swift-jupyter" groups="nodefault,tensorflow" revision="master" />
 
-  <project remote="github" name="jpsim/Yams" path="Yams" />
+  <project remote="github" name="jpsim/Yams" path="Yams" revision="master" />
 
-  <project remote="github" name="Kitware/CMake" path="CMake" groups="nodefault,dependencies" />
+  <project remote="github" name="Kitware/CMake" path="CMake" groups="nodefault,dependencies" revision="master" />
 
-  <project remote="github" name="madler/zlib" path="zlib" groups="nodefault,dependencies" />
+  <project remote="github" name="madler/zlib" path="zlib" groups="nodefault,dependencies" revision="master" />
   
-  <project remote="github" name="ninja-build/ninja" path="ninja" groups="nodefault,dependencies" />
+  <project remote="github" name="ninja-build/ninja" path="ninja" groups="nodefault,dependencies" revision="master" />
 
-  <project remote="github" name="pvieito/PythonKit" path="PythonKit" groups="nodefault,tensorflow" />
+  <project remote="github" name="pvieito/PythonKit" path="PythonKit" groups="nodefault,tensorflow" revision="master" />
 
-  <project remote="github" name="tensorflow/tensorflow" path="tensorflow" groups="notdefault,tensorflow" />
-  <project remote="github" name="tensorflow/swift-apis" path="tensorflow-swift-apis" groups="notdefault,tensorflow" />
-  <project remote="github" name="tensorflow/swift-models" path="tensorflow-swift-models" groups="notdefault,tensorflow" />
+  <project remote="github" name="tensorflow/tensorflow" path="tensorflow" groups="notdefault,tensorflow" revision="master" />
+  <project remote="github" name="tensorflow/swift-apis" path="tensorflow-swift-apis" groups="notdefault,tensorflow" revision="master" />
+  <project remote="github" name="tensorflow/swift-models" path="tensorflow-swift-models" groups="notdefault,tensorflow" revision="master" />
 
   <!-- <project remote="github" name="unicode-org/icu" path="icu" revision="maint/maint-66" /> -->
 </manifest>


### PR DESCRIPTION
In preparation for moving from master to trunk as the default branch and
to mirror the many repositories changing to main as the default branch,
update the repo manifest default branch to `main`.  Propagate the
existing default revision through the rest of the repositories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/325)
<!-- Reviewable:end -->
