### PR TITLE
add Dockerfile for windows based development image

### DIFF
--- a/docker/Windows-1809/Dockerfile
+++ b/docker/Windows-1809/Dockerfile
@@ -1,0 +1,37 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows/servercore:1809-amd64
+
+# Install windows buildtools.
+RUN powershell mkdir .\TEMP\; `
+    Invoke-WebRequest -Uri https://aka.ms/vs/16/release/vs_buildtools.exe -OutFile .\TEMP\vs_buildtools.exe; `
+    Start-Process .\TEMP\vs_buildtools.exe  -Wait -ArgumentList '--quiet --wait --norestart --nocache `
+    --installPath C:\BuildTools `
+    --add Microsoft.VisualStudio.Component.VC.CMake.Project `
+    --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+    --add Microsoft.VisualStudio.Component.Windows10SDK `
+    --add Microsoft.VisualStudio.Component.Windows10SDK.18362'; `
+    Remove-Item –path .\TEMP\vs_buildtools.exe
+
+ADD swift-build.py /swift-build.py
+
+# Install Swift toolchain.
+# use the azure cli to get an installation of python as Component.CPython.x64 component of buildtools was removed in vs2019
+RUN powershell Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile .\AzureCLI.msi; `
+    Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; `
+    Remove-Item –path .\AzureCLI.msi; `
+    C:/Program` Files` `(x86`)/Microsoft` SDKs/Azure/CLI2/python.exe -m pip install tabulate azure-devops; `
+    C:/Program` Files` `(x86`)/Microsoft` SDKs/Azure/CLI2/python.exe swift-build.py --download --build-id VS2019 --latest-artifacts --filter installer.exe --quiet; `
+    Expand-Archive -Force installer.exe.zip .; `
+    Start-Process installer.exe\installer.exe  -Wait -ArgumentList '/quiet'; `
+    Remove-Item –path .\installer.exe –recurse
+
+# Swift dev-env deploy
+RUN powershell Invoke-WebRequest -Uri https://github.com/compnerd/swift-devenv/releases/download/v0.0.3/swift-devenv.exe -OutFile C:/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swift-devenv.exe;`
+    Start-Process C:/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swift-devenv.exe -Wait -ArgumentList '--deploy'; `
+    $env:INCLUDE = "C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/ucrt;C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared;C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um;C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/winrt;C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/cppwinrt"; `
+    $env:LIB = "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.18362.0/ucrt/x64;C:/Program Files (x86)/Windows Kits/10/Lib/10.0.18362.0/um/x64"
+
+
+# Default to powershell
+ENTRYPOINT ["C:\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]

--- a/docker/Windows-1809/swift-build.py
+++ b/docker/Windows-1809/swift-build.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+# Copyright 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+
+from msrest.authentication import BasicAuthentication
+from azure.devops.connection import Connection
+
+from tabulate import tabulate
+import itertools
+import argparse
+import urllib
+import sys
+import re
+
+import sys
+if sys.version_info.major == 3:
+  unicode = str
+  urllib.urlretrieve = urllib.request.urlretrieve
+else:
+  itertools.filterfalse = itertools.ifilterfalse
+
+base_url = 'https://dev.azure.com/compnerd'
+project = 'swift-build'
+creds = BasicAuthentication('', '')
+
+connection = Connection(base_url = base_url, creds = creds)
+builds = connection.clients.get_build_client()
+
+definitions = ()
+
+def get_latest_build(definition):
+  return builds.get_builds(project, definitions = [definition],
+                           result_filter = 'succeeded,partiallySucceeded',
+                           top = True).value[0].id
+
+def get_artifacts(build_id):
+  return (
+    (artifact.name, artifact.resource.download_url) for artifact in
+        builds.get_artifacts(project, build_id)
+  )
+
+def print_progress(n, bs, s, artifact, quiet):
+  if not quiet:
+    sys.stdout.write("\r{0:s}.zip {1:d} bytes".format(artifact[0], (n * bs)))
+
+def main():
+  parser = argparse.ArgumentParser(project)
+  parser.add_argument('--list-builds', action = 'store_true',
+                      dest = 'list_builds',
+                      help = 'print the known builds')
+  parser.add_argument('--order-by', action = 'store', dest = 'order_by',
+                      choices = ['id', 'name'], default = 'id')
+  parser.add_argument('--build-id', action = 'append', dest = 'build_id',
+                      help = 'the build identifier (may be repeated)',
+                      default = [])
+  parser.add_argument('--latest-id', action = 'store_true', dest = 'latest_id',
+                      help = 'print the latest completed id')
+  parser.add_argument('--latest-artifacts', action = 'store_true',
+                      dest = 'latest_artifacts',
+                      help = 'print the artifacts of the latest build')
+  parser.add_argument('--download', action = 'store_true', dest = 'download',
+                      help = 'download the artifacts of the latest build')
+  parser.add_argument('--filter', action = 'store', dest = 'filter',
+                      help = 'filter the artifacts matching')
+  parser.add_argument('--quiet', action='store_true', dest='quiet',
+                        help='Silence download information')
+
+  args = parser.parse_args()
+
+  def _get_query_order(args):
+    if args.order_by == 'id':
+      return None
+    if args.order_by == 'name':
+      return 'definitionNameAscending'
+    assert False, "unexpected ORDER_BY"
+
+  definitions = ( (definition.id, definition.name) for definition in
+      builds.get_definitions(project, query_order = _get_query_order(args)).value
+  )
+
+  if args.list_builds:
+    print(tabulate(definitions, headers = ['ID', 'Name']))
+    return 0
+
+  pipelines = dict((value, key) for (key, value) in definitions)
+  build_ids = (
+      int(build) if unicode(build).isnumeric() else pipelines[build] for
+          build in args.build_id
+  )
+
+  if args.latest_id:
+    print(get_latest_build(definition) for definition in build_ids)
+  elif args.latest_artifacts:
+    artifacts = (
+        get_artifacts(get_latest_build(definition)) for definition in build_ids
+    )
+    if args.filter:
+      artifacts = itertools.filterfalse(lambda artifact: not re.search(args.filter, artifact[0]),
+                                        itertools.chain.from_iterable(artifacts))
+    else:
+      artifacts = itertools.chain.from_iterable(artifacts)
+    artifacts = [artifact for artifact in artifacts]
+    print(tabulate(artifacts, tablefmt = 'plain'))
+    if args.download:
+      for artifact in artifacts:
+        urllib.urlretrieve(artifact[1], "{0:s}.zip".format(artifact[0]),
+                           lambda n, bs, s:
+                             print_progress(n, bs, s, artifact, args.quiet))
+        print("")
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
hi compnerd, first and foremost huge thank you for all the work you did to bring swift to windows!

i noticed that the official download page of swift lacks a docker image for windows development and CI/CD

this commits adds a `windows/servercore:1809` based development image containing the buildtools and a swift toolchain from `//swift/build`

sadly to fulfill dockers buildcontext requirements i had to duplicate the `swift-build.py` file. it should be possible to clean this up later