### PR TITLE
GHA: package the SDK and runtime

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -822,6 +822,24 @@ jobs:
       - name: Install xctest
         run: cmake --build ${{ github.workspace }}/BinaryCache/xctest --target install
 
+      - uses: actions/setup-python@v2
+      - uses: jannekem/run-python-script-action@v1
+        with:
+          script: |
+            import os
+            import plistlib
+
+            info_plist = r'${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Info.plist'
+            with open(os.path.normpath(info_plist), 'wb') as plist:
+              # TODO(compnerd) derive this from the install directory
+              plistlib.dump({ 'DefaultProperties': { 'XCTEST_VERSION': 'development', 'SWIFTC_FLAGS': ['-use-ld=lld'] } }, plist)
+
+            sdk_settings_plist = r'${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/SDKSettings.plist'
+            with open(os.path.normpath(sdk_settings_plist), 'wb') as plist:
+              # TODO(compnerd) derive this from the CMAKE_BUILD_TYPE for the
+              # runtime.
+              plistlib.dump({ 'DefaultProperties': { 'DEFAULT_USE_RUNTIME': 'MD' } }, plist)
+
       - uses: actions/upload-artifact@v2
         with:
           name: windows-sdk-${{ matrix.arch }}
@@ -932,3 +950,77 @@ jobs:
         with:
           name: toolchain-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BinaryCache/toolchain/toolchain.msi
+
+  package_sdk_runtime:
+    runs-on: windows-latest
+    needs: [sdk]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['amd64'] # , 'arm64']
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: windows-sdk-${{ matrix.arch }}
+          path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform
+
+      # TODO(compnerd) hoist the revision to an input
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/swift-installer-scripts
+          ref: refs/heads/main
+          path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/swift
+          ref: ${{ github.event.inputs.swift_tag }}
+          path: ${{ github.workspace }}/SourceCache/swift
+
+      - uses: seanmiddleditch/gha-setup-vsdevenv@v4
+        with:
+          host_arch: amd64
+          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+          arch: ${{ matrix.arch }}
+
+      - name: Build Installer Custom Action
+        run: msbuild -nologo -restore -p:PlatformToolset=v142 -p:Configuration=Release
+        working-directory: ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/CustomActions/SwiftInstaller
+
+      - name: Package SDK
+        run: |
+          # TODO(compnerd) determine why PlatformToolset is set to v100 on GHA
+          msbuild -nologo -restore `
+              -p:Configuration=Release `
+              -p:RunWixToolsOutOfProc=true `
+              -p:OutputPath=${{ github.workspace }}\BinaryCache\sdk\ `
+              -p:IntermediateOutputPath=${{ github.workspace }}\BinaryCache\sdk\ `
+              -p:PLATFORM_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform `
+              -p:SDK_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk `
+              -p:SWIFT_SOURCE_DIR=${{ github.workspace }}/SourceCache/swift `
+              -p:PlatformToolset=v142 `
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/sdk.wixproj
+          # codesign /f $(CERTIFICATE) /p $(PASSPHRASE) /tr http://timestamp.digicert.com /fd sha256 /td sha256 ${{ github.workspace }}/BinaryCache/sdk/sdk.msi
+
+      - name: Package Runtime
+        run: |
+          msbuild -nologo `
+              -p:Configuration=Release `
+              -p:RunWixToolsOutOfProc=true `
+              -p:OutputPath=${{ github.workspace }}\BinaryCache\runtime\ `
+              -p:IntermediateOutputPath=${{ github.workspace }}\BinaryCache\runtime\ `
+              -p:PLATFORM_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform `
+              -p:SDK_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk `
+              -p:SWIFT_SOURCE_DIR=${{ github.workspace }}/SourceCache/swift `
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/runtime.wixproj
+          # codesign /f $(CERTIFICATE) /p $(PASSPHRASE) /tr http://timestamp.digicert.com /fd sha256 /td sha256 ${{ github.workspace }}/BinaryCache/runtime/runtime.msi
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: sdk-windows-${{ matrix.arch }}-msi
+          path: ${{ github.workspace }}/BinaryCache/sdk/sdk.msi
+      - uses: actions/upload-artifact@v2
+        with:
+          name: runtime-windows-${{ matrix.arch }}-msi
+          path: ${{ github.workspace }}/BinaryCache/runtime/runtime.msi


### PR DESCRIPTION
This adds the packaging steps for the runtime and SDK.  They are two halves of
the same build: the runtime is the redistributable portion of the SDK, and the
SDK is the developer component.  We package them in a single step as they are
packaging subets of the same files, and it does not seem valuable to spin up a
new environment to package up a different subset of the files.