### PR TITLE
Use older CMake for 5.4 and newer CMake for other branches

### DIFF
--- a/.ci/templates/toolchain.yml
+++ b/.ci/templates/toolchain.yml
@@ -158,8 +158,13 @@ jobs:
 
       - script: |
           choco install cmake --version=3.21.3 --installargs 'ADD_CMAKE_TO_PATH=User'
-        condition: and(eq( variables['Agent.OS'], 'Windows_NT' ), or(eq( variables['Agent.Name'], 'Hosted Agent' ), contains(variables['Agent.Name'], 'Azure Pipelines')))
+        condition: and(ne(parameters.VERSION, '5.4'), and(eq( variables['Agent.OS'], 'Windows_NT' ), or(eq( variables['Agent.Name'], 'Hosted Agent' ), contains(variables['Agent.Name'], 'Azure Pipelines'))))
         displayName: Install CMake 3.21.3
+
+      - script: |
+          choco install cmake --version=3.19.8 --installargs 'ADD_CMAKE_TO_PATH=User'
+        condition: and(eq(parameters.VERSION, '5.4'), and(eq( variables['Agent.OS'], 'Windows_NT' ), or(eq( variables['Agent.Name'], 'Hosted Agent' ), contains(variables['Agent.Name'], 'Azure Pipelines'))))
+        displayName: Install CMake 3.19.8
 
       - script: |
           git config --global user.name builder


### PR DESCRIPTION
Hope I didn't mess with parentheses. Let's try 3.19.8 for 5.4, and 3.21.3 for others.