### PR TITLE
GHA: enable swift-system in the devtools build

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -14,10 +14,6 @@ on:
         default: 'refs/heads/main'
 
       # devtools
-      yams_revision:
-        description: 'Yams revision'
-        required: true
-        default: 'refs/heads/main'
       swift_argument_parser_revision:
         description: 'swift-argument-parser revision'
         required: true
@@ -28,6 +24,14 @@ on:
         default: 'refs/tags/1.1.6'
       swift_collections_revision:
         description: 'swift-collections revision'
+        required: true
+        default: 'refs/heads/main'
+      swift_system_revision:
+        description: 'swift-system revision'
+        required: true
+        default: 'refs/heads/main'
+      yams_revision:
+        description: 'Yams revision'
         required: true
         default: 'refs/heads/main'
 
@@ -899,6 +903,11 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/swift-package-manager
       - uses: actions/checkout@v2
         with:
+          repository: apple/swift-system
+          ref: ${{ github.event.inputs.swift_system_revision }}
+          path: ${{ github.workspace }}/SourceCache/swift-system
+      - uses: actions/checkout@v2
+        with:
           repository: apple/swift-tools-support-core
           ref: ${{ github.event.inputs.swift_tag }}
           path: ${{ github.workspace }}/SourceCache/swift-tools-support-core
@@ -1101,6 +1110,41 @@ jobs:
       - name: Build swift-llbuild
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-llbuild
 
+      - name: Configure swift-system
+        run: |
+          # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+          if ( "${{ matrix.arch }}" -eq "arm64" ) {
+            $COMPILER_TARGET="aarch64-unknown-windows-msvc"
+
+            $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
+            $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=ARM64"
+          } else {
+            $COMPILER_TARGET="x86_64-unknown-windows-msvc"
+          }
+          cmake -B ${{ github.workspace }}/BinaryCache/swift-system `
+                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_TESTING=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${CLANG_CL} `
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_CXX_COMPILER=${CLANG_CL} `
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows" `
+                ${CMAKE_SYSTEM_NAME} `
+                ${CMAKE_SYSTEM_PROCESSOR} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-system `
+                -D CMAKE_C_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_CXX_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D CMAKE_Swift_COMPILER_TARGET=${COMPILER_TARGET}
+      - name: Build swift-system
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-system
+
       - name: Configure swift-tools-support-core
         run: |
           # Workaround CMake 3.20 issue
@@ -1133,6 +1177,7 @@ jobs:
                 -D CMAKE_C_COMPILER_TARGET=${COMPILER_TARGET} `
                 -D CMAKE_CXX_COMPILER_TARGET=${COMPILER_TARGET} `
                 -D CMAKE_Swift_COMPILER_TARGET=${COMPILER_TARGET} `
+                -D SwiftSystem_DIR=${{ github.workspace }}/BinaryCache/swift-system/cmake/modules `
                 -D SQLite3_LIBRARY=${{ github.workspace }}/BuildRoot/Library/sqlite-3.36.0/usr/lib/SQLite3.lib `
                 -D SQLite3_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/sqlite-3.36.0/usr/include
       - name: Build swift-tools-support-core
@@ -1172,6 +1217,7 @@ jobs:
                 -D CMAKE_Swift_COMPILER_TARGET=${COMPILER_TARGET} `
                 -D ArgumentParser_DIR=${{ github.workspace }}/BinaryCache/swift-argument-parser/cmake/modules `
                 -D LLBuild_DIR=${{ github.workspace }}/BinaryCache/swift-llbuild/cmake/modules `
+                -D SwiftSystem_DIR=${{ github.workspace }}/BinaryCache/swift-system/cmake/modules `
                 -D TSC_DIR=${{ github.workspace }}/BinaryCache/swift-tools-support-core/cmake/modules `
                 -D Yams_DIR=${{ github.workspace }}/BinaryCache/yams/cmake/modules
       - name: Build swift-driver
@@ -1213,6 +1259,7 @@ jobs:
                 -D SwiftCollections_DIR=${{ github.workspace }}/BinaryCache/swift-collections/cmake/modules `
                 -D SwiftDriver_DIR=${{ github.workspace }}/BinaryCache/swift-driver/cmake/modules `
                 -D SwiftCrypto_DIR=${{ github.workspace }}/BinaryCache/swift-crypto/cmake/modules `
+                -D SwiftSystem_DIR=${{ github.workspace }}/BinaryCache/swift-system/cmake/modules `
                 -D LLBuild_DIR=${{ github.workspace }}/BinaryCache/swift-llbuild/cmake/modules `
                 -D TSC_DIR=${{ github.workspace }}/BinaryCache/swift-tools-support-core/cmake/modules `
                 -D Yams_DIR=${{ github.workspace }}/BinaryCache/yams/cmake/modules
@@ -1291,6 +1338,7 @@ jobs:
                 -D LLBuild_DIR=${{ github.workspace }}/BinaryCache/swift-llbuild/cmake/modules `
                 -D SwiftCollections_DIR=${{ github.workspace }}/BinaryCache/swift-collections/cmake/modules `
                 -D SwiftPM_DIR=${{ github.workspace }}/BinaryCache/swift-package-manager/cmake/modules `
+                -D SwiftSystem_DIR=${{ github.workspace }}/BinaryCache/swift-system/cmake/modules `
                 -D TSC_DIR=${{ github.workspace }}/BinaryCache/swift-tools-support-core/cmake/modules
       - name: Build SourceKit-LSP
         run: cmake --build ${{ github.workspace }}/BinaryCache/SourceKit-LSP
@@ -1305,6 +1353,8 @@ jobs:
         run: cmake --build ${{ github.workspace }}/BinaryCache/yams --target install
       - name: Install swift-llbuild
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-llbuild --target install
+      - name: Install swift-system
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-system --target install
       - name: Install swift-tools-support-core
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-tools-support-core --target install
       - name: Install swift-driver


### PR DESCRIPTION
Add a build of SwiftSystem and wire it up to its dependents in
preparation for a new dependency being introduced.  This will still need
a separate change for packaging which can occur after we are sure that
we can build properly.