### PR TITLE
package.cmd: restore headers for `_InternalSwiftScan`, `_InternalSwif…

### DIFF
--- a/package.cmd
+++ b/package.cmd
@@ -6,6 +6,7 @@ set PlatformInstallRoot=S:\Library\Developer\Platforms\Windows.platform
 set SDKInstallRoot=%PlatformInstallRoot%\Developer\SDKs\Windows.sdk
 
 FOR %%M In (_InternalSwiftScan, _InternalSwiftSyntaxParser) DO (
+  copy /Y %ToolchainInstallRoot%\usr\include\%%M %ToolchainInstallRoot%\usr\lib\swift\%%M
   copy /Y %ToolchainInstallRoot%\usr\lib\%%M.lib %ToolchainInstallRoot%\usr\lib\swift\windows\%%M.lib
 )
 

--- a/package.cmd
+++ b/package.cmd
@@ -6,7 +6,9 @@ set PlatformInstallRoot=S:\Library\Developer\Platforms\Windows.platform
 set SDKInstallRoot=%PlatformInstallRoot%\Developer\SDKs\Windows.sdk
 
 FOR %%M In (_InternalSwiftScan, _InternalSwiftSyntaxParser) DO (
+  md %ToolchainInstallRoot%\usr\lib\swift\%%M
   copy /Y %ToolchainInstallRoot%\usr\include\%%M %ToolchainInstallRoot%\usr\lib\swift\%%M
+  md %ToolchainInstallRoot%\usr\lib\swift\windows
   copy /Y %ToolchainInstallRoot%\usr\lib\%%M.lib %ToolchainInstallRoot%\usr\lib\swift\windows\%%M.lib
 )
 


### PR DESCRIPTION
…tSyntaxParser`

The headers for these libraries need to be copied back to allow
packaging to continue as the installation places them in the wrong
location.