### PR TITLE
VS2022, main and 5.6: use VC 14.31 toolset

### DIFF
--- a/.ci/vs2022-swift-5.6.yml
+++ b/.ci/vs2022-swift-5.6.yml
@@ -251,6 +251,12 @@ stages:
           - checkout: apple/swift-corelibs-libdispatch
             fetchDepth: 1
           - script: |
+              "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vs_installer.exe" modify --quiet --norestart ^
+               --productId Microsoft.VisualStudio.Product.Enterprise ^
+               --channelId VisualStudio.17.Release ^
+               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.x86.x64 ^
+               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL
+          - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
                 SET vs="%%i"
@@ -263,7 +269,7 @@ stages:
           - task: BatchScript@1
             inputs:
               filename: $(VsDevCmd)
-              arguments: -no_logo -arch=$(arch) -host_arch=amd64
+              arguments: -no_logo -arch=$(arch) -host_arch=amd64 -vcvars_ver=14.31
               modifyEnvironment: true
           - task: CMake@1
             inputs:
@@ -741,6 +747,12 @@ stages:
           - checkout: apple/swift-corelibs-xctest
             fetchDepth: 1
           - script: |
+              "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vs_installer.exe" modify --quiet --norestart ^
+               --productId Microsoft.VisualStudio.Product.Enterprise ^
+               --channelId VisualStudio.17.Release ^
+               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.x86.x64 ^
+               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL
+          - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
                 SET vs="%%i"
@@ -753,7 +765,7 @@ stages:
           - task: BatchScript@1
             inputs:
               filename: $(VsDevCmd)
-              arguments: -no_logo -arch=$(arch) -host_arch=amd64
+              arguments: -no_logo -arch=$(arch) -host_arch=amd64 -vcvars_ver=14.31
               modifyEnvironment: true
           - task: PowerShell@2
             inputs:

--- a/.ci/vs2022.yml
+++ b/.ci/vs2022.yml
@@ -259,6 +259,12 @@ stages:
           - checkout: apple/swift-experimental-string-processing
             fetchDepth: 1
           - script: |
+              "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vs_installer.exe" modify --quiet --norestart ^
+               --productId Microsoft.VisualStudio.Product.Enterprise ^
+               --channelId VisualStudio.17.Release ^
+               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.x86.x64 ^
+               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL
+          - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
                 SET vs="%%i"
@@ -271,7 +277,7 @@ stages:
           - task: BatchScript@1
             inputs:
               filename: $(VsDevCmd)
-              arguments: -no_logo -arch=$(arch) -host_arch=amd64
+              arguments: -no_logo -arch=$(arch) -host_arch=amd64 -vcvars_ver=14.31
               modifyEnvironment: true
           - task: PowerShell@2
             inputs:
@@ -766,6 +772,12 @@ stages:
           - checkout: apple/swift-experimental-string-processing
             fetchDepth: 1
           - script: |
+              "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vs_installer.exe" modify --quiet --norestart ^
+               --productId Microsoft.VisualStudio.Product.Enterprise ^
+               --channelId VisualStudio.17.Release ^
+               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.x86.x64 ^
+               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL
+          - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
                 SET vs="%%i"
@@ -778,7 +790,7 @@ stages:
           - task: BatchScript@1
             inputs:
               filename: $(VsDevCmd)
-              arguments: -no_logo -arch=$(arch) -host_arch=amd64
+              arguments: -no_logo -arch=$(arch) -host_arch=amd64 -vcvars_ver=14.31
               modifyEnvironment: true
           - task: PowerShell@2
             inputs:


### PR DESCRIPTION
Same changes as in #430, but for main and 5.6 branches.