### PR TITLE
CI: use older cmake (3.19.7)

### DIFF
--- a/.ci/templates/toolchain.yml
+++ b/.ci/templates/toolchain.yml
@@ -157,6 +157,10 @@ jobs:
         displayName: checkout apple/sourcekit-lsp
 
       - script: |
+          choco install cmake --version=3.19.7 --installargs 'ADD_CMAKE_TO_PATH=User'
+        displayName: Install CMake 3.19.7
+
+      - script: |
           git config --global user.name builder
           git config --global user.email builder@compnerd.org
 

--- a/.ci/templates/windows-devtools.yml
+++ b/.ci/templates/windows-devtools.yml
@@ -150,6 +150,10 @@ jobs:
         displayName: checkout apple/sourcekit-lsp
 
       - script: |
+          choco install cmake --version=3.19.7 --installargs 'ADD_CMAKE_TO_PATH=User'
+        displayName: Install CMake 3.19.7
+
+      - script: |
           git config --global user.name 'builder'
           git config --global user.email 'builder@compnerd.org'
 

--- a/.ci/templates/windows-sdk.yml
+++ b/.ci/templates/windows-sdk.yml
@@ -142,6 +142,10 @@ jobs:
         displayName: checkout apple/sourcekit-lsp
 
       - script: |
+          choco install cmake --version=3.19.7 --installargs 'ADD_CMAKE_TO_PATH=User'
+        displayName: Install CMake 3.19.7
+
+      - script: |
           git config --global user.name 'builder'
           git config --global user.email 'builder@compnerd.org'
 


### PR DESCRIPTION
Current version (3.20) is known to have some issues with Swift pipelines.
3.19.7 is a last version we had before builds gone red.

I suggest to switch back to 3.19 until we have a new CMake release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/355)
<!-- Reviewable:end -->
