### PR TITLE
build llvm-config as part of build tools job

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -211,6 +211,8 @@ jobs:
         run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target clang-tblgen
       - name: Build lldb-tblgen
         run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target lldb-tblgen
+      - name: Build llvm-config
+        run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target llvm-config
       - name: Build swift-def-to-yaml-converter
         run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target swift-def-to-yaml-converter
       - name: Build swift-serialize-diagnostics
@@ -223,6 +225,7 @@ jobs:
             ${{ github.workspace }}/BinaryCache/0/bin/llvm-tblgen.exe
             ${{ github.workspace }}/BinaryCache/0/bin/clang-tblgen.exe
             ${{ github.workspace }}/BinaryCache/0/bin/lldb-tblgen.exe
+            ${{ github.workspace }}/BinaryCache/0/bin/llvm-config.exe
             ${{ github.workspace }}/BinaryCache/0/bin/swift-def-to-yaml-converter.exe
             ${{ github.workspace }}/BinaryCache/0/bin/swift-serialize-diagnostics.exe
 
@@ -355,6 +358,7 @@ jobs:
                 -D LLVM_TABLEGEN=${{ github.workspace }}/BinaryCache/0/bin/llvm-tblgen.exe `
                 -D CLANG_TABLEGEN=${{ github.workspace }}/BinaryCache/0/bin/clang-tblgen.exe `
                 -D LLDB_TABLEGEN=${{ github.workspace }}/BinaryCache/0/bin/lldb-tblgen.exe `
+                -D LLVM_CONFIG_PATH=${{ github.workspace }}/BinaryCache/0/bin/llvm-config.exe `
                 -D SWIFT_NATIVE_SWIFT_TOOLS_PATH=${{ github.workspace }}/BinaryCache/0/bin `
                 -D LLVM_PARALLEL_LINK_JOBS=2 `
                 -D SWIFT_PARALLEL_LINK_JOBS=2 `


### PR DESCRIPTION
This is one of the steps required to eventually enable runtimes in arm64 builds. `builtins` and `compiler-rt` targets are depending on `llvm-config` tool. This triggers native llvm build If the tool is not provided externally. We could build `llvm-config` together with other native tools we already preparing in `build_tools` job.