### PR TITLE
WIX: correct debug info package for developer tools

### DIFF
--- a/wix/windows-devtools.wxs
+++ b/wix/windows-devtools.wxs
@@ -149,7 +149,7 @@
 
         <?ifdef INCLUDE_DEBUG_INFO ?>
         <Component Id="SWIFT_CRYPTO_DEBUGINFO" Guid="4cbda17f-a85b-4620-bdd4-18b03ba07499">
-          <File Id="CRYPTO_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.pdb" Chekcsum="yes" />
+          <File Id="CRYPTO_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.pdb" Checksum="yes" />
         </Component>
         <?endif?>
       <?endif?>
@@ -267,7 +267,7 @@
       </Component>
 
       <?ifdef INCLUDE_DEBUG_INFO ?>
-      <Component Id="SWIFT_PD_4_2_DEBUGINFO" GUid="">
+      <Component Id="SWIFT_PD_4_2_DEBUGINFO" Guid="bfd57cc1-f965-484e-a60a-afaa9500eb8b">
         <File Id="PD4_2_PACKAGE_DESCRIPTION_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\4_2\PackageDescription.pdb" Checksum="yes" />
       </Component>
       <?endif?>


### PR DESCRIPTION
Ensure that we checksum the crypto debug modules.  Add a guid for the
debug info component for the package description.  This largely doesn't
impact anything as the debug information is not currently packaged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/351)
<!-- Reviewable:end -->
