### PR TITLE
packaging: update rules for unified package manifest in SPM

### DIFF
--- a/.ci/templates/devtools-msi.yml
+++ b/.ci/templates/devtools-msi.yml
@@ -56,12 +56,19 @@ jobs:
             solution: $(Build.SourcesDirectory)/wix/windows-devtools.wixproj
             msbuildArguments: /p:RunWixToolsOutOfProc=true -p:OutputPath=$(Build.BinariesDirectory)\devtools-msi\ -p:IntermediateOutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:DEVTOOLS_ROOT=$(devtools.directory) -p:TENSORFLOW=${{ parameters.tensorflow }}
 
-      - ${{ if ne(parameters.VERSION, '5.4') }}:
+      - ${{ if eq(parameters.VERSION, '5.5') }}:
         - task: MSBuild@1
           displayName: ${{ parameters.platform }}-devtools-${{ parameters.proc }}.msi
           inputs:
             solution: $(Build.SourcesDirectory)/wix/windows-devtools.wixproj
             msbuildArguments: /p:RunWixToolsOutOfProc=true -p:OutputPath=$(Build.BinariesDirectory)\devtools-msi\ -p:IntermediateOutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:DEVTOOLS_ROOT=$(devtools.directory) -p:HAVE_SWIFT_CRYPTO=true -p:HAVE_SWIFT_PACKAGE_COLLECTIONS=true -p:TENSORFLOW=${{ parameters.tensorflow }}
+
+      - ${{ if and(ne(parameters.VERSION, '5.4'), ne(parameters.VERSION, '5.5')) }}:
+        - task: MSBuild@1
+          displayName: ${{ parameters.platform }}-devtools-${{ parameters.proc }}.msi
+          inputs:
+            solution: $(Build.SourcesDirectory)/wix/windows-devtools.wixproj
+            msbuildArguments: /p:RunWixToolsOutOfProc=true -p:OutputPath=$(Build.BinariesDirectory)\devtools-msi\ -p:IntermediateOutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:DEVTOOLS_ROOT=$(devtools.directory) -p:HAVE_SWIFT_CRYPTO=true -p:HAVE_SWIFT_PACKAGE_COLLECTIONS=true -p:HAVE_UNIFIED_SPM_MANIFEST=true -p:TENSORFLOW=${{ parameters.tensorflow }}
 
       - script: |
           signtool sign /f $(certificate.secureFilePath) /p $(CERTIFICATE_PASSWORD) /tr http://timestamp.digicert.com /fd sha256 /td sha256 $(Build.BinariesDirectory)/devtools-msi/devtools.msi

--- a/wix/windows-devtools.wixproj
+++ b/wix/windows-devtools.wixproj
@@ -25,12 +25,13 @@
   <PropertyGroup>
     <HAVE_SWIFT_CRYPTO Condition=" '$(HAVE_SWIFT_CRYPTO)' == '' ">false</HAVE_SWIFT_CRYPTO>
     <HAVE_SWIFT_PACKAGE_COLLECTIONS Condition=" '$(HAVE_SWIFT_PACKAGE_COLLECTIONS)' == '' ">false</HAVE_SWIFT_PACKAGE_COLLECTIONS>
+    <HAVE_UNIFIED_SPM_MANIFEST Condition=" '$(HAVE_UNIFIED_SPM_MANIFEST)' == '' ">false</HAVE_UNIFIED_SPM_MANIFEST>
   </PropertyGroup>
 
   <Import Project="$(WixTargetsPath)" />
 
   <PropertyGroup>
-    <DefineConstants>DEVTOOLS_ROOT=$(DEVTOOLS_ROOT);HAVE_SWIFT_CRYPTO=$(HAVE_SWIFT_CRYPTO);HAVE_SWIFT_PACKAGE_COLLECTIONS=$(HAVE_SWIFT_PACKAGE_COLLECTIONS)</DefineConstants>
+    <DefineConstants>DEVTOOLS_ROOT=$(DEVTOOLS_ROOT);HAVE_SWIFT_CRYPTO=$(HAVE_SWIFT_CRYPTO);HAVE_SWIFT_PACKAGE_COLLECTIONS=$(HAVE_SWIFT_PACKAGE_COLLECTIONS);HAVE_UNIFIED_SPM_MANIFEST=$(HAVE_UNIFIED_SPM_MANIFEST)</DefineConstants>
     <HarvestDirectoryAutogenerateGuids>false</HarvestDirectoryAutogenerateGuids>
     <HarvestDirectoryGenerateGuidsNow>true</HarvestDirectoryGenerateGuidsNow>
     <HarvestDirectoryNoLogo>true</HarvestDirectoryNoLogo>

--- a/wix/windows-devtools.wxs
+++ b/wix/windows-devtools.wxs
@@ -46,10 +46,15 @@
                     <!-- FIXME(compnerd) should we include the TSC, SPM import libraries? -->
                     <Directory Id="USR_LIB_SWIFT" Name="swift">
                       <Directory Id="USR_LIB_SWIFT_PM" Name="pm">
+                        <?if $(var.HAVE_UNIFIED_SPM_MANIFEST) = true?>
+                        <Directory Id="USR_LIB_SWIFT_PM_MANIFEST_API" Name="ManifestAPI">
+                        </Directory>
+                        <?else?>
                         <Directory Id="USR_LIB_SWIFT_PM_4" Name="4">
                         </Directory>
                         <Directory Id="USR_LIB_SWIFT_PM_4_2" Name="4_2">
                         </Directory>
+                        <?endif?>
                       </Directory>
                       <!--
                       FIXME(compnerd) should we include the import libraries and swiftmodules for Yams, ArgumentParser?
@@ -251,6 +256,22 @@
       <?endif?>
     </DirectoryRef>
 
+    <?if $(var.HAVE_UNIFIED_SPM_MANIFEST) = true?>
+    <DirectoryRef Id="USR_LIB_SWIFT_PM_MANIFEST_API">
+      <Component Id="MANIFEST_API" Guid="8680a7e7-654d-4980-be93-6d34142846f2">
+        <File Id="MANIFEST_API_PACKAGE_DESCRIPTION_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.dll" Checksum="yes" />
+        <File Id="MANIFEST_API_PACKAGE_DESCRIPTION_LIB" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.lib" Checksum="yes" />
+        <File Id="MANIFEST_API_PACKAGE_DESCRIPTION_SWIFTDOC" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftdoc" Checksum="yes" />
+        <File Id="MANIFEST_API_PACKAGE_DESCRIPTION_SWIFTMODULE" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftmodule" Checksum="yes" />
+      </Component>
+
+      <?ifdef INCLUDE_DEBUG_INFO?>
+      <Component Id="MANIFEST_API_DEBUGINFO" Guid="f4c75c22-bdc9-4cf2-b7d0-cf9ac8a95bef">
+        <File Id="MANIFESAT_API_PACKAGE_DESCRIPTION_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.pdb" Checksum="yes" />
+      </Component>
+      <?endif?>
+    </DirectoryRef>
+    <?else?>
     <DirectoryRef Id="USR_LIB_SWIFT_PM_4">
       <!-- Swift PackageDescription 4 -->
       <Component Id="SWIFT_PD_4" Guid="c827d4fc-2498-402d-8052-aff2ed731d0a">
@@ -282,6 +303,7 @@
       </Component>
       <?endif?>
     </DirectoryRef>
+    <?endif?>
 
     <Feature Id="DEVTOOLS" Level="1">
       <ComponentRef Id="INDEXSTOREDB_BINS" />
@@ -294,8 +316,12 @@
       <ComponentRef Id="SWIFT_DRIVER_BINS" />
       <ComponentRef Id="SWIFT_PACKAGE_MANAGER_BINS" />
       <ComponentRef Id="SWIFT_TOOLS_SUPPORT_CORE_BINS" />
+      <?if $(var.HAVE_UNIFIED_SPM_MANIFEST) = true?>
+      <ComponentRef Id="MANIFEST_API" />
+      <?else?>
       <ComponentRef Id="SWIFT_PD_4" />
       <ComponentRef Id="SWIFT_PD_4_2" />
+      <?endif?>
       <ComponentRef Id="YAMS_BINS" />
     </Feature>
 
@@ -312,8 +338,12 @@
       <ComponentRef Id="SWIFT_DRIVER_DEBUGINFO" />
       <ComponentRef Id="SWIFT_PACKAGE_MANAGER_DEBUGINFO" />
       <ComponentRef Id="SWIFT_TOOLS_SUPPORT_CORE_DEBUGINFO" />
+      <?if $(var.HAVE_UNIFIED_SPM_MANIFEST) = true?>
+      <ComponentRef Id="MANIFEST_API_DEBUGINFO" />
+      <?else?>
       <ComponentRef Id="SWIFT_PD_4_DEBUGINFO" />
       <ComponentRef Id="SWIFT_PD_4_2_DEBUGINFO" />
+      <?endif?>
       <ComponentRef Id="YAMS_DEBUGINFO" />
     </Feature>
     <?endif?>


### PR DESCRIPTION
This updates the devtools packaging to account for the unified module
layout that SPM adopted in apple/swift-package-manager#3464.