### PR TITLE
Update swift-toolchain.yml

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -224,7 +224,7 @@ jobs:
 
   toolchain:
     runs-on: windows-latest
-    needs: [icu, build_tools]
+    needs: [build_tools]
 
     env:
       PYTHON_VERSION: 3.9.7
@@ -235,11 +235,6 @@ jobs:
         arch: ['amd64', 'arm64']
 
     steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: icu-${{ matrix.arch }}-69.1
-          path: ${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr
-
       - uses: actions/download-artifact@v2
         with:
           name: build-tools
@@ -342,14 +337,6 @@ jobs:
                 -D LLVM_EXTERNAL_SWIFT_SOURCE_DIR=${{ github.workspace }}/SourceCache/swift `
                 -D LLVM_EXTERNAL_CMARK_SOURCE_DIR=${{ github.workspace }}/SourceCache/swift-cmark `
                 -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE=${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch `
-                -D SWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/include/unicode `
-                -D SWIFT_WINDOWS_aarch64_ICU_UC=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuuc69.lib `
-                -D SWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/include `
-                -D SWIFT_WINDOWS_aarch64_ICU_I18N=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuin69.lib `
-                -D SWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/include/unicode `
-                -D SWIFT_WINDOWS_x86_64_ICU_UC=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuuc69.lib `
-                -D SWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/include `
-                -D SWIFT_WINDOWS_x86_64_ICU_I18N=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuin69.lib `
                 -D LLVM_USE_HOST_TOOLS=NO `
                 -D LLVM_TABLEGEN=${{ github.workspace }}/BinaryCache/0/bin/llvm-tblgen.exe `
                 -D CLANG_TABLEGEN=${{ github.workspace }}/BinaryCache/0/bin/clang-tblgen.exe `
@@ -675,19 +662,7 @@ jobs:
                 -D SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED=YES `
                 -D SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING=YES `
                 -D SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING=YES `
-                -D EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR=${{ github.workspace }}/SourceCache/swift-experimental-string-processing `
-                -D SWIFT_WINDOWS_aarch64_ICU_UC_INCLUDE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/include/unicode `
-                -D SWIFT_WINDOWS_aarch64_ICU_UC=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuuc69.lib `
-                -D SWIFT_WINDOWS_aarch64_ICU_I18N_INCLUDE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/include `
-                -D SWIFT_WINDOWS_aarch64_ICU_I18N=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuin69.lib `
-                -D SWIFT_WINDOWS_i686_ICU_UC_INCLUDE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/include/unicode `
-                -D SWIFT_WINDOWS_i686_ICU_UC=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuuc69.lib `
-                -D SWIFT_WINDOWS_i686_ICU_I18N_INCLUDE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/include `
-                -D SWIFT_WINDOWS_i686_ICU_I18N=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuin69.lib `
-                -D SWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/include/unicode `
-                -D SWIFT_WINDOWS_x86_64_ICU_UC=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuuc69.lib `
-                -D SWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/include `
-                -D SWIFT_WINDOWS_x86_64_ICU_I18N=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr/lib/icuin69.lib
+                -D EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR=${{ github.workspace }}/SourceCache/swift-experimental-string-processing
       - name: Build Swift Standard Library
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift
       - name: Install Swift Standard Library


### PR DESCRIPTION
Drop ICU dependency for toolchain; the standard library does not use ICU any longer.