### PR TITLE
CI: remove tensorflow/swift-apis

### DIFF
--- a/.ci/macOS.yml
+++ b/.ci/macOS.yml
@@ -80,12 +80,6 @@ resources:
       ref: main
       endpoint: GitHub
 
-    - repository: tensorflow/swift-apis
-      type: github
-      name: tensorflow/swift-apis
-      ref: main
-      endpoint: GitHub
-
     - repository: jpsim/Yams
       type: github
       name: jpsim/Yams

--- a/.ci/templates/devtools-deb.yml
+++ b/.ci/templates/devtools-deb.yml
@@ -55,10 +55,6 @@ jobs:
       - checkout: apple/sourcekit-lsp
         displayName: checkout apple/sourcekit-lsp
 
-      - ${{ if eq(parameters.TENSORFLOW, true) }}:
-        - checkout: tensorflow/swift-apis
-          displayName: checkout tensorflow/swift-apis
-
       - script: |
           mkdir -p $(Build.StagingDirectory)/swift-devtools
           rsync -v -a -l $(Pipeline.Workspace)/devtools-linux-${{ parameters.host }}/Library $(Build.StagingDirectory)/swift-devtools/Library

--- a/.ci/templates/icu-deb.yml
+++ b/.ci/templates/icu-deb.yml
@@ -57,10 +57,6 @@ jobs:
       - checkout: apple/sourcekit-lsp
         displayName: checkout apple/sourcekit-lsp
 
-      - ${{ if eq(parameters.TENSORFLOW, true) }}:
-        - checkout: tensorflow/swift-apis
-          displayName: checkout tensorflow/swift-apis
-
       - script: |
           mkdir -p $(Build.StagingDirectory)/swift-icu
           rsync -v -a -l $(Pipeline.Workspace)/icu/icu-linux-${{ parameters.host }}/Library $(Build.StagingDirectory)/swift-icu/Library

--- a/.ci/templates/linux-devtools.yml
+++ b/.ci/templates/linux-devtools.yml
@@ -76,10 +76,6 @@ jobs:
       - checkout: apple/sourcekit-lsp
         displayName: checkout apple/sourcekit-lsp
 
-      - ${{ if eq(parameters.TENSORFLOW, true) }}:
-        - checkout: tensorflow/swift-apis
-          displayName: checkout tensorflow/swift-apis
-
       - script: |
           function ApplyPatches() {
             local repository=${1} ; shift

--- a/.ci/templates/linux-sdk.yml
+++ b/.ci/templates/linux-sdk.yml
@@ -3,10 +3,6 @@ parameters:
     type: string
     default: ''
 
-  - name: TENSORFLOW
-    type: boolean
-    default: false
-
   - name: VisualStudio
     type: string
     default: ''
@@ -123,10 +119,6 @@ jobs:
 
       - checkout: apple/sourcekit-lsp
         displayName: checkout apple/sourcekit-lsp
-
-      - ${{ if eq(parameters.TENSORFLOW, true) }}:
-        - checkout: tensorflow/swift-apis
-          displayName: checkout tensorflow/swift-apis
 
       - script: |
           function ApplyPatches() {

--- a/.ci/templates/macos-sdk.yml
+++ b/.ci/templates/macos-sdk.yml
@@ -3,10 +3,6 @@ parameters:
     type: string
     default: ''
 
-  - name: TENSORFLOW
-    type: boolean
-    default: false
-
   - name: VisualStudio
     type: string
     default: ''
@@ -39,13 +35,11 @@ jobs:
 
       curl.version: development
       icu.version: ${{ parameters.ICU_VERSION }}
-      tensorflow.version: 2.4.0
       xml2.version: development
       zlib.version: 1.2.11
 
       curl.directory: $(Pipeline.Workspace)/curl/curl-${{ parameters.platform }}-${{ parameters.host }}/Library/libcurl-$(curl.version)
       icu.directory: $(Pipeline.Workspace)/icu/icu-${{ parameters.platform }}-${{ parameters.host }}/Library/icu-$(icu.version)
-      tensorflow.directory: $(Pipeline.Workspace)/tensorflow/tensorflow-${{ parameters.platform }}-${{ parameters.host }}/Library/tensorflow-$(tensorflow.version)
       xml2.directory: $(Pipeline.Workspace)/xml2/xml2-${{ parameters.platform }}-${{ parameters.host }}/Library/libxml2-$(xml2.version)
       zlib.directory: $(Pipeline.Workspace)/zlib/zlib-${{ parameters.platform }}-${{ parameters.host }}/Library/zlib-$(zlib.version)
 
@@ -83,11 +77,6 @@ jobs:
         artifact: toolchain-darwin-x64
         displayName: download toolchain
 
-      - ${{ if eq(parameters.TENSORFLOW, true) }}:
-        - download: tensorflow
-          artifact: tensorflow-${{ parameters.platform }}-${{ parameters.host }}
-          displayName: download TensorFlow
-
       - script: |
           git config --global --add core.autocrlf false
           git config --global --add core.symlinks true
@@ -112,11 +101,6 @@ jobs:
       - checkout: apple/swift-corelibs-xctest
         displayName: checkout apple/swift-corelibs-xctest
 
-      - ${{ if eq(parameters.TENSORFLOW, true) }}:
-        - checkout: tensorflow/swift-apis
-          displayName: checkout tensorflow/swift-apis
-          path: s/tensorflow-swift-apis
-
       - script: |
           function ApplyPatches() {
             local repository=${1} ; shift
@@ -134,19 +118,6 @@ jobs:
           ApplyPatches swift-corelibs-foundation ${FOUNDATION_PR}
           ApplyPatches swift-corelibs-xctest ${XCTEST_PR}
         displayName: Apply Patches
-
-      - ${{ if eq(parameters.TENSORFLOW, true) }}:
-        - script: |
-            function ApplyPatches() {
-              local repository=${1} ; shift
-              for PR in "${@}" ; do
-                git -C ${repository} fetch origin pull/${PR}/head
-                git -C ${repository} cherry-pick FETCH_HEAD
-              done
-            }
-
-            ApplyPatches tensorflow-swift-apis ${SWIFT_APIS_PR}
-          displayName: Apply Patches
 
       - task: BatchScript@1
         condition: eq( variables['Agent.OS'], 'Windows_NT' )
@@ -294,35 +265,6 @@ jobs:
         enabled: false
         inputs:
           cmakeArgs: --build $(Build.BinariesDirectory)/xctest
-
-      - ${{ if eq(parameters.TENSORFLOW, true) }}:
-        - task: CMake@1
-          displayName: Configure tensorflow-swift-apis
-          inputs:
-            cmakeArgs:
-              -B $(Build.BinariesDirectory)/tensorflow-swift-apis
-              -D BUILD_SHARED_LIBS=YES
-              -D SWIFT_STDLIB_DIR=$(Build.BinariesDirectory)/swift-stdlib
-              -C $(Build.SourcesDirectory)/swift-build/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}-swift-flags.cmake
-              -D BUILD_TESTING=NO
-              -D CMAKE_Swift_COMPILER=$(toolchain.directory)/usr/bin/swiftc
-              -D CMAKE_BUILD_TYPE=Release
-              -D CMAKE_INSTALL_PREFIX=$(install.directory)
-              -D BUILD_X10=YES
-              -D X10_LIBRARY=$(tensorflow.directory)/usr/lib/libx10.dylib
-              -D X10_INCLUDE_DIRS=$(tensorflow.directory)/usr/include
-              -G Ninja
-              -S $(Build.SourcesDirectory)/tensorflow-swift-apis
-
-        - task: CMake@1
-          displayName: Build tensorflow-swift-apis
-          inputs:
-            cmakeArgs: --build $(Build.BinariesDirectory)/tensorflow-swift-apis
-
-        - task: CMake@1
-          displayName: Install tensorflow-swift-apis
-          inputs:
-            cmakeArgs: --build $(Build.BinariesDirectory)/tensorflow-swift-apis --target install
 
       - task: CMake@1
         displayName: Install Foundation

--- a/.ci/templates/sdk-deb.yml
+++ b/.ci/templates/sdk-deb.yml
@@ -58,10 +58,6 @@ jobs:
       - checkout: apple/sourcekit-lsp
         displayName: checkout apple/sourcekit-lsp
 
-      - ${{ if eq(parameters.TENSORFLOW, true) }}:
-        - checkout: tensorflow/swift-apis
-          displayName: checkout tensorflow/swift-apis
-
       - script: |
           mkdir -p $(Build.StagingDirectory)/swift-${{ parameters.platform }}-sdk
           rsync -v -a -l $(Pipeline.Workspace)/sdk-${{ parameters.platform }}-${{ parameters.host }}/Library $(Build.StagingDirectory)/swift-${{ parameters.platform }}-sdk

--- a/.ci/templates/toolchain-deb.yml
+++ b/.ci/templates/toolchain-deb.yml
@@ -57,10 +57,6 @@ jobs:
       - checkout: apple/sourcekit-lsp
         displayName: checkout apple/sourcekit-lsp
 
-      - ${{ if eq(parameters.TENSORFLOW, true) }}:
-        - checkout: tensorflow/swift-apis
-          displayName: checkout tensorflow/swift-apis
-
       - script: |
           mkdir -p $(Build.StagingDirectory)/swift-toolchain
           rsync -v -a -l $(Pipeline.Workspace)/toolchain-linux-${{ parameters.host }}/Library $(Build.StagingDirectory)/swift-toolchain

--- a/.ci/templates/toolchain.yml
+++ b/.ci/templates/toolchain.yml
@@ -7,10 +7,6 @@ parameters:
     type: boolean
     default: false
 
-  - name: TENSORFLOW
-    type: boolean
-    default: false
-
   - name: LLVM_OPTIONS
     type: string
     default: ''
@@ -59,8 +55,6 @@ jobs:
       icu.version: ${{ parameters.ICU_VERSION }}
       icu.directory: $(Pipeline.Workspace)/icu/icu-${{ parameters.platform }}-${{ parameters.host }}/Library/icu-$(icu.version)
 
-      tensorflow.directory: $(Pipeline.Workspace)/tensorflow-${{ parameters.platform }}-${{ parameters.host }}/Library
-
       install.directory: $(Build.StagingDirectory)/toolchain-${{ parameters.platform }}-${{ parameters.host }}/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
 
     workspace:
@@ -103,11 +97,6 @@ jobs:
         artifact: icu-${{ parameters.platform }}-${{ parameters.host }}
         condition: not( eq( variables['Agent.OS'], 'Darwin' ) )
         displayName: download ICU
-
-      - ${{ if eq(parameters.TENSORFLOW, true) }}:
-        - download: tensorflow
-          artifact: tensorflow-${{ parameters.platform }}-${{ parameters.host }}
-          displayName: download TensorFlow
 
       - script: |
           git config --global --add core.autocrlf false
@@ -166,10 +155,6 @@ jobs:
 
       - checkout: apple/sourcekit-lsp
         displayName: checkout apple/sourcekit-lsp
-
-      - ${{ if eq(parameters.TENSORFLOW, true) }}:
-        - checkout: tensorflow/swift-apis
-          displayName: checkout tensorflow/swift-apis
 
       - script: |
           git config --global user.name builder

--- a/.ci/templates/windows-devtools.yml
+++ b/.ci/templates/windows-devtools.yml
@@ -28,9 +28,6 @@ parameters:
   - name: SQLITE_VERSION
     type: string
 
-  - name: TENSORFLOW
-    default: false
-
   - name: USE_PREBUILT_TOOLCHAIN
     default: false
 
@@ -151,10 +148,6 @@ jobs:
 
       - checkout: apple/sourcekit-lsp
         displayName: checkout apple/sourcekit-lsp
-
-      - ${{ if eq(parameters.TENSORFLOW, true) }}:
-        - checkout: tensorflow/swift-apis
-          displayName: checkout tensorflow/swift-apis
 
       - script: |
           git config --global user.name 'builder'

--- a/.ci/templates/windows-sdk.yml
+++ b/.ci/templates/windows-sdk.yml
@@ -3,10 +3,6 @@ parameters:
     type: string
     default: ''
 
-  - name: TENSORFLOW
-    type: boolean
-    default: false
-
   - name: VisualStudio
     type: string
     default: ''
@@ -51,13 +47,11 @@ jobs:
 
       curl.version: development
       icu.version: ${{ parameters.ICU_VERSION }}
-      tensorflow.version: 2.4.0
       xml2.version: development
       zlib.version: 1.2.11
 
       curl.directory: $(Pipeline.Workspace)/curl/curl-${{ parameters.platform }}-${{ parameters.host }}/Library/libcurl-$(curl.version)
       icu.directory: $(Pipeline.Workspace)/icu/icu-${{ parameters.platform }}-${{ parameters.host }}/Library/icu-$(icu.version)
-      tensorflow.directory: $(Pipeline.Workspace)/tensorflow/tensorflow-${{ parameters.platform }}-${{ parameters.host }}/Library/tensorflow-$(tensorflow.version)
       xml2.directory: $(Pipeline.Workspace)/xml2/xml2-${{ parameters.platform }}-${{ parameters.host }}/Library/libxml2-$(xml2.version)
       zlib.directory: $(Pipeline.Workspace)/zlib/zlib-${{ parameters.platform }}-${{ parameters.host }}/Library/zlib-$(zlib.version)
 
@@ -88,11 +82,6 @@ jobs:
       - download: zlib
         artifact: zlib-${{ parameters.platform }}-${{ parameters.host }}
         displayName: download zlib
-
-      - ${{ if eq(parameters.TENSORFLOW, true) }}:
-        - download: tensorflow
-          artifact: tensorflow-${{ parameters.platform }}-${{ parameters.host }}
-          displayName: download TensorFlow
 
       - script: |
           git config --global --add core.autocrlf false
@@ -152,10 +141,6 @@ jobs:
       - checkout: apple/sourcekit-lsp
         displayName: checkout apple/sourcekit-lsp
 
-      - ${{ if eq(parameters.TENSORFLOW, true) }}:
-        - checkout: tensorflow/swift-apis
-          displayName: checkout tensorflow/swift-apis
-
       - script: |
           git config --global user.name 'builder'
           git config --global user.email 'builder@compnerd.org'
@@ -179,25 +164,6 @@ jobs:
           endlocal
           goto :eof
         displayName: Apply Patches
-
-      - ${{ if eq(parameters.TENSORFLOW, true) }}:
-        - script: |
-            call :ApplyPatches "%SWIFT_APIS_PR%" swift-apis
-
-            goto :eof
-
-            :ApplyPatches
-            setlocal
-            set list=%~1
-            set repository=%~2
-            for /F "tokens=1*" %%P in ("%list%") do (
-              git -C %repository% fetch origin pull/%%P/merge
-              git -C %repository% merge FETCH_HEAD
-              if not "%%Q" == "" call :ApplyPatches "%%Q" %repository%
-            )
-            endlocal
-            goto :eof
-          displayName: Apply Patches
 
       - task: BatchScript@1
         inputs:
@@ -396,33 +362,6 @@ jobs:
         inputs:
           versionSpec: ${{ parameters.PythonVersion }}
         continueOnError: true
-
-      - ${{ if eq(parameters.TENSORFLOW, true) }}:
-        - task: CMake@1
-          displayName: Configure tensorflow-swift-apis
-          inputs:
-            cmakeArgs:
-              -B $(Build.BinariesDirectory)/tensorflow-swift-apis
-              -D BUILD_SHARED_LIBS=YES
-              -D BUILD_TESTING=NO
-              -D CMAKE_BUILD_TYPE=Release
-              -D CMAKE_INSTALL_PREFIX=$(install.directory)
-              -D CMAKE_Swift_FLAGS="-sdk $(sdk.directory) -resource-dir $(sdk.directory)/usr/lib/swift -L $(sdk.directory)/usr/lib/swift/${{ parameters.platform }}"
-              -D BUILD_X10=YES
-              -D X10_LIBRARY=$(tensorflow.directory)/usr/lib/x10.lib
-              -D X10_INCLUDE_DIRS=$(tensorflow.directory)/usr/include
-              -G Ninja
-              -S $(Build.SourcesDirectory)/swift-apis
-
-        - task: CMake@1
-          displayName: Build tensorflow-swift-apis
-          inputs:
-            cmakeArgs: --build $(Build.BinariesDirectory)/tensorflow-swift-apis
-
-        - task: CMake@1
-          displayName: Install tensorflow-swift-apis
-          inputs:
-            cmakeArgs: --build $(Build.BinariesDirectory)/tensorflow-swift-apis --target install
 
       - publish: $(Build.StagingDirectory)/sdk-${{ parameters.platform }}-${{ parameters.host }}
         artifact: sdk-${{ parameters.platform }}-${{ parameters.host }}

--- a/.ci/ubuntu-18.04-flowkey.yml
+++ b/.ci/ubuntu-18.04-flowkey.yml
@@ -101,12 +101,6 @@ resources:
       ref: main
       endpoint: GitHub
 
-    - repository: tensorflow/swift-apis
-      type: github
-      name: tensorflow/swift-apis
-      ref: main
-      endpoint: GitHub
-
     - repository: jpsim/Yams
       type: github
       name: jpsim/Yams

--- a/.ci/vs2017-facebook.yml
+++ b/.ci/vs2017-facebook.yml
@@ -95,12 +95,6 @@ resources:
       ref: main
       endpoint: GitHub
 
-    - repository: tensorflow/swift-apis
-      type: github
-      name: tensorflow/swift-apis
-      ref: main
-      endpoint: GitHub
-
     - repository: jpsim/Yams
       type: github
       name: jpsim/Yams

--- a/.ci/vs2017-swift-5.2.yml
+++ b/.ci/vs2017-swift-5.2.yml
@@ -87,12 +87,6 @@ resources:
       ref: swift-5.2-branch
       endpoint: GitHub
 
-    - repository: tensorflow/swift-apis
-      type: github
-      name: tensorflow/swift-apis
-      ref: main
-      endpoint: GitHub
-
 schedules:
   - cron: "0 17 * * *"
     branches:

--- a/.ci/vs2017.yml
+++ b/.ci/vs2017.yml
@@ -90,12 +90,6 @@ resources:
       ref: main
       endpoint: GitHub
 
-    - repository: tensorflow/swift-apis
-      type: github
-      name: tensorflow/swift-apis
-      ref: main
-      endpoint: GitHub
-
     - repository: jpsim/Yams
       type: github
       name: jpsim/Yams

--- a/.ci/vs2019-devtools.yml
+++ b/.ci/vs2019-devtools.yml
@@ -81,12 +81,6 @@ resources:
       ref: main
       endpoint: GitHub
 
-    - repository: tensorflow/swift-apis
-      type: github
-      name: tensorflow/swift-apis
-      ref: main
-      endpoint: GitHub
-
     - repository: jpsim/Yams
       type: github
       name: jpsim/Yams

--- a/.ci/vs2019-facebook.yml
+++ b/.ci/vs2019-facebook.yml
@@ -96,12 +96,6 @@ resources:
       ref: main
       endpoint: GitHub
 
-    - repository: tensorflow/swift-apis
-      type: github
-      name: tensorflow/swift-apis
-      ref: main
-      endpoint: GitHub
-
     - repository: jpsim/Yams
       type: github
       name: jpsim/Yams

--- a/.ci/vs2019-google.yml
+++ b/.ci/vs2019-google.yml
@@ -89,12 +89,6 @@ resources:
       ref: main
       endpoint: GitHub
 
-    - repository: tensorflow/swift-apis
-      type: github
-      name: tensorflow/swift-apis
-      ref: main
-      endpoint: GitHub
-
     - repository: jpsim/Yams
       type: github
       name: jpsim/Yams

--- a/.ci/vs2019-master-next.yml
+++ b/.ci/vs2019-master-next.yml
@@ -76,12 +76,6 @@ resources:
       ref: master
       endpoint: GitHub
 
-    - repository: tensorflow/swift-apis
-      type: github
-      name: tensorflow/swift-apis
-      ref: main
-      endpoint: GitHub
-
     - repository: jpsim/Yams
       type: github
       name: jpsim/Yams

--- a/.ci/vs2019-packaging.yml
+++ b/.ci/vs2019-packaging.yml
@@ -74,12 +74,6 @@ resources:
       ref: main
       endpoint: GitHub
 
-    - repository: tensorflow/swift-apis
-      type: github
-      name: tensorflow/swift-apis
-      ref: main
-      endpoint: GitHub
-
     - repository: jpsim/Yams
       type: github
       name: jpsim/Yams

--- a/.ci/vs2019-swift-5.2.yml
+++ b/.ci/vs2019-swift-5.2.yml
@@ -82,12 +82,6 @@ resources:
       ref: swift-5.2-branch
       endpoint: GitHub
 
-    - repository: tensorflow/swift-apis
-      type: github
-      name: tensorflow/swift-apis
-      ref: main
-      endpoint: GitHub
-
     - repository: jpsim/Yams
       type: github
       name: jpsim/Yams

--- a/.ci/vs2019-swift-5.3.yml
+++ b/.ci/vs2019-swift-5.3.yml
@@ -93,12 +93,6 @@ resources:
       ref: release/5.3
       endpoint: GitHub
 
-    - repository: tensorflow/swift-apis
-      type: github
-      name: tensorflow/swift-apis
-      ref: main
-      endpoint: GitHub
-
     - repository: jpsim/Yams
       type: github
       name: jpsim/Yams

--- a/.ci/vs2019-swift-5.4.yml
+++ b/.ci/vs2019-swift-5.4.yml
@@ -93,12 +93,6 @@ resources:
       ref: main
       endpoint: GitHub
 
-    - repository: tensorflow/swift-apis
-      type: github
-      name: tensorflow/swift-apis
-      ref: main
-      endpoint: GitHub
-
     - repository: jpsim/Yams
       type: github
       name: jpsim/Yams

--- a/.ci/vs2019.yml
+++ b/.ci/vs2019.yml
@@ -90,12 +90,6 @@ resources:
       ref: main
       endpoint: GitHub
 
-    - repository: tensorflow/swift-apis
-      type: github
-      name: tensorflow/swift-apis
-      ref: main
-      endpoint: GitHub
-
     - repository: jpsim/Yams
       type: github
       name: jpsim/Yams

--- a/default.xml
+++ b/default.xml
@@ -41,9 +41,5 @@
   
   <project remote="github" name="ninja-build/ninja" path="ninja" groups="nodefault,dependencies" revision="master" />
 
-  <project remote="github" name="tensorflow/tensorflow" path="tensorflow" groups="notdefault,tensorflow" revision="master" />
-  <project remote="github" name="tensorflow/swift-apis" path="tensorflow-swift-apis" groups="notdefault,tensorflow" revision="master" />
-  <project remote="github" name="tensorflow/swift-models" path="tensorflow-swift-models" groups="notdefault,tensorflow" revision="master" />
-
   <!-- <project remote="github" name="unicode-org/icu" path="icu" revision="maint/maint-66" /> -->
 </manifest>


### PR DESCRIPTION
The swift-apis project is no longer needed as
a) Swift for TensorFlow has been shelved
b) tensorflow/swift-apis can now be built standalone

It would be easy to setup a separate build to build the swift-apis.
Furthermore, the project itself has a GitHub action to build it
pre-commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/353)
<!-- Reviewable:end -->
