### PR TITLE
CI: extend the swift toolchain build

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -46,13 +46,15 @@ on:
         default: 'refs/heads/main'
 
 jobs:
+  # TODO(compnerd) use environment variables for package version information and wire that throughout
+
   icu:
     runs-on: windows-latest
 
     strategy:
       fail-fast: false
       matrix:
-        arch: ['amd64', 'arm64']
+        arch: ['amd64', 'arm64', 'x86']
 
     steps:
       - uses: actions/checkout@v2
@@ -335,7 +337,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ['amd64', 'arm64']
+        arch: ['amd64', 'arm64', 'x86']
 
     steps:
       - uses: actions/checkout@v2
@@ -381,7 +383,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ['amd64', 'arm64']
+        arch: ['amd64', 'arm64', 'x86']
 
     steps:
       - uses: actions/checkout@v2
@@ -454,7 +456,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ['amd64', 'arm64']
+        arch: ['amd64', 'arm64', 'x86']
 
     steps:
       - uses: actions/checkout@v2
@@ -498,3 +500,278 @@ jobs:
         with:
           name: libxml2-${{ matrix.arch }}-2.9.12
           path: ${{ github.workspace }}/BuildRoot/Library/libxml2-2.9.12/usr
+
+  sdk:
+    runs-on: windows-latest
+    needs: [icu, libxml2, curl, zlib, toolchain]
+
+    # TODO(compnerd) use dictionaries to track triples for architecture and wire that in rather than powershell scripting
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['amd64'] # , 'x86']
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: icu-${{ matrix.arch }}-69.1
+          path: ${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: libxml2-${{ matrix.arch }}-2.9.12
+          path: ${{ github.workspace }}/BuildRoot/Library/libxml2-2.9.12/usr
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: curl-${{ matrix.arch }}-7.77.0
+          path: ${{ github.workspace }}/BuildRoot/Library/curl-7.77.0/usr
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: zlib-${{ matrix.arch }}-1.2.11
+          path: ${{ github.workspace }}/BuildRoot/Library/zlib-1.2.11/usr
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: toolchain-amd64
+          path: ${{ github.workspace }}/BuildRoot/Library
+
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/llvm-project
+          ref: ${{ github.event.inputs.llvm_revision }}
+          path: ${{ github.workspace }}/SourceCache/llvm-project
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/swift
+          ref: ${{ github.event.inputs.swift_tag }}
+          path: ${{ github.workspace }}/SourceCache/swift
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/swift-corelibs-libdispatch
+          ref: ${{ github.event.inputs.swift_tag }}
+          path: ${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/swift-corelibs-foundation
+          ref: ${{ github.event.inputs.swift_tag }}
+          path: ${{ github.workspace }}/SourceCache/swift-corelibs-foundation
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/swift-corelibs-xctest
+          ref: ${{ github.event.inputs.swift_tag }}
+          path: ${{ github.workspace }}/SourceCache/swift-corelibs-xctest
+
+      - uses: seanmiddleditch/gha-setup-vsdevenv@v4
+        with:
+          host_arch: amd64
+          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+          arch: ${{ matrix.arch }}
+
+      - name: 'Copy Support Files'
+        run: |
+          Copy-Item "${{ github.workspace }}\SourceCache\swift\stdlib\public\Platform\ucrt.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\ucrt\module.modulemap"
+          Copy-Item "${{ github.workspace }}\SourceCache\swift\stdlib\public\Platform\visualc.modulemap" -destination "$env:VCToolsInstallDir\include\module.modulemap"
+          Copy-Item "${{ github.workspace }}\SourceCache\swift\stdlib\public\Platform\visualc.apinotes" -destination "$env:VCToolsInstallDir\include\visualc.apinotes"
+          Copy-Item "${{ github.workspace }}\SourceCache\swift\stdlib\public\Platform\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
+
+      - name: Configure LLVM
+        run:
+          cmake -B ${{ github.workspace }}/BinaryCache/llvm `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=cl `
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_CXX_COMPILER=cl `
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/llvm-project/llvm `
+                -D LLVM_ENABLE_ASSERTIONS=YES
+
+      - name: Configure Swift Standard Library
+        run: |
+          if ( "${{ matrix.arch }}" -eq "x86" ) {
+            $CACHE="Runtime-Windows-i686.cmake"
+            $CMAKE_Swift_COMPILER_TARGET="i686-unknown-windows-msvc"
+            $MSVC_C_ARCHITECTURE_ID="-D MSVC_C_ARCHITECTURE_ID=x86"
+            $MSVC_CXX_ARCHITECTURE_ID="-D MSVC_CXX_ARCHITECTURE_ID=x86"
+          } else {
+            $CACHE="Runtime-Windows-x86_64.cmake"
+            $CMAKE_Swift_COMPILER_TARGET="x86_64-unknown-windows-msvc"
+          }
+          # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+          cmake -B ${{ github.workspace }}/BinaryCache/swift `
+                -C ${{ github.workspace }}/SourceCache/swift/cmake/caches/${CACHE} `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${CLANG_CL} `
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_CXX_COMPILER=${CLANG_CL} `
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr `
+                ${MSVC_C_ARCHITECTURE_ID} `
+                ${MSVC_CXX_ARCHITECTURE_ID} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift `
+                -D CMAKE_Swift_COMPILER_TARGET=${CMAKE_Swift_COMPILER_TARGET} `
+                -D LLVM_DIR=${{ github.workspace }}/BinaryCache/llvm/lib/cmake/llvm `
+                -D SWIFT_NATIVE_SWIFT_TOOLS_PATH=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin `
+                -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE=${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch `
+                -D SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=YES `
+                -D SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED=YES `
+                -D SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING=YES `
+                -D SWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/include/unicode `
+                -D SWIFT_WINDOWS_aarch64_ICU_UC=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuuc69.lib `
+                -D SWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/include `
+                -D SWIFT_WINDOWS_aarch64_ICU_I18N=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuin69.lib `
+                -D SWIFT_WINDOWS_i686_ICU_UC_INCLUDE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/include/unicode `
+                -D SWIFT_WINDOWS_i686_ICU_UC=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuuc69.lib `
+                -D SWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/include `
+                -D SWIFT_WINDOWS_i686_ICU_I18N=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuin69.lib `
+                -D SWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/include/unicode `
+                -D SWIFT_WINDOWS_x86_64_ICU_UC=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuuc69.lib `
+                -D SWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/include `
+                -D SWIFT_WINDOWS_x86_64_ICU_I18N=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuin69.lib
+      - name: Build Swift Standard Library
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift
+      - name: Install Swift Standard Library
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift --target install
+
+
+      - name: Configure libdispstch
+        run: |
+          # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+          if ( "${{ matrix.arch }}" -eq "x86" ) {
+            $COMPILER_TARGET="i686-unknown-windows-msvc"
+
+            $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
+            $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=x86"
+            $MSVC_C_ARCHITECTURE_ID="-D MSVC_C_ARCHITECTURE_ID=x86"
+          } else {
+            $COMPILER_TARGET="x86_64-unknown-windows-msvc"
+          }
+          cmake -B ${{ github.workspace }}/BinaryCache/libdispatch `
+                -D BUILD_SHARED_LIBS=YES `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${CLANG_CL} `
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_CXX_COMPILER=${CLANG_CL} `
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr `
+                -D CMAKE_SWIFT_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows" `
+                ${CMAKE_SYSTEM_NAME} `
+                ${CMAKE_SYSTEM_PROCESSOR} `
+                ${MSVC_C_ARCHITECTURE_ID} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch `
+                -D CMAKE_C_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_CXX_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_Swift_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D BUILD_TESTING=NO `
+                -D ENABLE_SWIFT=YES
+      - name: Build libdispatch
+        run: cmake --build ${{ github.workspace }}/BinaryCache/libdispatch
+
+      - name: Configure Foundation
+        run: |
+          # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+          if ( "${{ matrix.arch }}" -eq "x86" ) {
+            $COMPILER_TARGET="i686-unknown-windows-msvc"
+
+            $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
+            $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=x86"
+            $MSVC_C_ARCHITECTURE_ID="-D MSVC_C_ARCHITECTURE_ID=x86"
+          } else {
+            $COMPILER_TARGET="x86_64-unknown-windows-msvc"
+          }
+          cmake -B ${{ github.workspace }}/BinaryCache/foundation `
+                -D BUILD_SHARED_LIBS=YES `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${CLANG_CL} `
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_CXX_COMPILER=${CLANG_CL} `
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows" `
+                ${CMAKE_SYSTEM_NAME} `
+                ${CMAKE_SYSTEM_PROCESSOR} `
+                ${MSVC_C_ARCHITECTURE_ID} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-corelibs-foundation `
+                -D CMAKE_C_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_CXX_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_Swift_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D ENABLE_TESTING=NO `
+                -D dispatch_DIR=${{ github.workspace }}/BinaryCache/libdispatch/cmake/modules `
+                -D ICU_ROOT=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr `
+                -D ICU_UC_LIBRARY_RELEASE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuuc69.lib `
+                -D ICU_I18N_LIBRARY_RELEASE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuin69.lib `
+                -D LIBXML2_LIBRARY=${{ github.workspace }}/BuildRoot/Library/libxml2-2.9.12/usr/lib/libxml2s.lib `
+                -D LIBXML2_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/libxml2-2.9.12/usr/include/libxml2 `
+                -D LIBXML2_DEFINITIONS="/DLIBXML_STATIC" `
+                -D CURL_DIR=${{ github.workspace }}/BuildRoot/Library/curl-7.77.0/usr/lib/cmake/CURL `
+                -D ZLIB_ROOT=${{ github.workspace }}/BuildRoot/Library/zlib-1.2.11/usr `
+                -D ZLIB_LIBRARY=${{ github.workspace }}/BuildRoot/Library/zlib-1.2.11/usr/lib/zlibstatic.lib
+      - name: Build foundation
+        run: cmake --build ${{ github.workspace }}/BinaryCache/foundation
+
+      # TODO(compnerd) correctly version XCTest
+      - name: Configure xctest
+        run: |
+          # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+          if ( "${{ matrix.arch }}" -eq "x86" ) {
+            $COMPILER_TARGET="i686-unknown-windows-msvc"
+
+            $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
+            $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=x86"
+          } else {
+            $COMPILER_TARGET="x86_64-unknown-windows-msvc"
+          }
+          cmake -B ${{ github.workspace }}/BinaryCache/xctest `
+                -D BUILD_SHARED_LIBS=YES `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${CLANG_CL} `
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_CXX_COMPILER=${CLANG_CL} `
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/Library/XCTest-development/usr `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows" `
+                ${CMAKE_SYSTEM_NAME} `
+                ${CMAKE_SYSTEM_PROCESSOR} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-corelibs-xctest `
+                -D CMAKE_C_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_CXX_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_Swift_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D ENABLE_TESTING=NO `
+                -D dispatch_DIR=${{ github.workspace }}/BinaryCache/libdispatch/cmake/modules `
+                -D Foundation_DIR=${{ github.workspace }}/BinaryCache/foundation/cmake/modules
+      - name: Build xctest
+        run: cmake --build ${{ github.workspace }}/BinaryCache/xctest
+
+      - name: Install libdispatch
+        run: cmake --build ${{ github.workspace }}/BinaryCache/libdispatch --target install
+      - name: Install foundation
+        run: cmake --build ${{ github.workspace }}/BinaryCache/foundation --target install
+      - name: Install xctest
+        run: cmake --build ${{ github.workspace }}/BinaryCache/xctest --target install
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: windows-sdk-${{ matrix.arch }}
+          path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform


### PR DESCRIPTION
The next phase of the build is the SDK (stdlib, libdispatch, Foundation,
XCTest).  This should allow building x86 and x86_64 SDKs.