### PR TITLE
Update swift-toolchain.yml

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -239,7 +239,6 @@ jobs:
           if ( "${{ matrix.arch }}" -eq "arm64" ) {
             $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
             $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=ARM64"
-            $LLDB_PYTHON_RELATIVE_PATH="-D LLDB_PYTHON_RELATIVE_PATH=lib/site-packages"
             $CACHE="Windows-arm64.cmake"
 
             # FIXME(compnerd) re-enable python after we have nuget wired up for Python
@@ -278,7 +277,7 @@ jobs:
                 -D SWIFT_VENDOR=compnerd.org `
                 -D LLVM_APPEND_VC_REV=NO `
                 -D LLVM_VERSION_SUFFIX="" `
-                ${LLDB_PYTHON_RELATIVE_PATH} `
+                -D LLDB_PYTHON_RELATIVE_PATH=lib/site-packages `
                 -D SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=YES `
                 -D SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED=YES `
                 -D SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING=YES `


### PR DESCRIPTION
inline `LLDB_PYTHON_RELATIVE_PATH` to reduce divergence between targets.  This value is identical across the platforms.