### PR TITLE
doc: use correct Windows codename in requirements section

### DIFF
--- a/docs/GettingStartedWindows.md
+++ b/docs/GettingStartedWindows.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Windows 10 RedStone 4 (10.0.17763.0) or newer
+- Windows 10 RedStone 5 (10.0.17763.0) or newer
 
 - Visual Studio 2017 or newer (Visual Studio 2019 recommended)
 


### PR DESCRIPTION
Although the lack of official sources, I believe that 10.0.17763.0 is a RedStone *5*, not 4.
Links:
- [Wikipedia](https://en.wikipedia.org/wiki/Windows_10_version_history_(version_1809))
- [Microsoft Forum](https://answers.microsoft.com/en-us/insider/forum/insider_wintp-insider_install-insiderplat_pc/complete-list-of-redstone-5-insider-builds/248dca70-a41f-4f96-a64f-6ce505fb5e33)