### PR TITLE
Adopt renamed swift-def tool converter

### DIFF
--- a/.ci/vs2022.yml
+++ b/.ci/vs2022.yml
@@ -208,7 +208,7 @@ stages:
           - task: CMake@1
             inputs:
               cmakeArgs:
-                --build $(Agent.BuildDirectory)/0 --target swift-def-to-yaml-converter
+                --build $(Agent.BuildDirectory)/0 --target swift-def-to-strings-converter
           - task: CMake@1
             inputs:
              cmakeArgs:
@@ -221,7 +221,7 @@ stages:
                 bin/clang-tblgen.exe
                 bin/lldb-tblgen.exe
                 bin/llvm-config.exe
-                bin/swift-def-to-yaml-converter.exe
+                bin/swift-def-to-strings-converter.exe
                 bin/swift-serialize-diagnostics.exe
               TargetFolder: $(Build.StagingDirectory)/build-tools
           - publish: $(Build.StagingDirectory)/build-tools


### PR DESCRIPTION
Looks like `swift-def-to-yaml-converter` is now `swift-def-to-strings-converter`.