### PR TITLE
WIX: enable Developer Mode with SwiftPM

### DIFF
--- a/wix/windows-devtools.wxs
+++ b/wix/windows-devtools.wxs
@@ -149,7 +149,7 @@
 
         <?ifdef INCLUDE_DEBUG_INFO ?>
         <Component Id="SWIFT_CRYPTO_DEBUGINFO" Guid="4cbda17f-a85b-4620-bdd4-18b03ba07499">
-          <File Id="CRYPTO_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.pdb" Chekcsum="yes" />
+          <File Id="CRYPTO_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.pdb" Checksum="yes" />
         </Component>
         <?endif?>
       <?endif?>
@@ -187,6 +187,11 @@
         <File Id="SWIFT_PACKAGE_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-package.exe" Checksum="yes" />
         <File Id="SWIFT_RUN_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-run.exe" Checksum="yes" />
         <File Id="SWIFT_TEST_EXE" Source="$(var.DEVTOOLS_ROOT)\usr\bin\swift-test.exe" Checksum="yes" />
+
+        <!-- SwiftPM requires Developer Mode -->
+        <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock">
+          <RegistryValue Type="integer" Name="AllowDevelopmentWithoutDevLicense" Value="1" />
+        </RegistryKey>
       </Component>
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
@@ -267,7 +272,7 @@
       </Component>
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SWIFT_PD_4_2_DEBUGINFO" GUid="">
+      <Component Id="SWIFT_PD_4_2_DEBUGINFO" Guid="161c6709-9042-4781-bd48-0e88cd6b73ce">
         <File Id="PD4_2_PACKAGE_DESCRIPTION_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\4_2\PackageDescription.pdb" Checksum="yes" />
       </Component>
       <?endif?>


### PR DESCRIPTION
SwiftPM requires Developer Mode to function properly. Instead of asking users to enable it manually, we can enable it through the installer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/350)
<!-- Reviewable:end -->
