### PR TITLE
GHA: begin packaging the toolchain

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -841,3 +841,43 @@ jobs:
         with:
           name: icu-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BinaryCache/icu/icu.msi
+
+  package_toolchain:
+    runs-on: windows-latest
+    needs: [toolchain]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['amd64'] # , 'arm64']
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: toolchain-${{ matrix.arch }}
+          path: ${{ github.workspace }}/BuildRoot/Library
+
+      # TODO(compnerd) hoist the revision to an input
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/swift-installer-scripts
+          ref: refs/heads/main
+          path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
+
+      - uses: microsoft/setup-msbuild@v1.0.3
+
+      - name: Package
+        run: |
+          msbuild -nologo `
+              -p:Configuration=Release `
+              -p:RunWixToolsOutOfProc=true `
+              -p:OutputPath=${{ github.workspace }}\BinaryCache\toolchain\ `
+              -p:IntermediateOutputPath=${{ github.workspace }}\BinaryCache\toolchain\ `
+              -p:TOOLCHAIN_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/toolchain.wixproj
+          # codesign /f $(CERTIFICATE) /p $(PASSPHRASE) /tr http://timestamp.digicert.com /fd sha256 /td sha256 ${{ github.workspace }}/BinaryCache/toolchain/toolchain.msi
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: toolchain-${{ matrix.arch }}-msi
+          path: ${{ github.workspace }}/BinaryCache/toolchain/toolchain.msi


### PR DESCRIPTION
We currently only package the amd64 toolchain as the toolchain packaging assumes
that we have SourceKit and _InternalSwiftSyntaxParser, which currently do not
build on ARM64.