### PR TITLE
CI: correct parameter for CF headers

### DIFF
--- a/.ci/templates/sdk-msi.yml
+++ b/.ci/templates/sdk-msi.yml
@@ -107,14 +107,14 @@ jobs:
           displayName: ${{ parameters.platform }}-sdk-${{ parameters.proc }}.msi
           inputs:
             solution: $(Build.SourcesDirectory)/swift-build/wix/windows-sdk.wixproj
-            msbuildArguments: /p:RunWixToolsOutOfProc=true -p:OutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:IntermediateOutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:PLATFORM_ROOT=$(platform.directory) -p:SDK_ROOT=$(sdk.directory) -p:SWIFT_SOURCE_DIR=$(Build.SourcesDirectory)/swift -p:CORE_OLD_LAYOUT=true -p:HAVE_MSVCRT=true -p:HAVE__CONCURRENCY=false -p:HAVE__DIFFERENTIATION=false -p:INCLUDE_CF_HEADERS=YES -p:TensorFlow_ROOT=$(Pipeline.Workspace)/tensorflow/tensorflow-${{ parameters.platform }}-${{ parameters.host }} -p:TENSORFLOW=${{ parameters.tensorflow }}
+            msbuildArguments: /p:RunWixToolsOutOfProc=true -p:OutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:IntermediateOutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:PLATFORM_ROOT=$(platform.directory) -p:SDK_ROOT=$(sdk.directory) -p:SWIFT_SOURCE_DIR=$(Build.SourcesDirectory)/swift -p:CORE_OLD_LAYOUT=true -p:HAVE_MSVCRT=true -p:HAVE__CONCURRENCY=false -p:HAVE__DIFFERENTIATION=false -p:INCLUDE_CF_HEADERS=true -p:TensorFlow_ROOT=$(Pipeline.Workspace)/tensorflow/tensorflow-${{ parameters.platform }}-${{ parameters.host }} -p:TENSORFLOW=${{ parameters.tensorflow }}
 
       - ${{ if ne(parameters.VERSION, '5.3') }}:
         - task: MSBuild@1
           displayName: ${{ parameters.platform }}-sdk-${{ parameters.proc }}.msi
           inputs:
             solution: $(Build.SourcesDirectory)/swift-build/wix/windows-sdk.wixproj
-            msbuildArguments: /p:RunWixToolsOutOfProc=true -p:OutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:IntermediateOutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:PLATFORM_ROOT=$(platform.directory) -p:SDK_ROOT=$(sdk.directory) -p:SWIFT_SOURCE_DIR=$(Build.SourcesDirectory)/swift -p:CORE_OLD_LAYOUT=false -p:HAVE_MSVCRT=false -p:HAVE__CONCURRENCY=true -p:HAVE__DIFFERENTIATION=true -p:INCLUDE_CF_HEADERS=NO -p:TensorFlow_ROOT=$(Pipeline.Workspace)/tensorflow/tensorflow-${{ parameters.platform }}-${{ parameters.host }} -p:TENSORFLOW=${{ parameters.tensorflow }}
+            msbuildArguments: /p:RunWixToolsOutOfProc=true -p:OutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:IntermediateOutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:PLATFORM_ROOT=$(platform.directory) -p:SDK_ROOT=$(sdk.directory) -p:SWIFT_SOURCE_DIR=$(Build.SourcesDirectory)/swift -p:CORE_OLD_LAYOUT=false -p:HAVE_MSVCRT=false -p:HAVE__CONCURRENCY=true -p:HAVE__DIFFERENTIATION=true -p:INCLUDE_CF_HEADERS=false -p:TensorFlow_ROOT=$(Pipeline.Workspace)/tensorflow/tensorflow-${{ parameters.platform }}-${{ parameters.host }} -p:TENSORFLOW=${{ parameters.tensorflow }}
 
       - script: |
           signtool sign /f $(certificate.secureFilePath) /p $(CERTIFICATE_PASSWORD) /tr http://timestamp.digicert.com /fd sha256 /td sha256 $(Build.BinariesDirectory)/sdk-msi/sdk.msi


### PR DESCRIPTION
Repair the packaging for the 5.3 release to include the CoreFoundation
headers as that release did not use the `@_imlementationOnly` imports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/341)
<!-- Reviewable:end -->
