### PR TITLE
Installer: clean up the custom action a bit

### DIFF
--- a/wix/SwiftInstaller/Headers/logging.hh
+++ b/wix/SwiftInstaller/Headers/logging.hh
@@ -53,9 +53,6 @@ log_message &operator<<(log_message &message, const Value_ &value) noexcept {
 extern template
 log_message &operator<<<std::wstring>(log_message &,
                                       const std::wstring &) noexcept;
-
-extern template
-log_message &operator<<<MSIHANDLE>(log_message &, const MSIHANDLE &) noexcept;
 }
 
 #define LOG(Install,Severity)                                                   \

--- a/wix/SwiftInstaller/Headers/swift_installer.hh
+++ b/wix/SwiftInstaller/Headers/swift_installer.hh
@@ -25,9 +25,6 @@ extern "C" {
 #endif
 
 UINT SWIFT_INSTALLER_API
-SwiftInstaller_RecordAuxiliaryFiles(MSIHANDLE hInstall);
-
-UINT SWIFT_INSTALLER_API
 SwiftInstaller_InstallAuxiliaryFiles(MSIHANDLE hInstall);
 
 #if defined(__cplusplus)

--- a/wix/SwiftInstaller/Sources/logging.cc
+++ b/wix/SwiftInstaller/Sources/logging.cc
@@ -69,27 +69,4 @@ log_message &operator<<<std::wstring>(log_message &message,
   message.stream_ << utf8.to_bytes(str.data(), str.data() + str.size());
   return message;
 }
-
-template <>
-log_message &
-operator<<<MSIHANDLE>(log_message &message, const MSIHANDLE &record) noexcept {
-#if WORKING_MSI_ERROR_LOOKUP
-  UINT status;
-  DWORD size = 0;
-
-  status = MsiFormatRecordW(message.install_, record, L"", &size);
-  if (status == ERROR_MORE_DATA) {
-    std::vector<wchar_t> buffer;
-    buffer.resize(++size);
-
-    status = MsiFormatRecordW(message.install_, record, buffer.data(), &size);
-    if (status == ERROR_SUCCESS) {
-      message << std::wstring{buffer.data(), buffer.size()};
-      return message;
-    }
-  }
-#endif
-  message << "[\\{]record conversion failure - " << MsiRecordGetInteger(record, 1) << "[\\}]";
-  return message;
-}
 }

--- a/wix/windows-sdk.wxs
+++ b/wix/windows-sdk.wxs
@@ -457,10 +457,6 @@
     </ComponentGroup>
 
     <DirectoryRef Id="TARGETDIR">
-      <Component Id="AuxiliaryFiles" Guid="cc168d3c-1826-414a-be5f-3b943b3a89ff">
-        <!-- Filled in by the Custom Action -->
-      </Component>
-
       <Component Id="ENV_VARS" Guid="0fe99b48-0366-4790-844f-137029531da7">
         <!-- <Condition> %PROCESSOR_ARCHITECTURE~="amd64" </Condition> -->
         <Environment Id="DEVELOPER_DIR" Action="set" Name="DEVELOPER_DIR" Part="all" Permanent="no" System="yes" Value="[INSTALLDIR]Library\Developer" />
@@ -533,7 +529,6 @@
 
       <ComponentRef Id="WINDOWS_MODULE_MAPS_AND_APINOTES" />
 
-      <ComponentRef Id="AuxiliaryFiles" />
       <ComponentRef Id="ENV_VARS" />
       <ComponentGroupRef Id="PLISTS" />
 
@@ -560,11 +555,6 @@
     <Binary Id="SwiftInstaller.dll"
             SourceFile="$(var.SwiftInstaller.TargetDir)\SwiftInstaller.dll" />
 
-    <CustomAction Id="SwiftInstaller_RecordAuxiliaryFiles"
-                  BinaryKey="SwiftInstaller.dll"
-                  DllEntry="SwiftInstaller_RecordAuxiliaryFiles"
-                  Impersonate="yes" />
-
     <CustomAction Id="SwiftInstaller_InstallAuxiliaryFiles"
                   BinaryKey="SwiftInstaller.dll"
                   DllEntry="SwiftInstaller_InstallAuxiliaryFiles"
@@ -578,14 +568,10 @@
 
     <!-- Hooks -->
     <InstallExecuteSequence>
-      <Custom Action="SwiftInstaller_RecordAuxiliaryFiles" Before="InstallInitialize">
-        NOT REMOVE
-      </Custom>
-
       <Custom Action="SwiftInstaller_InstallAuxiliaryFiles.SetProperty"
               Before="SwiftInstaller_InstallAuxiliaryFiles" />
 
-      <Custom Action="SwiftInstaller_InstallAuxiliaryFiles" After="InstallFiles">
+      <Custom Action="SwiftInstaller_InstallAuxiliaryFiles" After="InstallExecute">
         NOT REMOVE
       </Custom>
     </InstallExecuteSequence>


### PR DESCRIPTION
Remove the now extraneous logic as there is a better understanding of
the scheduling sequence and handling of the cleanup.  The last item that
remains to be resolved is the committing of the alterations to the
database.  We know now that there will be a single action executed
deferred, not impersonated, after InstallExecute to ensure that we can
deploy the auxiliary support files.  The elevate privileges should allow
us to also mutate the on-disk database for the cached MSI to allow
tracking of the deployed files so that we can clean them up on the way
out.  The clever idea of using the `RemoveFile` table allows us to avoid
using a custom action for the removal process.