### PR TITLE
GHA: begin sketching out the devtools additions

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -44,6 +44,10 @@ on:
         description: 'swift-crypto revision'
         required: true
         default: 'refs/heads/main'
+      swift_collections_revision:
+        description: 'swift-collections revision'
+        required: true
+        default: 'refs/heads/main'
 
 jobs:
   # TODO(compnerd) use environment variables for package version information and wire that throughout
@@ -826,6 +830,496 @@ jobs:
         with:
           name: windows-sdk-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform
+
+  devtools:
+    runs-on: windows-latest
+    needs: [sqlite, toolchain, sdk]
+
+    # TODO(compnerd) use dictionaries to track triples for architecture and wire that in rather than powershell scripting
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['amd64'] # , 'arm64']
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: sqlite-${{ matrix.arch }}-3.36.0
+          path: ${{ github.workspace }}/BuildRoot/Library/sqlite-3.36.0/usr
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: toolchain-amd64
+          path: ${{ github.workspace }}/BuildRoot/Library
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: windows-sdk-${{ matrix.arch }}
+          path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform
+
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/indexstore-db
+          ref: ${{ github.event.inputs.swift_tag }}
+          path: ${{ github.workspace }}/SourceCache/indexstore-db
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/sourcekit-lsp
+          ref: ${{ github.event.inputs.swift_tag }}
+          path: ${{ github.workspace }}/SourceCache/sourcekit-lsp
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/swift-argument-parser
+          ref: ${{ github.event.inputs.swift_argument_parser_revision }}
+          path: ${{ github.workspace }}/SourceCache/swift-argument-parser
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/swift-collections
+          ref: ${{ github.event.inputs.swift_collections_revision }}
+          path: ${{ github.workspace }}/SourceCache/swift-collections
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/swift-crypto
+          ref: ${{ github.event.inputs.swift_crypto_revision }}
+          path: ${{ github.workspace }}/SourceCache/swift-crypto
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/swift-driver
+          ref: ${{ github.event.inputs.swift_tag }}
+          path: ${{ github.workspace }}/SourceCache/swift-driver
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/swift-llbuild
+          ref: ${{ github.event.inputs.swift_tag }}
+          path: ${{ github.workspace }}/SourceCache/swift-llbuild
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/swift-package-manager
+          ref: ${{ github.event.inputs.swift_tag }}
+          path: ${{ github.workspace }}/SourceCache/swift-package-manager
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/swift-tools-support-core
+          ref: ${{ github.event.inputs.swift_tag }}
+          path: ${{ github.workspace }}/SourceCache/swift-tools-support-core
+      - uses: actions/checkout@v2
+        with:
+          repository: jpsim/Yams
+          ref: ${{ github.event.inputs.yams_revision }}
+          path: ${{ github.workspace }}/SourceCache/Yams
+      - uses: actions/checkout@v2
+        with:
+          repository: apple/swift
+          ref: ${{ github.event.inputs.swift_tag }}
+          path: ${{ github.workspace }}/SourceCache/swift
+
+      - uses: seanmiddleditch/gha-setup-vsdevenv@v4
+        with:
+          host_arch: amd64
+          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+          arch: ${{ matrix.arch }}
+
+      - name: 'Copy Support Files'
+        run: |
+          Copy-Item "${{ github.workspace }}\SourceCache\swift\stdlib\public\Platform\ucrt.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\ucrt\module.modulemap"
+          Copy-Item "${{ github.workspace }}\SourceCache\swift\stdlib\public\Platform\visualc.modulemap" -destination "$env:VCToolsInstallDir\include\module.modulemap"
+          Copy-Item "${{ github.workspace }}\SourceCache\swift\stdlib\public\Platform\visualc.apinotes" -destination "$env:VCToolsInstallDir\include\visualc.apinotes"
+          Copy-Item "${{ github.workspace }}\SourceCache\swift\stdlib\public\Platform\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
+
+      - name: Configure swift-argument-parser
+        run: |
+          # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+          if ( "${{ matrix.arch }}" -eq "arm64" ) {
+            $COMPILER_TARGET="aarch64-unknown-windows-msvc"
+
+            $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
+            $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=ARM64"
+          } else {
+            $COMPILER_TARGET="x86_64-unknown-windows-msvc"
+          }
+          cmake -B ${{ github.workspace }}/BinaryCache/swift-argument-parser `
+                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_TESTING=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${CLANG_CL} `
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_CXX_COMPILER=${CLANG_CL} `
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows" `
+                ${CMAKE_SYSTEM_NAME} `
+                ${CMAKE_SYSTEM_PROCESSOR} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-argument-parser `
+                -D CMAKE_C_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_CXX_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_Swift_COMPILER_TARGET=${COMPILER_TARGET}
+      - name: Build swift-argument-parser
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-argument-parser
+
+      - name: Configure swift-collections
+        run: |
+          # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+          if ( "${{ matrix.arch }}" -eq "arm64" ) {
+            $COMPILER_TARGET="aarch64-unknown-windows-msvc"
+
+            $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
+            $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=ARM64"
+          } else {
+            $COMPILER_TARGET="x86_64-unknown-windows-msvc"
+          }
+          cmake -B ${{ github.workspace }}/BinaryCache/swift-collections `
+                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_TESTING=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${CLANG_CL} `
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_CXX_COMPILER=${CLANG_CL} `
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows" `
+                ${CMAKE_SYSTEM_NAME} `
+                ${CMAKE_SYSTEM_PROCESSOR} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-collections `
+                -D CMAKE_C_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_CXX_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_Swift_COMPILER_TARGET=${COMPILER_TARGET}
+      - name: Build swift-collections
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-collections
+
+      - name: Configure swift-crypto
+        run: |
+          # Workaround CMake 3.20 issue
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+          if ( "${{ matrix.arch }}" -eq "arm64" ) {
+            $COMPILER_TARGET="aarch64-unknown-windows-msvc"
+
+            $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
+            $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=ARM64"
+          } else {
+            $COMPILER_TARGET="x86_64-unknown-windows-msvc"
+          }
+          cmake -B ${{ github.workspace }}/BinaryCache/swift-crypto `
+                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_TESTING=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=cl `
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_CXX_COMPILER=cl `
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows" `
+                ${CMAKE_SYSTEM_NAME} `
+                ${CMAKE_SYSTEM_PROCESSOR} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-crypto `
+                -D CMAKE_C_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_CXX_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_Swift_COMPILER_TARGET=${COMPILER_TARGET}
+      - name: Build swift-crypto
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-crypto
+
+      - name: Configure Yams
+        run: |
+          # Workaround CMake 3.20 issue
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+          if ( "${{ matrix.arch }}" -eq "arm64" ) {
+            $COMPILER_TARGET="aarch64-unknown-windows-msvc"
+
+            $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
+            $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=ARM64"
+          } else {
+            $COMPILER_TARGET="x86_64-unknown-windows-msvc"
+          }
+          cmake -B ${{ github.workspace }}/BinaryCache/yams `
+                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_TESTING=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=cl `
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_CXX_COMPILER=cl `
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows" `
+                ${CMAKE_SYSTEM_NAME} `
+                ${CMAKE_SYSTEM_PROCESSOR} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/Yams `
+                -D CMAKE_C_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_CXX_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_Swift_COMPILER_TARGET=${COMPILER_TARGET}
+      - name: Build Yams
+        run: cmake --build ${{ github.workspace }}/BinaryCache/yams
+
+      - name: Configure swift-llbuild
+        run: |
+          # Workaround CMake 3.20 issue
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+          if ( "${{ matrix.arch }}" -eq "arm64" ) {
+            $COMPILER_TARGET="aarch64-unknown-windows-msvc"
+
+            $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
+            $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=ARM64"
+          } else {
+            $COMPILER_TARGET="x86_64-unknown-windows-msvc"
+          }
+          cmake -B ${{ github.workspace }}/BinaryCache/swift-llbuild `
+                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_TESTING=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=cl `
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code" `
+                -D CMAKE_CXX_COMPILER=cl `
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows" `
+                ${CMAKE_SYSTEM_NAME} `
+                ${CMAKE_SYSTEM_PROCESSOR} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-llbuild `
+                -D CMAKE_C_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_CXX_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_Swift_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D LLBUILD_SUPPORT_BINDINGS=Swift `
+                -D SQLite3_LIBRARY=${{ github.workspace }}/BuildRoot/Library/sqlite-3.36.0/usr/lib/SQLite3.lib `
+                -D SQLite3_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/sqlite-3.36.0/usr/include
+      - name: Build swift-llbuild
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-llbuild
+
+      - name: Configure swift-tools-support-core
+        run: |
+          # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+          if ( "${{ matrix.arch }}" -eq "arm64" ) {
+            $COMPILER_TARGET="aarch64-unknown-windows-msvc"
+
+            $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
+            $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=ARM64"
+          } else {
+            $COMPILER_TARGET="x86_64-unknown-windows-msvc"
+          }
+          cmake -B ${{ github.workspace }}/BinaryCache/swift-tools-support-core `
+                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_TESTING=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${CLANG_CL} `
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_CXX_COMPILER=${CLANG_CL} `
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows" `
+                ${CMAKE_SYSTEM_NAME} `
+                ${CMAKE_SYSTEM_PROCESSOR} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-tools-support-core `
+                -D CMAKE_C_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_CXX_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_Swift_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D SQLite3_LIBRARY=${{ github.workspace }}/BuildRoot/Library/sqlite-3.36.0/usr/lib/SQLite3.lib `
+                -D SQLite3_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/sqlite-3.36.0/usr/include
+      - name: Build swift-tools-support-core
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-tools-support-core
+
+      - name: Configure swift-driver
+        run: |
+          # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+          if ( "${{ matrix.arch }}" -eq "arm64" ) {
+            $COMPILER_TARGET="aarch64-unknown-windows-msvc"
+
+            $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
+            $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=ARM64"
+          } else {
+            $COMPILER_TARGET="x86_64-unknown-windows-msvc"
+          }
+          cmake -B ${{ github.workspace }}/BinaryCache/swift-driver `
+                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_TESTING=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${CLANG_CL} `
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_CXX_COMPILER=${CLANG_CL} `
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows" `
+                ${CMAKE_SYSTEM_NAME} `
+                ${CMAKE_SYSTEM_PROCESSOR} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-driver `
+                -D CMAKE_C_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_CXX_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_Swift_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D ArgumentParser_DIR=${{ github.workspace }}/BinaryCache/swift-argument-parser/cmake/modules `
+                -D LLBuild_DIR=${{ github.workspace }}/BinaryCache/swift-llbuild/cmake/modules `
+                -D TSC_DIR=${{ github.workspace }}/BinaryCache/swift-tools-support-core/cmake/modules `
+                -D Yams_DIR=${{ github.workspace }}/BinaryCache/yams/cmake/modules
+      - name: Build swift-driver
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-driver
+
+      - name: Configure swift-package-manager
+        run: |
+          # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+          if ( "${{ matrix.arch }}" -eq "arm64" ) {
+            $COMPILER_TARGET="aarch64-unknown-windows-msvc"
+
+            $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
+            $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=ARM64"
+          } else {
+            $COMPILER_TARGET="x86_64-unknown-windows-msvc"
+          }
+          cmake -B ${{ github.workspace }}/BinaryCache/swift-package-manager `
+                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_TESTING=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${CLANG_CL} `
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_CXX_COMPILER=${CLANG_CL} `
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows" `
+                ${CMAKE_SYSTEM_NAME} `
+                ${CMAKE_SYSTEM_PROCESSOR} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-package-manager `
+                -D CMAKE_C_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_CXX_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_Swift_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D ArgumentParser_DIR=${{ github.workspace }}/BinaryCache/swift-argument-parser/cmake/modules `
+                -D SwiftCollections_DIR=${{ github.workspace }}/BinaryCache/swift-collections/cmake/modules `
+                -D SwiftDriver_DIR=${{ github.workspace }}/BinaryCache/swift-driver/cmake/modules `
+                -D SwiftCrypto_DIR=${{ github.workspace }}/BinaryCache/swift-crypto/cmake/modules `
+                -D LLBuild_DIR=${{ github.workspace }}/BinaryCache/swift-llbuild/cmake/modules `
+                -D TSC_DIR=${{ github.workspace }}/BinaryCache/swift-tools-support-core/cmake/modules `
+                -D Yams_DIR=${{ github.workspace }}/BinaryCache/yams/cmake/modules
+      - name: Build swift-package-manager
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-package-manager
+
+      - name: Configure IndexStoreDB
+        run: |
+          # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+          if ( "${{ matrix.arch }}" -eq "arm64" ) {
+            $COMPILER_TARGET="aarch64-unknown-windows-msvc"
+
+            $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
+            $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=ARM64"
+          } else {
+            $COMPILER_TARGET="x86_64-unknown-windows-msvc"
+          }
+          cmake -B ${{ github.workspace }}/BinaryCache/indexstore-db `
+                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_TESTING=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${CLANG_CL} `
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code" `
+                -D CMAKE_CXX_COMPILER=${CLANG_CL} `
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code -I ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -I ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/Block" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows" `
+                ${CMAKE_SYSTEM_NAME} `
+                ${CMAKE_SYSTEM_PROCESSOR} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/indexstore-db `
+                -D CMAKE_C_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_CXX_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_Swift_COMPILER_TARGET=${COMPILER_TARGET}
+      - name: Build indexstore-db
+        run: cmake --build ${{ github.workspace }}/BinaryCache/indexstore-db
+
+      - name: Configure SourceKit-LSP
+        run: |
+          # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+          if ( "${{ matrix.arch }}" -eq "arm64" ) {
+            $COMPILER_TARGET="aarch64-unknown-windows-msvc"
+
+            $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
+            $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=ARM64"
+          } else {
+            $COMPILER_TARGET="x86_64-unknown-windows-msvc"
+          }
+          cmake -B ${{ github.workspace }}/BinaryCache/sourcekit-lsp `
+                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_TESTING=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${CLANG_CL} `
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code" `
+                -D CMAKE_CXX_COMPILER=${CLANG_CL} `
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows" `
+                ${CMAKE_SYSTEM_NAME} `
+                ${CMAKE_SYSTEM_PROCESSOR} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/sourcekit-lsp `
+                -D CMAKE_C_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_CXX_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_Swift_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D ArgumentParser_DIR=${{ github.workspace }}/BinaryCache/swift-argument-parser/cmake/modules `
+                -D IndexStoreDB_DIR=${{ github.workspace }}/BinaryCache/indexstore-db/cmake/modules `
+                -D LLBuild_DIR=${{ github.workspace }}/BinaryCache/swift-llbuild/cmake/modules `
+                -D SwiftCollections_DIR=${{ github.workspace }}/BinaryCache/swift-collections/cmake/modules `
+                -D SwiftPM_DIR=${{ github.workspace }}/BinaryCache/swift-package-manager/cmake/modules `
+                -D TSC_DIR=${{ github.workspace }}/BinaryCache/swift-tools-support-core/cmake/modules
+      - name: Build SourceKit-LSP
+        run: cmake --build ${{ github.workspace }}/BinaryCache/SourceKit-LSP
+
+      - name: Install swift-argument-parser
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-argument-parser --target install
+      - name: Install swift-collections
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-collections --target install
+      - name: Install swift-crypto
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-crypto --target install
+      - name: Install Yams
+        run: cmake --build ${{ github.workspace }}/BinaryCache/yams --target install
+      - name: Install swift-llbuild
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-llbuild --target install
+      - name: Install swift-tools-support-core
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-tools-support-core --target install
+      - name: Install swift-driver
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-driver --target install
+      - name: Install swift-package-manager
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-package-manager --target install
+      - name: Install IndexStoreDB
+        run: cmake --build ${{ github.workspace }}/BinaryCache/indexstore-db --target install
+      - name: Install SourceKit-LSP
+        run: cmake --build ${{ github.workspace }}/BinaryCache/sourcekit-lsp --target install
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: windows-sdk-${{ matrix.arch }}
+          path: ${{ github.workspace }}/BuildRoot-DevTools/Library
 
   vscode_plugin:
     runs-on: windows-latest


### PR DESCRIPTION
Add the builds for Swift Package Manager (and its dependency tree) and
SourceKit-LSP (excluding the VSCode plugin).  This builds the rest of the
installer components for a full toolchain build.