### PR TITLE
GHA: add a packaging phase for ICU

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -799,3 +799,45 @@ jobs:
         with:
           name: sourcekit-lsp-vsix
           path: ${{ github.workspace }}/SourceCache/sourcekit-lsp/Editors/vscode/sourcekit-lsp-development.vsix
+
+  package_icu:
+    runs-on: windows-latest
+    needs: [icu]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['amd64'] # , 'arm64', 'x86']
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: icu-${{ matrix.arch }}-69.1
+          path: ${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr
+
+      # TODO(compnerd) hoist the revision to an input
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/swift-installer-scripts
+          ref: refs/heads/main
+          path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
+
+      - uses: microsoft/setup-msbuild@v1.0.3
+
+      - name: Package
+        run: |
+          msbuild -nologo `
+              -p:Configuration=Release `
+              -p:RunWixToolsOutOfProc=true `
+              -p:OutputPath=${{ github.workspace }}\BinaryCache\icu\ `
+              -p:IntermediateOutputPath=${{ github.workspace }}\BinaryCache\icu\ `
+              -p:ICU_ROOT=${{ github.workspace }}/BuildRoot `
+              -p:ProductVersion=69.1 `
+              -p:ProductVersionMajor=69 `
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/icu.wixproj
+          # codesign /f $(CERTIFICATE) /p $(PASSPHRASE) /tr http://timestamp.digicert.com /fd sha256 /td sha256 ${{ github.workspace }}/BinaryCache/icu/icu.msi
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: icu-${{ matrix.arch }}-msi
+          path: ${{ github.workspace }}/BinaryCache/icu/icu.msi


### PR DESCRIPTION
Because ICU is a dependency in the runtime and Foundation, we dynamically link
against it.  Additionally, the data is fairly large and thus is shared across
the two.  This begins the packaging for building the installer.