### PR TITLE
Foundation build workaround for CMake 3.22

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -741,6 +741,7 @@ jobs:
                 -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy" `
+                -D CMAKE_ASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreadedDLL="/MD" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `


### PR DESCRIPTION
CMake 3.22 fails to generate Foundation build files:
```
CMake Error in CoreFoundation/CMakeLists.txt:
  MSVC_RUNTIME_LIBRARY value 'MultiThreadedDLL' not known for this ASM
  compiler.
```

I am still not sure _why_ it fails to detect the correct MSVC library flag. The [code related to this option](https://gitlab.kitware.com/cmake/cmake/-/blob/master/Source/cmLocalGenerator.cxx#L1968) seems to be the same as for previous versions. The configuration step has the actual value of `CMAKE_ASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreadedDLL`  set to `-MD`. But I guess we could give CMake a hint as a workaround.