### PR TITLE
CI: set default branches for late branched 5.4 projects

### DIFF
--- a/.ci/vs2019-swift-5.4.yml
+++ b/.ci/vs2019-swift-5.4.yml
@@ -72,25 +72,25 @@ resources:
     - repository: apple/swift-tools-support-core
       type: github
       name: apple/swift-tools-support-core
-      ref: main
+      ref: release/5.4
       endpoint: GitHub
 
     - repository: apple/swift-package-manager
       type: github
       name: apple/swift-package-manager
-      ref: main
+      ref: release/5.4
       endpoint: GitHub
 
     - repository: apple/indexstore-db
       type: github
       name: apple/indexstore-db
-      ref: main
+      ref: release/5.4
       endpoint: GitHub
 
     - repository: apple/sourcekit-lsp
       type: github
       name: apple/sourcekit-lsp
-      ref: main
+      ref: release/5.4
       endpoint: GitHub
 
     - repository: jpsim/Yams
@@ -102,7 +102,7 @@ resources:
     - repository: apple/swift-driver
       type: github
       name: apple/swift-driver
-      ref: main
+      ref: release/5.4
       endpoint: GitHub
 
     - repository: apple/swift-argument-parser


### PR DESCRIPTION
Update the default branch points for the late branched projects in the
5.4 release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/354)
<!-- Reviewable:end -->
