### PR TITLE
VS2022: enable packaging the SDK & runtime for i686

### DIFF
--- a/.ci/vs2022.yml
+++ b/.ci/vs2022.yml
@@ -1525,9 +1525,9 @@ stages:
       - job: build
         strategy:
           matrix:
-            # 'x86':
-            #   arch: x86
-            #   platform: x86
+            'x86':
+              arch: x86
+              platform: x86
             'x64':
               arch: amd64
               platform: x64


### PR DESCRIPTION
Enable the i686 Windows SDK and runtime packaging.  These are not fully ready
for consumption due to ABI issues in the compiler, however, the packaging can
be prepared in spite of that.  This lays the groundwork for the platform arch
once the compiler issues are resolved.