### PR TITLE
vs2022, wait for VS installer, but with powershell

### DIFF
--- a/.ci/vs2022-swift-5.6.yml
+++ b/.ci/vs2022-swift-5.6.yml
@@ -250,12 +250,9 @@ stages:
             fetchDepth: 1
           - checkout: apple/swift-corelibs-libdispatch
             fetchDepth: 1
-          - script: |
-              start /w "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vs_installer.exe" modify --quiet --norestart ^
-               --productId Microsoft.VisualStudio.Product.Enterprise ^
-               --channelId VisualStudio.17.Release ^
-               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.x86.x64 ^
-               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL
+          - powershell: |
+              $InstallerArguments = "modify --quiet --norestart --productId Microsoft.VisualStudio.Product.Enterprise --channelId VisualStudio.17.Release --add Microsoft.VisualStudio.Component.VC.14.31.17.1.x86.x64 --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL"
+              Start-Process -FilePath "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe" -Wait -ArgumentList $InstallerArguments
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
@@ -746,12 +743,9 @@ stages:
             fetchDepth: 1
           - checkout: apple/swift-corelibs-xctest
             fetchDepth: 1
-          - script: |
-              start /w "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vs_installer.exe" modify --quiet --norestart ^
-               --productId Microsoft.VisualStudio.Product.Enterprise ^
-               --channelId VisualStudio.17.Release ^
-               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.x86.x64 ^
-               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL
+          - powershell: |
+              $InstallerArguments = "modify --quiet --norestart --productId Microsoft.VisualStudio.Product.Enterprise --channelId VisualStudio.17.Release --add Microsoft.VisualStudio.Component.VC.14.31.17.1.x86.x64 --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL"
+              Start-Process -FilePath "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe" -Wait -ArgumentList $InstallerArguments
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (

--- a/.ci/vs2022-swift-5.7.yml
+++ b/.ci/vs2022-swift-5.7.yml
@@ -257,12 +257,9 @@ stages:
             fetchDepth: 1
           - checkout: apple/swift-experimental-string-processing
             fetchDepth: 1
-          - script: |
-              start /w "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vs_installer.exe" modify --quiet --norestart ^
-               --productId Microsoft.VisualStudio.Product.Enterprise ^
-               --channelId VisualStudio.17.Release ^
-               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.x86.x64 ^
-               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL
+          - powershell: |
+              $InstallerArguments = "modify --quiet --norestart --productId Microsoft.VisualStudio.Product.Enterprise --channelId VisualStudio.17.Release --add Microsoft.VisualStudio.Component.VC.14.31.17.1.x86.x64 --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL"
+              Start-Process -FilePath "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe" -Wait -ArgumentList $InstallerArguments
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
@@ -758,12 +755,9 @@ stages:
             fetchDepth: 1
           - checkout: apple/swift-experimental-string-processing
             fetchDepth: 1
-          - script: |
-              start /w "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vs_installer.exe" modify --quiet --norestart ^
-               --productId Microsoft.VisualStudio.Product.Enterprise ^
-               --channelId VisualStudio.17.Release ^
-               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.x86.x64 ^
-               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL
+          - powershell: |
+              $InstallerArguments = "modify --quiet --norestart --productId Microsoft.VisualStudio.Product.Enterprise --channelId VisualStudio.17.Release --add Microsoft.VisualStudio.Component.VC.14.31.17.1.x86.x64 --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL"
+              Start-Process -FilePath "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe" -Wait -ArgumentList $InstallerArguments
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (

--- a/.ci/vs2022.yml
+++ b/.ci/vs2022.yml
@@ -258,18 +258,14 @@ stages:
             fetchDepth: 1
           - checkout: apple/swift-experimental-string-processing
             fetchDepth: 1
-          - script: |
-              if "$(arch)"=="arm64" (
-                set ARCH_COMPONENT="ARM64"
-              ) else (
-                set ARCH_COMPONENT="x86.x64"
-              )
-
-              start /w "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vs_installer.exe" modify --quiet --norestart ^
-               --productId Microsoft.VisualStudio.Product.Enterprise ^
-               --channelId VisualStudio.17.Release ^
-               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.%ARCH_COMPONENT% ^
-               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL
+          - powershell: |
+              if ("$(arch)" -eq "amd64") {
+                $ArchComponent = "x86.x64"
+              } else {
+                $ArchComponent = "ARM64"
+              }
+              $InstallerArguments = "modify --quiet --norestart --productId Microsoft.VisualStudio.Product.Enterprise --channelId VisualStudio.17.Release --add Microsoft.VisualStudio.Component.VC.14.31.17.1.$ArchComponent --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL"
+              Start-Process -FilePath "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe" -Wait -ArgumentList $InstallerArguments
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
@@ -777,18 +773,14 @@ stages:
             fetchDepth: 1
           - checkout: apple/swift-experimental-string-processing
             fetchDepth: 1
-          - script: |
-              if "$(arch)"=="arm64" (
-                set ARCH_COMPONENT="ARM64"
-              ) else (
-                set ARCH_COMPONENT="x86.x64"
-              )
-
-              start /w "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vs_installer.exe" modify --quiet --norestart ^
-               --productId Microsoft.VisualStudio.Product.Enterprise ^
-               --channelId VisualStudio.17.Release ^
-               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.%ARCH_COMPONENT% ^
-               --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL
+          - powershell: |
+              if ("$(arch)" -eq "amd64") {
+                $ArchComponent = "x86.x64"
+              } else {
+                $ArchComponent = "ARM64"
+              }
+              $InstallerArguments = "modify --quiet --norestart --productId Microsoft.VisualStudio.Product.Enterprise --channelId VisualStudio.17.Release --add Microsoft.VisualStudio.Component.VC.14.31.17.1.$ArchComponent --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL"
+              Start-Process -FilePath "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe" -Wait -ArgumentList $InstallerArguments
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (


### PR DESCRIPTION
`start /w` in cmd.exe behaves weirdly with VS installer, i.e. it could wait forever. I got more stable results with powershell `Start-Process` command.