### PR TITLE
vs2022: force python x64

### DIFF
--- a/.ci/vs2022-swift-5.5.yml
+++ b/.ci/vs2022-swift-5.5.yml
@@ -222,6 +222,7 @@ stages:
             'x64':
               arch: amd64
               platform: x64
+              EXTRA_CMAKE_ARGS: -D PYTHON_EXECUTABLE=$(PYTHON_EXECUTABLE) -D Python3_ROOT_DIR=$(PYTHON_ROOT) -D Python3_INCLUDE_DIR=$(PYTHON_ROOT)/include -D Python3_LIBRARY=$(PYTHON_ROOT)/libs/python310.lib
             # TODO(compnerd) enable AArch64 SDK
             # 'arm64':
             #  arch: arm64
@@ -270,17 +271,34 @@ stages:
               filename: $(VsDevCmd)
               arguments: -no_logo -arch=$(arch) -host_arch=amd64 -vcvars_ver=14.31
               modifyEnvironment: true
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '3.10' 
+              addToPath: true 
+              architecture: 'x64'
           - script: |
               CALL :where python.exe PYTHON_EXECUTABLE
               FOR /F "tokens=* USEBACKQ" %%i IN (`cygpath -m "%PYTHON_EXECUTABLE%"`) DO (
                 SET PYTHON_EXECUTABLE=%%i
               )
               ECHO PYTHON_EXECUTABLE=%PYTHON_EXECUTABLE%
-              @echo ##vso[task.setvariable variable=PythonExecutable;]%PYTHON_EXECUTABLE%
+
+              CALL :getpath "%PYTHON_EXECUTABLE%" PYTHON_ROOT
+              FOR /F "tokens=* USEBACKQ" %%i IN (`cygpath -m "%PYTHON_ROOT%\"`) DO (
+                SET PYTHON_ROOT=%%i
+              )
+              ECHO PYTHON_ROOT=%PYTHON_ROOT%
+
+              @echo ##vso[task.setvariable variable=PYTHON_ROOT;]%PYTHON_ROOT%
+              @echo ##vso[task.setvariable variable=PYTHON_EXECUTABLE;]%PYTHON_EXECUTABLE%
               GOTO :eof
-              
+
               :where
               SET %2=%~$PATH:1
+              EXIT /b
+
+              :getpath
+              SET %2=%~dp1
               EXIT /b
             displayName: Find Python
           - script: |
@@ -340,7 +358,7 @@ stages:
                 -D SWIFT_BUILD_DYNAMIC_SDK_OVERLAY=NO
                 -D LLDB_USE_STATIC_BINDINGS=YES
                 -D SWIFT_CLANG_LOCATION="$(ClangLocation)"
-                -D PYTHON_EXECUTABLE="$(PythonExecutable)"
+                $(EXTRA_CMAKE_ARGS)
           - task: CMake@1
             inputs:
               cmakeArgs:

--- a/.ci/vs2022-swift-5.6.yml
+++ b/.ci/vs2022-swift-5.6.yml
@@ -231,7 +231,8 @@ stages:
           matrix:
             'x64':
               arch: amd64
-              platform: x64
+              platform: x86_64
+              EXTRA_CMAKE_ARGS: -D Python3_ROOT_DIR=$(PYTHON_ROOT) -D Python3_INCLUDE_DIR=$(PYTHON_ROOT)/include -D Python3_LIBRARY=$(PYTHON_ROOT)/libs/python310.lib
             # TODO(compnerd) enable AArch64 SDK
             # 'arm64':
             #  arch: arm64
@@ -268,6 +269,36 @@ stages:
               filename: $(VsDevCmd)
               arguments: -no_logo -arch=$(arch) -host_arch=amd64 -vcvars_ver=14.31
               modifyEnvironment: true
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '3.10' 
+              addToPath: true 
+              architecture: 'x64'
+          - script: |
+              CALL :where python.exe PYTHON_EXECUTABLE
+              FOR /F "tokens=* USEBACKQ" %%i IN (`cygpath -m "%PYTHON_EXECUTABLE%"`) DO (
+                SET PYTHON_EXECUTABLE=%%i
+              )
+              ECHO PYTHON_EXECUTABLE=%PYTHON_EXECUTABLE%
+
+              CALL :getpath "%PYTHON_EXECUTABLE%" PYTHON_ROOT
+              FOR /F "tokens=* USEBACKQ" %%i IN (`cygpath -m "%PYTHON_ROOT%\"`) DO (
+                SET PYTHON_ROOT=%%i
+              )
+              ECHO PYTHON_ROOT=%PYTHON_ROOT%
+
+              @echo ##vso[task.setvariable variable=PYTHON_ROOT;]%PYTHON_ROOT%
+              GOTO :eof
+
+              :where
+              SET %2=%~$PATH:1
+              EXIT /b
+
+              :getpath
+              SET %2=%~dp1
+              EXIT /b
+            displayName: Find Python
+            condition: eq(variables['platform'], 'x86_64')
           - task: CMake@1
             inputs:
               cmakeArgs:
@@ -304,6 +335,7 @@ stages:
                 -D SWIFT_PARALLEL_LINK_JOBS=2
                 -D SWIFT_BUILD_DYNAMIC_STDLIB=NO
                 -D SWIFT_BUILD_DYNAMIC_SDK_OVERLAY=NO
+                $(EXTRA_CMAKE_ARGS)
           - task: CMake@1
             inputs:
               cmakeArgs:

--- a/.ci/vs2022-swift-5.7.yml
+++ b/.ci/vs2022-swift-5.7.yml
@@ -236,7 +236,8 @@ stages:
           matrix:
             'x64':
               arch: amd64
-              platform: x64
+              platform: x86_64
+              EXTRA_CMAKE_ARGS: -D Python3_ROOT_DIR=$(PYTHON_ROOT) -D Python3_INCLUDE_DIR=$(PYTHON_ROOT)/include -D Python3_LIBRARY=$(PYTHON_ROOT)/libs/python310.lib
             # TODO(compnerd) enable AArch64 SDK
             # 'arm64':
             #  arch: arm64
@@ -275,6 +276,36 @@ stages:
               filename: $(VsDevCmd)
               arguments: -no_logo -arch=$(arch) -host_arch=amd64 -vcvars_ver=14.31
               modifyEnvironment: true
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '3.10' 
+              addToPath: true 
+              architecture: 'x64'
+          - script: |
+              CALL :where python.exe PYTHON_EXECUTABLE
+              FOR /F "tokens=* USEBACKQ" %%i IN (`cygpath -m "%PYTHON_EXECUTABLE%"`) DO (
+                SET PYTHON_EXECUTABLE=%%i
+              )
+              ECHO PYTHON_EXECUTABLE=%PYTHON_EXECUTABLE%
+
+              CALL :getpath "%PYTHON_EXECUTABLE%" PYTHON_ROOT
+              FOR /F "tokens=* USEBACKQ" %%i IN (`cygpath -m "%PYTHON_ROOT%\"`) DO (
+                SET PYTHON_ROOT=%%i
+              )
+              ECHO PYTHON_ROOT=%PYTHON_ROOT%
+
+              @echo ##vso[task.setvariable variable=PYTHON_ROOT;]%PYTHON_ROOT%
+              GOTO :eof
+
+              :where
+              SET %2=%~$PATH:1
+              EXIT /b
+
+              :getpath
+              SET %2=%~dp1
+              EXIT /b
+            displayName: Find Python
+            condition: eq(variables['platform'], 'x86_64')
           - task: CMake@1
             inputs:
               cmakeArgs:
@@ -314,6 +345,7 @@ stages:
                 -D SWIFT_PARALLEL_LINK_JOBS=2
                 -D SWIFT_BUILD_DYNAMIC_STDLIB=NO
                 -D SWIFT_BUILD_DYNAMIC_SDK_OVERLAY=NO
+                $(EXTRA_CMAKE_ARGS)
           - task: CMake@1
             inputs:
               cmakeArgs:

--- a/.ci/vs2022.yml
+++ b/.ci/vs2022.yml
@@ -237,7 +237,7 @@ stages:
             'x64':
               arch: amd64
               platform: x86_64
-              EXTRA_CMAKE_ARGS: 
+              EXTRA_CMAKE_ARGS: -D Python3_ROOT_DIR=$(PYTHON_ROOT) -D Python3_INCLUDE_DIR=$(PYTHON_ROOT)/include -D Python3_LIBRARY=$(PYTHON_ROOT)/libs/python310.lib
             'arm64':
               arch: arm64
               platform: arm64
@@ -300,6 +300,31 @@ stages:
                   (Get-Content $stdatomic).replace('#if __STDC_HOSTED__ && __has_include_next(<stdatomic.h>)', '#if 0') | Set-Content $stdatomic
                 }
             condition: eq(variables['platform'], 'arm64')
+          - script: |
+              CALL :where python.exe PYTHON_EXECUTABLE
+              FOR /F "tokens=* USEBACKQ" %%i IN (`cygpath -m "%PYTHON_EXECUTABLE%"`) DO (
+                SET PYTHON_EXECUTABLE=%%i
+              )
+              ECHO PYTHON_EXECUTABLE=%PYTHON_EXECUTABLE%
+
+              CALL :getpath "%PYTHON_EXECUTABLE%" PYTHON_ROOT
+              FOR /F "tokens=* USEBACKQ" %%i IN (`cygpath -m "%PYTHON_ROOT%\"`) DO (
+                SET PYTHON_ROOT=%%i
+              )
+              ECHO PYTHON_ROOT=%PYTHON_ROOT%
+
+              @echo ##vso[task.setvariable variable=PYTHON_ROOT;]%PYTHON_ROOT%
+              GOTO :eof
+
+              :where
+              SET %2=%~$PATH:1
+              EXIT /b
+
+              :getpath
+              SET %2=%~dp1
+              EXIT /b
+            displayName: Find Python
+            condition: eq(variables['platform'], 'x86_64')
           - task: CMake@1
             inputs:
               cmakeArgs:

--- a/.ci/vs2022.yml
+++ b/.ci/vs2022.yml
@@ -283,6 +283,11 @@ stages:
               filename: $(VsDevCmd)
               arguments: -no_logo -arch=$(arch) -host_arch=amd64 -vcvars_ver=14.31
               modifyEnvironment: true
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '3.10' 
+              addToPath: true 
+              architecture: 'x64'
           - task: PowerShell@2
             inputs:
               targetType: 'inline'


### PR DESCRIPTION
Latest builds are broken because agent uses python x86 for some reason. In the build logs I see this:
```
-- Found Python3: C:/hostedtoolcache/windows/Python/3.10.6/x86/python3.exe (found suitable version "3.10.6", minimum required is "3.6") found components: Interpreter 
```

Let's try to force the x64 version. I didn't actually try this with Swift pipeline, so there are chances it would not help. In theory, `UsePythonVersion` task would set up the requested Python version and add it to the PATH. And then CMake should just pick it up for toolchain config.
