### PR TITLE
CI: repair the SPM build on windows

### DIFF
--- a/.ci/templates/devtools-msi.yml
+++ b/.ci/templates/devtools-msi.yml
@@ -61,7 +61,7 @@ jobs:
           displayName: ${{ parameters.platform }}-devtools-${{ parameters.proc }}.msi
           inputs:
             solution: $(Build.SourcesDirectory)/wix/windows-devtools.wixproj
-            msbuildArguments: /p:RunWixToolsOutOfProc=true -p:OutputPath=$(Build.BinariesDirectory)\devtools-msi\ -p:IntermediateOutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:DEVTOOLS_ROOT=$(devtools.directory) -p:HAVE_SWIFT_CRYPTO=true -p:HAVE_SWIFT_PACKAGE_COLLECTIONS=true -p:HAVE_UNIFIED_SPM_MANIFEST=true -p:TENSORFLOW=${{ parameters.tensorflow }}
+            msbuildArguments: /p:RunWixToolsOutOfProc=true -p:OutputPath=$(Build.BinariesDirectory)\devtools-msi\ -p:IntermediateOutputPath=$(Build.BinariesDirectory)\sdk-msi\ -p:DEVTOOLS_ROOT=$(devtools.directory) -p:HAVE_SWIFT_CRYPTO=true -p:HAVE_SWIFT_COLLECTIONS=true -p:HAVE_SWIFT_PACKAGE_COLLECTIONS=true -p:HAVE_UNIFIED_SPM_MANIFEST=true -p:TENSORFLOW=${{ parameters.tensorflow }}
 
       - script: |
           signtool sign /f $(certificate.secureFilePath) /p $(CERTIFICATE_PASSWORD) /tr http://timestamp.digicert.com /fd sha256 /td sha256 $(Build.BinariesDirectory)/devtools-msi/devtools.msi

--- a/.ci/templates/windows-devtools.yml
+++ b/.ci/templates/windows-devtools.yml
@@ -366,6 +366,7 @@ jobs:
         inputs:
           cmakeArgs:
             -B $(Build.BinariesDirectory)/swift-collections
+            -D CMAKE_Swift_SDK=$(sdk.directory)
             -C $(Build.SourcesDirectory)/swift-build/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}-swift-flags.cmake
             -D BUILD_TESTING=NO
             -D CMAKE_BUILD_TYPE=Release

--- a/.ci/templates/windows-devtools.yml
+++ b/.ci/templates/windows-devtools.yml
@@ -149,6 +149,9 @@ jobs:
       - checkout: apple/sourcekit-lsp
         displayName: checkout apple/sourcekit-lsp
 
+      - checkout: apple/swift-collections
+        displayName: checkout apple/swift-collections
+
       - script: |
           choco install cmake --version=3.19.7 --installargs 'ADD_CMAKE_TO_PATH=User'
         condition: and(eq( variables['Agent.OS'], 'Windows_NT' ), or(eq( variables['Agent.Name'], 'Hosted Agent' ), contains(variables['Agent.Name'], 'Azure Pipelines')))
@@ -165,6 +168,7 @@ jobs:
           call :ApplyPatches "%SWIFTDRIVER_PR%" swift-driver
           call :ApplyPatches "%INDEXSTOREDB_PR%" indexstore-db
           call :ApplyPatches "%SOURCEKITLSP_PR%" sourcekit-lsp
+          call :ApplyPatches "%SWIFTCOLLECTIONS_PR%" swift-collections
 
           goto :eof
 
@@ -358,6 +362,23 @@ jobs:
           cmakeArgs: --build $(Build.BinariesDirectory)/swift-crypto --target install
 
       - task: CMake@1
+        displayName: Configure swift-collections
+        inputs:
+          cmakeArgs:
+            -B $(Build.BinariesDirectory)/swift-collections
+            -C $(Build.SourcesDirectory)/swift-build/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}-swift-flags.cmake
+            -D BUILD_TESTING=NO
+            -D CMAKE_BUILD_TYPE=Release
+            -D CMAKE_INSTALL_PREFIX=$(devtools.toolchain.directory)/usr
+            -G Ninja
+            -S $(Build.SourcesDirectory)/swift-collections
+
+      - task: CMake@1
+        displayName: Build swift-collections
+        inputs:
+          cmakeArgs: --build $(Build.BinariesDirectory)/swift-collections --target install
+
+      - task: CMake@1
         displayName: Configure swift-package-manager
         inputs:
           cmakeArgs:
@@ -373,6 +394,7 @@ jobs:
             -D SwiftDriver_DIR=$(Build.BinariesDirectory)/swift-driver/cmake/modules
             -D ArgumentParser_DIR=$(Build.BinariesDirectory)/swift-argument-parser/cmake/modules
             -D SwiftCrypto_DIR=$(Build.BinariesDirectory)/swift-crypto/cmake/modules
+            -D SwiftCollections_DIR=$(Build.BinariesDirectory)/swift-collections/cmake/modules
             -G Ninja
             -S $(Build.SourcesDirectory)/swift-package-manager
 
@@ -427,6 +449,7 @@ jobs:
             -D SwiftPM_DIR=$(Build.BinariesDirectory)/swift-package-manager/cmake/modules
             -D ArgumentParser_DIR=$(Build.BinariesDirectory)/swift-argument-parser/cmake/modules
             -D IndexStoreDB_DIR=$(Build.BinariesDirectory)/indexstore-db/cmake/modules
+            -D SwiftCollections_DIR=$(Build.BinariesDirectory)/swift-collections/cmake/modules
             -G Ninja
             -S $(Build.SourcesDirectory)/sourcekit-lsp
 

--- a/.ci/vs2019-devtools.yml
+++ b/.ci/vs2019-devtools.yml
@@ -105,6 +105,12 @@ resources:
       ref: main
       endpoint: GitHub
 
+    - repository: apple/swift-collections
+      type: github
+      name: apple/swift-collections
+      ref: main
+      endpoint: GitHub
+
 stages:
 - stage: devtools
   pool: Google

--- a/.ci/vs2019-google.yml
+++ b/.ci/vs2019-google.yml
@@ -113,6 +113,12 @@ resources:
       ref: main
       endpoint: GitHub
 
+    - repository: apple/swift-collections
+      type: github
+      name: apple/swift-collections
+      ref: main
+      endpoint: GitHub
+
 trigger:
   branches:
     include:

--- a/.ci/vs2019-swift-5.4.yml
+++ b/.ci/vs2019-swift-5.4.yml
@@ -117,6 +117,12 @@ resources:
       ref: main
       endpoint: GitHub
 
+    - repository: apple/swift-collections
+      type: github
+      name: apple/swift-collections
+      ref: main
+      endpoint: GitHub
+
 schedules:
   - cron: "0 5 * * *"
     branches:

--- a/.ci/vs2019-swift-5.5.yml
+++ b/.ci/vs2019-swift-5.5.yml
@@ -117,6 +117,12 @@ resources:
       ref: main
       endpoint: GitHub
 
+    - repository: apple/swift-collections
+      type: github
+      name: apple/swift-collections
+      ref: main
+      endpoint: GitHub
+
 schedules:
   - cron: "0 5 * * *"
     branches:

--- a/.ci/vs2019.yml
+++ b/.ci/vs2019.yml
@@ -114,6 +114,12 @@ resources:
       ref: main
       endpoint: GitHub
 
+    - repository: apple/swift-collections
+      type: github
+      name: apple/swift-collections
+      ref: main
+      endpoint: GitHub
+
 schedules:
   - cron: "0 0 * * *"
     branches:

--- a/wix/windows-devtools.wxs
+++ b/wix/windows-devtools.wxs
@@ -148,15 +148,32 @@
 
       <!-- swift-crypto -->
       <?if $(var.HAVE_SWIFT_CRYPTO) = true ?>
-        <Component Id="SWIFT_CRYPTO_BINS" Guid="aab41adf-d876-4fa5-9d3e-c9c197e09331">
-          <File Id="CRYPTO_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.dll" Checksum="yes" />
-        </Component>
+      <Component Id="SWIFT_CRYPTO_BINS" Guid="aab41adf-d876-4fa5-9d3e-c9c197e09331">
+        <File Id="CRYPTO_DLL" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.dll" Checksum="yes" />
+      </Component>
 
-        <?ifdef INCLUDE_DEBUG_INFO ?>
-        <Component Id="SWIFT_CRYPTO_DEBUGINFO" Guid="4cbda17f-a85b-4620-bdd4-18b03ba07499">
-          <File Id="CRYPTO_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.pdb" Checksum="yes" />
-        </Component>
-        <?endif?>
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Component Id="SWIFT_CRYPTO_DEBUGINFO" Guid="4cbda17f-a85b-4620-bdd4-18b03ba07499">
+        <File Id="CRYPTO_PDB" Source="$(var.DEVTOOLS_ROOT)\usr\bin\Crypto.pdb" Checksum="yes" />
+      </Component>
+      <?endif?>
+      <?endif?>
+
+      <!-- swift-collections -->
+      <?ifdef $(var.HAVE_SWIFT_COLLECTIONS) = true ?>
+      <Component Id="SWIFT_COLLECTIONS_BINS" Guid="522f00f6-aa89-421e-a89b-5c91d75793af">
+        <File Id="COLLECTIONS_DLL" Source="$(var.SWIFT_COLLECTIONS_ROOT)\usr\bin\Collections.dll" Checksum="yes" />
+        <File Id="DEQUE_MODULE_DLL" Source="$(var.SWIFT_COLLECTIONS_ROOT)\usr\bin\DequeModule.dll" Checksum="yes" />
+        <File Id="ORDERED_COLLECTIONS_DLL" Source="$(var.SWIFT_COLLECTIONS_ROOT)\usr\bin\OrderedCollections.dll" Checksum="yes" />
+      </Component>
+
+      <?ifdef INCLUDE_DEBUG_INFO ?>
+      <Component Id="SWIFT_COLLECTIONS_DEBUGINFO" Guid="59abe3a6-dfa0-43dc-ba8c-2e2d1119cd44">
+        <File Id="COLLECTIONS_PDB" Source="$(var.SWIFT_COLLECTIONS_ROOT)\usr\bin\Collections.pdb" Checksum="yes" />
+        <File Id="DEQUE_MODULE_PDB" Source="$(var.SWIFT_COLLECTIONS_ROOT)\usr\bin\DequeModule.pdb" Checksum="yes" />
+        <File Id="ORDERED_COLLECTIONS_PDB" Source="$(var.SWIFT_COLLECTIONS_ROOT)\usr\bin\OrderedCollections.pdb" Checksum="yes" />
+      </Component>
+      <?endif?>
       <?endif?>
 
       <!-- swift-driver -->
@@ -313,6 +330,9 @@
       <?if $(var.HAVE_SWIFT_CRYPTO) = true ?>
       <ComponentRef Id="SWIFT_CRYPTO_BINS" />
       <?endif?>
+      <?if $(var.HAVE_SWIFT_COLLECTIONS) = true ?>
+      <ComponentRef Id="SWIFT_COLLECTIONS_BINS" />
+      <?endif?>
       <ComponentRef Id="SWIFT_DRIVER_BINS" />
       <ComponentRef Id="SWIFT_PACKAGE_MANAGER_BINS" />
       <ComponentRef Id="SWIFT_TOOLS_SUPPORT_CORE_BINS" />
@@ -334,6 +354,9 @@
       <ComponentRef Id="SWIFT_ARGUMENT_PARSER_DEBUGINFO" />
       <?if $(var.HAVE_SWIFT_CRYPTO) = true ?>
       <ComponentRef Id="SWIFT_CRYPTO_DEBUGINFO" />
+      <?endif?>
+      <?if $(var.HAVE_SWIFT_COLLECTIONS) = true ?>
+      <ComponentRef Id="SWIFT_COLLECTIONS_DEBUGINFO" />
       <?endif?>
       <ComponentRef Id="SWIFT_DRIVER_DEBUGINFO" />
       <ComponentRef Id="SWIFT_PACKAGE_MANAGER_DEBUGINFO" />


### PR DESCRIPTION
SPM has grown a dependency on swift-collections, add swift-collections to the
set of packages we build.