### PR TITLE
installer: enable the repair option for the bundle

### DIFF
--- a/wix/windows-bundle.wxs
+++ b/wix/windows-bundle.wxs
@@ -18,7 +18,7 @@
         LicenseUrl=""
         LogoFile="$(var.Logo)"
         SuppressOptionsUI="yes"
-        SuppressRepair="yes" />
+        SuppressRepair="no" />
     </BootstrapperApplicationRef>
 
     <Chain>


### PR DESCRIPTION
The repair option is now important for users.  With the ability to
auto-deploy the support files, having the ability to repair will mean
that installation before Visual Studio, or when Visual Studio is
updated, users can simply repair the installation rather than uninstall
and install.