### PR TITLE
Make compiler runtimes step compatible with latest CMake (3.21)

### DIFF
--- a/.ci/templates/toolchain.yml
+++ b/.ci/templates/toolchain.yml
@@ -157,9 +157,9 @@ jobs:
         displayName: checkout apple/sourcekit-lsp
 
       - script: |
-          choco install cmake --version=3.19.7 --installargs 'ADD_CMAKE_TO_PATH=User'
+          choco install cmake --version=3.21.3 --installargs 'ADD_CMAKE_TO_PATH=User'
         condition: and(eq( variables['Agent.OS'], 'Windows_NT' ), or(eq( variables['Agent.Name'], 'Hosted Agent' ), contains(variables['Agent.Name'], 'Azure Pipelines')))
-        displayName: Install CMake 3.19.7
+        displayName: Install CMake 3.21.3
 
       - script: |
           git config --global user.name builder

--- a/cmake/caches/toolchain-5.4.cmake
+++ b/cmake/caches/toolchain-5.4.cmake
@@ -1,0 +1,4 @@
+# Set CMAKE_MT for runtimes. Required for CMake 3.20+. As CMake external project, 
+# runtimes doesn't derive CMAKE_MT from toochain caches. We have to pass it 
+# explicitly as additional argument.
+set(RUNTIMES_CMAKE_ARGS "-DCMAKE_MT=mt" CACHE STRING "")

--- a/cmake/caches/toolchain-5.5.cmake
+++ b/cmake/caches/toolchain-5.5.cmake
@@ -1,1 +1,6 @@
 set(SWIFT_BUILD_ENABLE_PARSER_LIB TRUE CACHE BOOL "" FORCE)
+
+# Set CMAKE_MT for runtimes. Required for CMake 3.20+. As CMake external project, 
+# runtimes doesn't derive CMAKE_MT from toochain caches. We have to pass it 
+# explicitly as additional argument.
+set(RUNTIMES_CMAKE_ARGS "-DCMAKE_MT=mt" CACHE STRING "")

--- a/cmake/caches/toolchain-master.cmake
+++ b/cmake/caches/toolchain-master.cmake
@@ -1,1 +1,6 @@
 set(SWIFT_BUILD_ENABLE_PARSER_LIB TRUE CACHE BOOL "" FORCE)
+
+# Set CMAKE_MT for runtimes. Required for CMake 3.20+. As CMake external project, 
+# runtimes doesn't derive CMAKE_MT from toochain caches. We have to pass it 
+# explicitly as additional argument.
+set(RUNTIMES_CMAKE_ARGS "-DCMAKE_MT=mt" CACHE STRING "")


### PR DESCRIPTION
CMake 3.20+ fails to configure compiler runtimes because of issues with a manifest tool: older versions use `mt.exe` from VS toolset by default, but since 3.20 it resolves `CMAKE_MT` to `llvm-mt` from just built toolchain. I suspect it is introduced in [this commit](https://github.com/Kitware/CMake/commit/b12aec6c8daa3e087e6d0fa0441f59622251eb46), and now is expected behavior for MT resolution.

On top of that, the runtimes target doesn't derive CMAKE_MT from llvm configuration. Fortunately, we have an option to pass additional CMake arguments right to the runtimes target.

Unfortunately, we can't just disable CMake 3.19 download step, because the latest Visual Studio (16.11.3 at the moment) still ships with CMake 3.20, which has another annoying bug with processing compiler user flag. As an option, I suggest downloading and installing CMake 3.21 instead. When VS CMake gets an update, I will check it and do a follow-up PR to clean up this completely.
