### PR TITLE
GHA: move dependency revisions into hardcoded values

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3,24 +3,6 @@ name: swift-toolchain
 on:
   workflow_dispatch:
     inputs:
-      # depdendencies
-      icu_revision:
-        description: 'ICU revision'
-        required: true
-        default: 'refs/heads/maint/maint-69'
-      curl_revision:
-        description: 'libcurl revision'
-        required: true
-        default: 'refs/tags/curl-7_77_0'
-      libxml2_revision:
-        description: 'libxml2 revision'
-        required: true
-        default: 'refs/tags/v2.9.12'
-      zlib_revision:
-        description: 'zlib revision to build'
-        required: true
-        default: 'refs/heads/master'
-
       # toolchain
       llvm_revision:
         description: 'llvm-project revision'
@@ -119,7 +101,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: unicode-org/icu
-          ref: ${{ github.event.inputs.icu_revision }}
+          ref: 'refs/heads/maint/maint-69'
           path: ${{ github.workspace }}/SourceCache/icu
 
       - name: Copy CMakeLists.txt
@@ -398,7 +380,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: madler/zlib
-          ref: ${{ github.event.inputs.zlib_revision }}
+          ref: 'refs/heads/master'
           path: ${{ github.workspace }}/SourceCache/zlib
 
       - uses: seanmiddleditch/gha-setup-vsdevenv@v4
@@ -444,7 +426,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: curl/curl
-          ref: ${{ github.event.inputs.curl_revision }}
+          ref: 'refs/tags/curl-7_77_0'
           path: ${{ github.workspace }}/SourceCache/curl
 
       - uses: actions/download-artifact@v2
@@ -517,7 +499,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: gnome/libxml2
-          ref: ${{ github.event.inputs.libxml2_revision }}
+          ref: 'refs/tags/v2.9.12'
           path: ${{ github.workspace }}/SourceCache/libxml2
 
       - uses: seanmiddleditch/gha-setup-vsdevenv@v4


### PR DESCRIPTION
These are largely static, so move them into environment variables to
reduce the number of parameters which are limited to add additional ones
for the rest of the toolchain build.