### PR TITLE
CI: install cmake on Windows agent only

### DIFF
--- a/.ci/templates/toolchain.yml
+++ b/.ci/templates/toolchain.yml
@@ -158,6 +158,7 @@ jobs:
 
       - script: |
           choco install cmake --version=3.19.7 --installargs 'ADD_CMAKE_TO_PATH=User'
+        condition: eq( variables['Agent.OS'], 'Windows_NT' )
         displayName: Install CMake 3.19.7
 
       - script: |

--- a/.ci/templates/windows-devtools.yml
+++ b/.ci/templates/windows-devtools.yml
@@ -151,6 +151,7 @@ jobs:
 
       - script: |
           choco install cmake --version=3.19.7 --installargs 'ADD_CMAKE_TO_PATH=User'
+        condition: eq( variables['Agent.OS'], 'Windows_NT' )
         displayName: Install CMake 3.19.7
 
       - script: |

--- a/.ci/templates/windows-sdk.yml
+++ b/.ci/templates/windows-sdk.yml
@@ -143,6 +143,7 @@ jobs:
 
       - script: |
           choco install cmake --version=3.19.7 --installargs 'ADD_CMAKE_TO_PATH=User'
+        condition: eq( variables['Agent.OS'], 'Windows_NT' )
         displayName: Install CMake 3.19.7
 
       - script: |


### PR DESCRIPTION
I absolutely forgot about non-Windows agents when did #355. We should skip that step on other systems, like macOS, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/356)
<!-- Reviewable:end -->
