### PR TITLE
WIX: add `_InternalSwiftSyntaxParser` module

### DIFF
--- a/.ci/templates/toolchain-msi.yml
+++ b/.ci/templates/toolchain-msi.yml
@@ -102,12 +102,19 @@ jobs:
             solution: $(Build.SourcesDirectory)/swift-build/wix/windows-toolchain.wixproj
             msbuildArguments: /p:RunWixToolsOutOfProc=true -p:OutputPath=$(Build.BinariesDirectory)\toolchain-msi\ -p:IntermediateOutputPath=$(Build.BinariesDirectory)\toolchain-msi\ -p:TOOLCHAIN_ROOT=$(toolchain.directory) -p:INCLUDE_LLDB_PYTHON_SCRIPTS=false
 
-      - ${{ if ne(parameters.VERSION, '5.2') }}:
+      - ${{ if or(eq(parameters.VERSION, '5.3'), eq(parameters.VERSION, '5.4')) }}:
         - task: MSBuild@1
           displayName: toolchain.msi
           inputs:
             solution: $(Build.SourcesDirectory)/swift-build/wix/windows-toolchain.wixproj
             msbuildArguments: /p:RunWixToolsOutOfProc=true -p:OutputPath=$(Build.BinariesDirectory)\toolchain-msi\ -p:IntermediateOutputPath=$(Build.BinariesDirectory)\toolchain-msi\ -p:TOOLCHAIN_ROOT=$(toolchain.directory) -p:INCLUDE_LLDB_PYTHON_SCRIPTS=true
+
+      - ${{ if and(ne(parameters.VERSION, '5.2'), ne(parameters.VERSION, '5.3'), ne(parameters.VERSION, '5.4')) }}:
+        - task: MSBuild@1
+          displayName: toolchain.msi
+          inputs:
+            solution: $(Build.SourcesDirectory)/swift-build/wix/windows-toolchain.wixproj
+            msbuildArguments: /p:RunWixToolsOutOfProc=true -p:OutputPath=$(Build.BinariesDirectory)\toolchain-msi\ -p:IntermediateOutputPath=$(Build.BinariesDirectory)\toolchain-msi\ -p:TOOLCHAIN_ROOT=$(toolchain.directory) -p:INCLUDE_LLDB_PYTHON_SCRIPTS=true -p:HAVE__INTERNAL_SWIFT_SYNTAX_PARSER=true
 
       - script: |
           signtool sign /f $(certificate.secureFilePath) /p $(CERTIFICATE_PASSWORD) /tr http://timestamp.digicert.com /fd sha256 /td sha256 $(Build.BinariesDirectory)/toolchain-msi/toolchain.msi

--- a/.ci/vs2019-swift-5.4.yml
+++ b/.ci/vs2019-swift-5.4.yml
@@ -287,6 +287,8 @@ stages:
           os: Windows
           proc: amd64
 
+          VERSION: 5.4
+
   - stage: package_windows_sdk
     dependsOn: windows_sdk
     displayName: package SDK

--- a/wix/windows-toolchain.wixproj
+++ b/wix/windows-toolchain.wixproj
@@ -26,10 +26,11 @@
 
   <PropertyGroup>
     <INCLUDE_LLDB_PYTHON_SCRIPTS Condition=" '$(INCLUDE_LLDB_PYTHON_SCRIPTS)' == '' ">true</INCLUDE_LLDB_PYTHON_SCRIPTS>
+    <HAVE__INTERNAL_SWIFT_SYNTAX_PARSER Condition=" '$(HAVE__INTERNAL_SWIFT_SYNTAX_PARSER)' == '' ">false</HAVE__INTERNAL_SWIFT_SYNTAX_PARSER>
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefineConstants>TOOLCHAIN_ROOT=$(TOOLCHAIN_ROOT);TOOLCHAIN_ROOT_USR_LIB_CLANG=$(TOOLCHAIN_ROOT)\usr\lib\clang;$(INCLUDE_DEBUG_INFO);INCLUDE_LLDB_PYTHON_SCRIPTS=$(INCLUDE_LLDB_PYTHON_SCRIPTS)</DefineConstants>
+    <DefineConstants>TOOLCHAIN_ROOT=$(TOOLCHAIN_ROOT);TOOLCHAIN_ROOT_USR_LIB_CLANG=$(TOOLCHAIN_ROOT)\usr\lib\clang;$(INCLUDE_DEBUG_INFO);INCLUDE_LLDB_PYTHON_SCRIPTS=$(INCLUDE_LLDB_PYTHON_SCRIPTS);HAVE__INTERNAL_SWIFT_SYNTAX_PARSER=$(HAVE__INTERNAL_SWIFT_SYNTAX_PARSER)</DefineConstants>
     <HarvestDirectoryAutogenerateGuids>false</HarvestDirectoryAutogenerateGuids>
     <HarvestDirectoryGenerateGuidsNow>true</HarvestDirectoryGenerateGuidsNow>
     <HarvestDirectoryNoLogo>true</HarvestDirectoryNoLogo>

--- a/wix/windows-toolchain.wxs
+++ b/wix/windows-toolchain.wxs
@@ -39,6 +39,8 @@
                   <Directory Id="USR_BIN" Name="bin">
                   </Directory>
                   <Directory Id="USR_INCLUDE" Name="include">
+                    <Directory Id="USR_INCLUDE__INTERNALSWIFTSYNTAXPARSER" Name="_InternalSwiftSyntaxParser">
+                    </Directory>
                     <Directory Id="USR_INCLUDE_CLANG_C" Name="clang-c">
                     </Directory>
                     <Directory Id="USR_INCLUDE_DISPATCH" Name="dispatch">
@@ -161,6 +163,9 @@
         <File Id="SWIFT_REFACTOR_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-refactor.exe" Checksum="yes" />
         <File Id="SWIFT_EXE" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift.exe" Checksum="yes" />
         <File Id="SWIFTDEMANGLE_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swiftDemangle.dll" Checksum="yes" />
+        <?if $(var.HAVE__INTERNAL_SWIFT_SYNTAX_PARSER) = true ?>
+          <File Id="_INTERNALSWIFTSYNTAXPARSER_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftSyntaxParser.dll" Checksum="yes" />
+        <?endif?>
         <!-- sourcekit -->
         <File Id="BLOCKSRUNTIME_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.dll" Checksum="yes" />
         <File Id="DISPATCH_DLL" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\dispatch.dll" Checksum="yes" />
@@ -213,6 +218,9 @@
         <File Id="SWIFT_REFACTOR_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift-refactor.pdb" Checksum="yes" DiskId="5" />
         <File Id="SWIFT_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swift.pdb" Checksum="yes" DiskId="5" />
         <File Id="SWIFTDEMANGLE_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\swiftDemangle.pdb" Checksum="yes" DiskId="5" />
+        <?if $(var.HAVE__INTERNAL_SWIFT_SYNTAX_PARSER) = true ?>
+          <File Id="_INTERNALSWIFTSYNTAXPARSER_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\_InternalSwiftSyntaxParser.pdb" Checksum="yes" DiskId="5" />
+        <?endif?>
 
         <!-- sourcekit -->
         <File Id="BLOCKSRUNTIME_PDB" Source="$(var.TOOLCHAIN_ROOT)\usr\bin\BlocksRuntime.pdb" Checksum="yes" DiskId="6" />
@@ -232,6 +240,9 @@
         <File Id="LTO_LIB" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\LTO.lib" Checksum="yes" />
         <File Id="SOURCEKITD_IN_PROC_LIB" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\sourcekitdInProc.lib" Checksum="yes" />
         <File Id="SWIFTDEMANGLE_LIB" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swiftDemangle.lib" Checksum="yes" />
+        <?if $(var.HAVE__INTERNAL_SWIFT_SYNTAX_PARSER) = true ?>
+          <File Id="_INTERNALSWIFTSYNTAXPARSER_LIB" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\windows\_InternalSwiftSyntaxParser.lib" Checksum="yes" />
+        <?endif?>
       </Component>
     </DirectoryRef>
 
@@ -281,6 +292,15 @@
       </Component>
     </DirectoryRef>
     -->
+
+    <DirectoryRef Id="USR_INCLUDE__INTERNALSWIFTSYNTAXPARSER">
+      <?if $(var.HAVE__INTERNAL_SWIFT_SYNTAX_PARSER) = true ?>
+        <Component Id="_INTERNALSWIFTSYNTAXPARSER_HEADERS" Guid="751f758a-ee88-4be5-9285-97bbf3aa374a">
+          <File Id="SWIFTSYNTAXPARSER_H" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftSyntaxParser\SwiftSyntaxParser.h" Checksum="yes" />
+          <File Id="_INTERNALSWIFTSYNTAXPARSER_MODULE_MODULEMAP" Source="$(var.TOOLCHAIN_ROOT)\usr\lib\swift\_InternalSwiftSyntaxParser\module.modulemap" Checksum="yes" />
+        </Component>
+      <?endif?>
+    </DirectoryRef>
 
     <DirectoryRef Id="USR_INCLUDE_CLANG_C">
       <Component Id="LIBCLANG_HEADERS" Guid="98801c44-a3a4-4a2d-9cf9-0c2a642f4132">
@@ -371,6 +391,9 @@
       <!--
       <ComponentRef Id="BLOCK_HEADERS" />
       -->
+      <?if $(var.HAVE__INTERNAL_SWIFT_SYNTAX_PARSER) = true ?>
+        <ComponentRef Id="_INTERNALSWIFTSYNTAXPARSER_HEADERS" />
+      <?endif?>
       <ComponentRef Id="INDEXSTORE_HEADERS" />
       <ComponentRef Id="LIBCLANG_HEADERS" />
       <ComponentRef Id="LTO_HEADERS" />


### PR DESCRIPTION
This adds the `_InternalSwiftSyntaxParser` to the toolchain properly.
This is used by swift-format through the SwiftSyntax package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/338)
<!-- Reviewable:end -->
