### PR TITLE
VS2022, 5.7: use VC 14.31 toolset

### DIFF
--- a/.ci/vs2022-swift-5.7.yml
+++ b/.ci/vs2022-swift-5.7.yml
@@ -258,6 +258,12 @@ stages:
           - checkout: apple/swift-experimental-string-processing
             fetchDepth: 1
           - script: |
+              "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vs_installer.exe" modify --quiet --norestart ^
+               --productId Microsoft.VisualStudio.Product.Enterprise ^
+               --channelId VisualStudio.17.Release ^
+               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.x86.x64 ^
+               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL
+          - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
                 SET vs="%%i"
@@ -270,7 +276,7 @@ stages:
           - task: BatchScript@1
             inputs:
               filename: $(VsDevCmd)
-              arguments: -no_logo -arch=$(arch) -host_arch=amd64
+              arguments: -no_logo -arch=$(arch) -host_arch=amd64 -vcvars_ver=14.31
               modifyEnvironment: true
           - task: CMake@1
             inputs:
@@ -753,6 +759,12 @@ stages:
           - checkout: apple/swift-experimental-string-processing
             fetchDepth: 1
           - script: |
+              "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vs_installer.exe" modify --quiet --norestart ^
+               --productId Microsoft.VisualStudio.Product.Enterprise ^
+               --channelId VisualStudio.17.Release ^
+               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.x86.x64 ^
+               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL
+          - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
                 SET vs="%%i"
@@ -765,7 +777,7 @@ stages:
           - task: BatchScript@1
             inputs:
               filename: $(VsDevCmd)
-              arguments: -no_logo -arch=$(arch) -host_arch=amd64
+              arguments: -no_logo -arch=$(arch) -host_arch=amd64 -vcvars_ver=14.31
               modifyEnvironment: true
           - task: PowerShell@2
             inputs:


### PR DESCRIPTION
This is workaround for current miscompiling issue with latest MSVC toolset. Until the reason of the issue is known, we could use last known good toolset version.

Please note that I didn't actually test this solution with Pipelines, and I am not sure if it is possible to run build check against this PR. For GitHub Actions it worked well, so I believe this is the way we can fix builds temporarily, but I'd like to apologize in advance for any possible typos or yml syntax errors. I'll be here to fix them in follow-ups.