### PR TITLE
Install external clang and enable arm64 sourcekit

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -282,6 +282,23 @@ jobs:
           echo "PYTHON_LOCATION_amd64=$env:pythonLocation" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "PYTHON_LOCATION_arm64=${{ github.workspace }}\pythonarm64.${{ env.PYTHON_VERSION }}\tools" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+      - name: Install llvm
+        if: matrix.arch == 'arm64'
+        run: |
+          curl.exe -sL "https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/LLVM-13.0.0-win64.exe" -o $env:TEMP\llvm-installer.exe
+
+          Write-Host "Starting $env:TEMP\\llvm-installer.exe"
+          $Process = Start-Process -FilePath $env:TEMP\llvm-installer.exe -ArgumentList ("/S", "/D=${{ github.workspace }}\llvm") -Wait -PassThru
+          $ExitCode = $Process.ExitCode
+          if ($ExitCode -eq 0) {
+            Write-Host "Installation successful"
+          } else {
+            Write-Host "non-zero exit code returned by the installation process: $ExitCode"
+            exit $ExitCode
+          }
+          
+          Remove-Item $env:TEMP\llvm-installer.exe
+
       - uses: seanmiddleditch/gha-setup-vsdevenv@v4
         with:
           host_arch: amd64
@@ -302,14 +319,7 @@ jobs:
             $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
             $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=ARM64"
             $CACHE="Windows-arm64.cmake"
-
-            # FIXME(compnerd) re-enable SourceKit after we sort out libdispatch
-            $SWIFT_BUILD_SOURCEKIT="-D SWIFT_BUILD_SOURCEKIT=NO"
-            (Get-Content ${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-arm64.cmake).replace(' sourcekit-inproc', '') | Set-Content ${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-arm64.cmake
-
-            # FIXME(compnerd) re-enable SyntaxParser after we sort out libdispatch
-            $SWIFT_BUILD_SYNTAXPARSERLIB="-D SWIFT_BUILD_SYNTAXPARSERLIB=NO"
-            (Get-Content ${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-arm64.cmake).replace(' parser-lib', '') | Set-Content ${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-arm64.cmake
+            $SWIFT_CLANG_LOCATION="-D SWIFT_CLANG_LOCATION=${{ github.workspace }}\llvm\bin"
 
             # FIXME(compnerd) re-enable runtimes after we sort out compiler-rt
             (Get-Content ${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-arm64.cmake).replace(' runtimes', '') | Set-Content ${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-arm64.cmake
@@ -362,10 +372,24 @@ jobs:
                 -D Python3_ROOT_DIR=$env:pythonLocation `
                 -D Python3_INCLUDE_DIR=$env:PYTHON_LOCATION_${{ matrix.arch }}\include `
                 -D Python3_LIBRARY=$env:PYTHON_LOCATION_${{ matrix.arch }}\libs\python39.lib `
-                ${SWIFT_BUILD_SOURCEKIT} `
-                ${SWIFT_BUILD_SYNTAXPARSERLIB}
+                ${SWIFT_CLANG_LOCATION}
+
       - name: Build Toolchain Distribution
         run: cmake --build ${{ github.workspace }}/BinaryCache/1 --target distribution
+
+      # As cloud agents have pretty low disk quota, it is important to uninstall llvm as soon as it is not needed
+      - name: Uninstall llvm
+        if: matrix.arch == 'arm64'
+        run: |
+          Write-Host "Starting ${{ github.workspace }}\llvm\Uninstall.exe"
+          $Process = Start-Process -FilePath "${{ github.workspace }}\llvm\Uninstall.exe" -ArgumentList ("/S") -Wait -PassThru
+          $ExitCode = $Process.ExitCode
+          if ($ExitCode -eq 0) {
+            Write-Host "Uninstallation successful"
+          } else {
+            Write-Host "non-zero exit code returned by the uninstallation process: $ExitCode"
+          }
+
       - name: Install Toolchain Distribution
         run: cmake --build ${{ github.workspace }}/BinaryCache/1 --target install-distribution-stripped
 


### PR DESCRIPTION
Using clang from [official llvm project release](https://github.com/llvm/llvm-project/releases/tag/llvmorg-13.0.0) to build sourcekit and syntaxparser.