### PR TITLE
CI: avoid full clones for the devtools and SDK steps

### DIFF
--- a/.ci/templates/windows-devtools.yml
+++ b/.ci/templates/windows-devtools.yml
@@ -107,9 +107,11 @@ jobs:
 
       - checkout: apple/llvm-project
         displayName: checkout apple/llvm-project
+        fetchDepth: 1
 
       - checkout: apple/swift
         displayName: checkout apple/swift
+        fetchDepth: 1
 
       - checkout: apple/swift-cmark
         displayName: checkout apple/siwft-cmark

--- a/.ci/templates/windows-sdk.yml
+++ b/.ci/templates/windows-sdk.yml
@@ -107,9 +107,11 @@ jobs:
 
       - checkout: apple/llvm-project
         displayName: checkout apple/llvm-project
+        fetchDepth: 1
 
       - checkout: apple/swift
         displayName: checkout apple/swift
+        fetchDepth: 1
 
       - checkout: apple/swift-cmark
         displayName: checkout apple/swift-cmark

--- a/.ci/vs2019-google.yml
+++ b/.ci/vs2019-google.yml
@@ -113,6 +113,12 @@ resources:
       ref: main
       endpoint: GitHub
 
+    - repository: apple/swift-crypto
+      type: github
+      name: apple/swift-crypto
+      ref: main
+      endpoint: GitHub
+
 trigger:
   branches:
     include:


### PR DESCRIPTION
We can get away with a shallow fetch, use that instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/343)
<!-- Reviewable:end -->
