### PR TITLE
ICU: tweak ICU data packaging rules for multi-arch

### DIFF
--- a/.ci/vs2022.yml
+++ b/.ci/vs2022.yml
@@ -330,7 +330,7 @@ stages:
           matrix:
             'x86':
               arch: x86
-              BUILD_TOOLS: NO
+              BUILD_TOOLS: YES
             'x64':
               arch: amd64
               BUILD_TOOLS: YES
@@ -360,8 +360,51 @@ stages:
           - task: BatchScript@1
             inputs:
               filename: $(VsDevCmd)
+              arguments: -no_logo -arch=amd64 -host_arch=amd64
+              modifyEnvironment: true
+            condition: eq(variables['BUILD_TOOLS'], 'NO')
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                -B $(Agent.BuildDirectory)/icu-69.1-build
+                -D BUILD_SHARED_LIBS=NO
+                -D BUILD_TOOLS=YES
+                -D CMAKE_BUILD_TYPE=Release
+                -D CMAKE_C_COMPILER=cl
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
+                -D CMAKE_CXX_COMPILER=cl
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
+                -D CMAKE_MT=mt
+                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/icu-69.1/usr
+                -G Ninja
+                -S $(Build.SourcesDirectory)/icu/icu4c
+            condition: eq(variables['BUILD_TOOLS'], 'NO')
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                --build $(Agent.BuildDirectory)/icu-69.1-build
+            condition: eq(variables['BUILD_TOOLS'], 'NO')
+          - task: BatchScript@1
+            inputs:
+              filename: $(VsDevCmd)
               arguments: -no_logo -arch=$(arch) -host_arch=amd64
               modifyEnvironment: true
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                -B $(Agent.BuildDirectory)/icu-69.1
+                -D BUILD_SHARED_LIBS=YES
+                -D ICU_TOOLS_DIR=$(Agent.BuildDirectory)/icu-69.1-build
+                -D CMAKE_BUILD_TYPE=Release
+                -D CMAKE_C_COMPILER=cl
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
+                -D CMAKE_CXX_COMPILER=cl
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
+                -D CMAKE_MT=mt
+                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/icu-69.1/usr
+                -G Ninja
+                -S $(Build.SourcesDirectory)/icu/icu4c
+            condition: eq(variables['BUILD_TOOLS'], 'NO')
           - task: CMake@1
             inputs:
               cmakeArgs:
@@ -377,6 +420,7 @@ stages:
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/icu-69.1/usr
                 -G Ninja
                 -S $(Build.SourcesDirectory)/icu/icu4c
+            condition: eq(variables['BUILD_TOOLS'], 'YES')
           - task: CMake@1
             inputs:
               cmakeArgs:

--- a/cmake/ICU/CMakeLists69.txt
+++ b/cmake/ICU/CMakeLists69.txt
@@ -7,15 +7,14 @@ project(ICU LANGUAGES C CXX VERSION 69.1)
 
 option(BUILD_SHARED_LIBS "build shared libaries" YES)
 option(BUILD_TOOLS "build tools" NO)
+option(ICU_TOOLS_DIR "Path to prebuilt tools" "")
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 include(GNUInstallDirs)
 
-if(BUILD_TOOLS)
-  find_package(Python3 COMPONENTS Interpreter REQUIRED)
-endif()
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 if(NOT BUILD_SHARED_LIBS)
   add_compile_definitions(U_STATIC_IMPLEMENTATION)
@@ -633,71 +632,111 @@ if(BUILD_TOOLS)
   target_link_libraries(pkgdata PRIVATE
     icuuc icutu)
 
-  include(TestBigEndian)
-  test_big_endian(IS_BIG_ENDIAN_HOST)
+  set(ICU_TOOLS_DIR ${CMAKE_CURRENT_BINARY_DIR})
+elseif(ICU_TOOLS_DIR)
+  foreach(tool gencnval;gencfu;makeconv;genbrk;gensprep;gendict;icupkg;genrb;pkgdata)
+    add_executable(${tool} IMPORTED)
+    set_target_properties(${tool} PROPERTIES
+      IMPORTED_LOCATION ${ICU_TOOLS_DIR}/${tool}${CMAKE_EXECUTABLE_SUFFIX})
+  endforeach()
+else()
+  include(ExternalProject)
+  ExternalProject_Add(Tools
+    SOURCE_DIR ${PROJECT_SOURCE_DIR}
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/Tools
+    CMAKE_ARGS
+      -DBUILD_TOOLS=YES
+      -DCMAKE_BUILD_TYPE:STRING=Release
+      -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
+      -DCMAKE_SYSTEM_NAME:STRING=${CMAKE_HOST_SYSTEM_NAME}
+      -DCMAKE_SYSTEM_PROCESSOR:STRING=${CMAKE_HOST_SYSTEM_PROCESSOR}
+    BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR>
+    INSTALL_COMMAND ""
+    BUILD_BYPRODUCTS
+      <BINARY_DIR>/gencnval${CMAKE_EXECUTABLE_SUFFIX}
+      <BINARY_DIR>/gencfu${CMAKE_EXECUTABLE_SUFFIX}
+      <BINARY_DIR>/makeconv${CMAKE_EXECUTABLE_SUFFIX}
+      <BINARY_DIR>/genbrk${CMAKE_EXECUTABLE_SUFFIX}
+      <BINARY_DIR>/gensprep${CMAKE_EXECUTABLE_SUFFIX}
+      <BINARY_DIR>/gendict${CMAKE_EXECUTABLE_SUFFIX}
+      <BINARY_DIR>/icupkg${CMAKE_EXECUTABLE_SUFFIX}
+      <BINARY_DIR>/genrb${CMAKE_EXECUTABLE_SUFFIX}
+      <BINARY_DIR>/pkgdata${CMAKE_EXECUTABLE_SUFFIX})
+    ExternalProject_Get_Property(Tools BINARY_DIR)
 
-  set(U_ICUDATA_NAME icudt${PROJECT_VERSION_MAJOR})
-  if(IS_BIG_ENDIAN_HOST)
-    set(U_ICUDATA_PKGN icudt${PROJECT_VERSION_MAJOR}b)
+    foreach(tool gencnval;gencfu;makeconv;genbrk;gensprep;gendict;icupkg;genrb;pkgdata)
+      add_executable(${tool} IMPORTED)
+      set_target_properties(${tool} PROPERTIES
+        IMPORTED_LOCATION ${BINARY_DIR}/${tool}${CMAKE_EXECUTABLE_SUFFIX})
+    endforeach()
+
+    set(ICU_TOOLS_DIR ${BINARY_DIR})
+endif()
+
+include(TestBigEndian)
+test_big_endian(IS_BIG_ENDIAN_HOST)
+
+set(U_ICUDATA_NAME icudt${PROJECT_VERSION_MAJOR})
+if(IS_BIG_ENDIAN_HOST)
+  set(U_ICUDATA_PKGN icudt${PROJECT_VERSION_MAJOR}b)
+else()
+  set(U_ICUDATA_PKGN icudt${PROJECT_VERSION_MAJOR}l)
+endif()
+
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/icudata.lst
+  COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${PROJECT_SOURCE_DIR}/source/python
+    ${Python3_EXECUTABLE} -B -m icutools.databuilder
+    --mode $<IF:$<STREQUAL:${CMAKE_HOST_SYSTEM_NAME},Windows>,windows-exec,unix-exec>
+    --src_dir ${PROJECT_SOURCE_DIR}/source/data
+    --tool_dir ${ICU_TOOLS_DIR}
+    # NOTE(compnerd) setting the configuration allows us to move back into the
+    # binary directory as we emit all the tools into the binary directory.
+    --tool_cfg ..
+    --out_dir ${CMAKE_CURRENT_BINARY_DIR}/data/${U_ICUDATA_PKGN}
+    --tmp_dir ${CMAKE_CURRENT_BINARY_DIR}/data/tmp
+  DEPENDS gencnval gencfu makeconv genbrk gensprep gendict icupkg genrb
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/source/data)
+
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  if(BUILD_SHARED_LIBS)
+    set(_U_ICUDATA_LIB ${CMAKE_CURRENT_BINARY_DIR}/data/${U_ICUDATA_PKGN}/${CMAKE_SHARED_LIBRARY_PREFIX}${U_ICUDATA_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})
   else()
-    set(U_ICUDATA_PKGN icudt${PROJECT_VERSION_MAJOR}l)
+    set(_U_ICUDATA_LIB ${CMAKE_CURRENT_BINARY_DIR}/data/${U_ICUDATA_PKGN}/${CMAKE_STATIC_LIBRARY_PREFIX}${U_ICUDATA_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
   endif()
 
-  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/icudata.lst
-    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${PROJECT_SOURCE_DIR}/source/python
-      ${Python3_EXECUTABLE} -B -m icutools.databuilder
-      --mode $<IF:$<STREQUAL:${CMAKE_HOST_SYSTEM_NAME},Windows>,windows-exec,unix-exec>
-      --src_dir ${PROJECT_SOURCE_DIR}/source/data
-      --tool_dir ${CMAKE_CURRENT_BINARY_DIR}
-      # NOTE(compnerd) setting the configuration allows us to move back into the
-      # binary directory as we emit all the tools into the binary directory.
-      --tool_cfg ..
-      --out_dir ${CMAKE_CURRENT_BINARY_DIR}/data/${U_ICUDATA_PKGN}
-      --tmp_dir ${CMAKE_CURRENT_BINARY_DIR}/data/tmp
-    DEPENDS gencnval gencfu makeconv genbrk gensprep gendict icupkg genrb
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/source/data)
+  add_custom_command(OUTPUT ${_U_ICUDATA_LIB}
+    COMMAND $<TARGET_FILE:pkgdata> -a ${MSVC_C_ARCHITECTURE_ID} -f -e ${U_ICUDATA_NAME} -v -m $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,dll,static> -c -p ${U_ICUDATA_PKGN} -T ${CMAKE_CURRENT_BINARY_DIR}/data/tmp -L ${U_ICUDATA_NAME} -d ${CMAKE_CURRENT_BINARY_DIR}/data/${U_ICUDATA_PKGN} -s ${CMAKE_CURRENT_BINARY_DIR}/data/${U_ICUDATA_PKGN} ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/icudata.lst
+    DEPENDS pkgdata ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/icudata.lst
+    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/${U_ICUDATA_PKGN}.dat ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/${U_ICUDATA_PKGN}_dat.obj)
+  add_custom_target(icudata ALL
+    DEPENDS ${_U_ICUDATA_LIB})
 
-  if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-    if(BUILD_SHARED_LIBS)
-      set(_U_ICUDATA_LIB ${CMAKE_CURRENT_BINARY_DIR}/data/${U_ICUDATA_PKGN}/${CMAKE_SHARED_LIBRARY_PREFIX}${U_ICUDATA_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})
-    else()
-      set(_U_ICUDATA_LIB ${CMAKE_CURRENT_BINARY_DIR}/data/${U_ICUDATA_PKGN}/${CMAKE_STATIC_LIBRARY_PREFIX}${U_ICUDATA_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
-    endif()
-
-    add_custom_command(OUTPUT ${_U_ICUDATA_LIB}
-      COMMAND $<TARGET_FILE:pkgdata> -f -e ${U_ICUDATA_NAME} -v -m $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,dll,static> -c -p ${U_ICUDATA_PKGN} -T ${CMAKE_CURRENT_BINARY_DIR}/data/tmp -L ${U_ICUDATA_NAME} -d ${CMAKE_CURRENT_BINARY_DIR}/data/${U_ICUDATA_PKGN} -s ${CMAKE_CURRENT_BINARY_DIR}/data/${U_ICUDATA_PKGN} ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/icudata.lst
-      DEPENDS pkgdata ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/icudata.lst
-      BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/${U_ICUDATA_PKGN}.dat ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/${U_ICUDATA_PKGN}_dat.obj)
-    add_custom_target(icudata ALL
-      DEPENDS ${_U_ICUDATA_LIB})
-
-    if(BUILD_SHARED_LIBS)
-      install(FILES ${_U_ICUDATA_LIB} DESTINATION bin)
-    else()
-      install(FILES ${_U_ICUDATA_LIB} DESTINATION lib)
-    endif()
-  elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    message(FATAL_ERROR "cannot build ICU data library")
+  if(BUILD_SHARED_LIBS)
+    install(FILES ${_U_ICUDATA_LIB} DESTINATION bin)
   else()
-    enable_language(ASM)
-
-    configure_file(icupkg.inc.cmake ${CMAKE_BINARY_DIR}/icupkg.inc)
-
-    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/${U_ICUDATA_PKGN}_dat.S
-      COMMAND $<TARGET_FILE:pkgdata> -f -e ${U_ICUDATA_NAME} -v -m $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,dll,static> -c -p ${U_ICUDATA_PKGN} -T ${CMAKE_CURRENT_BINARY_DIR}/data/tmp -L ${U_ICUDATA_NAME} -d ${CMAKE_CURRENT_BINARY_DIR}/data/${U_ICUDATA_PKGN} -s ${CMAKE_CURRENT_BINARY_DIR}/data/${U_ICUDATA_PKGN} ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/icudata.lst -O ${CMAKE_BINARY_DIR}/icupkg.inc
-      DEPENDS pkgdata ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/icudata.lst
-      BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/${U_ICUDATA_PKGN}.dat ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/${U_ICUDATA_PKGN}_dat.S)
-
-    add_library(${U_ICUDATA_NAME}
-      ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/${U_ICUDATA_PKGN}_dat.S)
-    set_target_properties(${U_ICUDATA_NAME} PROPERTIES
-      LINKER_LANGUAGE C
-      LINK_OPTIONS "-nodefaultlibs;-nostdlib;-Bsymbolic"
-      LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/data/${U_ICUDATA_PKGN})
-
-    install(TARGETS ${U_ICUDATA_NAME}
-      DESTINATION lib)
+    install(FILES ${_U_ICUDATA_LIB} DESTINATION lib)
   endif()
+elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  message(FATAL_ERROR "cannot build ICU data library")
+else()
+  enable_language(ASM)
+
+  configure_file(icupkg.inc.cmake ${CMAKE_BINARY_DIR}/icupkg.inc)
+
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/${U_ICUDATA_PKGN}_dat.S
+    COMMAND $<TARGET_FILE:pkgdata> -f -e ${U_ICUDATA_NAME} -v -m $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,dll,static> -c -p ${U_ICUDATA_PKGN} -T ${CMAKE_CURRENT_BINARY_DIR}/data/tmp -L ${U_ICUDATA_NAME} -d ${CMAKE_CURRENT_BINARY_DIR}/data/${U_ICUDATA_PKGN} -s ${CMAKE_CURRENT_BINARY_DIR}/data/${U_ICUDATA_PKGN} ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/icudata.lst -O ${CMAKE_BINARY_DIR}/icupkg.inc
+    DEPENDS pkgdata ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/icudata.lst
+    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/${U_ICUDATA_PKGN}.dat ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/${U_ICUDATA_PKGN}_dat.S)
+
+  add_library(${U_ICUDATA_NAME}
+    ${CMAKE_CURRENT_BINARY_DIR}/data/tmp/${U_ICUDATA_PKGN}_dat.S)
+  set_target_properties(${U_ICUDATA_NAME} PROPERTIES
+    LINKER_LANGUAGE C
+    LINK_OPTIONS "-nodefaultlibs;-nostdlib;-Bsymbolic"
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/data/${U_ICUDATA_PKGN})
+
+  install(TARGETS ${U_ICUDATA_NAME}
+    DESTINATION lib)
 endif()
 
 install(TARGETS icuuc icuin


### PR DESCRIPTION
This adds support for targeting non-X86 platforms when building ICU
data.  This is required for making further progress towards enabling the
ARM64 hosted toolchain.