### PR TITLE
CI: install cmake only on hosted agents

### DIFF
--- a/.ci/templates/toolchain.yml
+++ b/.ci/templates/toolchain.yml
@@ -158,7 +158,7 @@ jobs:
 
       - script: |
           choco install cmake --version=3.19.7 --installargs 'ADD_CMAKE_TO_PATH=User'
-        condition: eq( variables['Agent.OS'], 'Windows_NT' )
+        condition: and(eq( variables['Agent.OS'], 'Windows_NT' ), or(eq( variables['Agent.Name'], 'Hosted Agent' ), contains(variables['Agent.Name'], 'Azure Pipelines')))
         displayName: Install CMake 3.19.7
 
       - script: |

--- a/.ci/templates/windows-devtools.yml
+++ b/.ci/templates/windows-devtools.yml
@@ -151,7 +151,7 @@ jobs:
 
       - script: |
           choco install cmake --version=3.19.7 --installargs 'ADD_CMAKE_TO_PATH=User'
-        condition: eq( variables['Agent.OS'], 'Windows_NT' )
+        condition: and(eq( variables['Agent.OS'], 'Windows_NT' ), or(eq( variables['Agent.Name'], 'Hosted Agent' ), contains(variables['Agent.Name'], 'Azure Pipelines')))
         displayName: Install CMake 3.19.7
 
       - script: |

--- a/.ci/templates/windows-sdk.yml
+++ b/.ci/templates/windows-sdk.yml
@@ -143,7 +143,7 @@ jobs:
 
       - script: |
           choco install cmake --version=3.19.7 --installargs 'ADD_CMAKE_TO_PATH=User'
-        condition: eq( variables['Agent.OS'], 'Windows_NT' )
+        condition: and(eq( variables['Agent.OS'], 'Windows_NT' ), or(eq( variables['Agent.Name'], 'Hosted Agent' ), contains(variables['Agent.Name'], 'Azure Pipelines')))
         displayName: Install CMake 3.19.7
 
       - script: |


### PR DESCRIPTION
I am not sure if this is correct way to check for agent type. Can't find any specific variable for such agents, unfortunately. Looks like the only way is to check agent name. Guessing from recent jobs, there are "Hosted Agent" and "Azure Pipelines N" agents.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/compnerd/swift-build/357)
<!-- Reviewable:end -->
