### PR TITLE
vs2022: use latest MSVC toolset

### DIFF
--- a/.ci/vs2022.yml
+++ b/.ci/vs2022.yml
@@ -267,16 +267,6 @@ stages:
             fetchDepth: 1
           - checkout: apple/swift-syntax
             fetchDepth: 1
-          - powershell: |
-              if ("$(arch)" -eq "amd64") {
-                $ArchComponent = ".x86.x64"
-                $AtlArchComponent = ""
-              } else {
-                $ArchComponent = ".ARM64"
-                $AtlArchComponent = ".ARM64"
-              }
-              $InstallerArguments = "modify --quiet --norestart --productId Microsoft.VisualStudio.Product.Enterprise --channelId VisualStudio.17.Release --add Microsoft.VisualStudio.Component.VC.14.31.17.1$ArchComponent --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL$AtlArchComponent"
-              Start-Process -FilePath "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe" -Wait -ArgumentList $InstallerArguments
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
@@ -290,7 +280,7 @@ stages:
           - task: BatchScript@1
             inputs:
               filename: $(VsDevCmd)
-              arguments: -no_logo -arch=$(arch) -host_arch=amd64 -vcvars_ver=14.31
+              arguments: -no_logo -arch=$(arch) -host_arch=amd64
               modifyEnvironment: true
           - task: UsePythonVersion@0
             inputs:
@@ -411,9 +401,6 @@ stages:
             fetchDepth: 1
           - script: |
               copy $(Build.SourcesDirectory)\swift-installer-scripts\shared\ICU\CMakeLists.txt $(Build.SourcesDirectory)\icu\icu4c\CMakeLists.txt
-          - powershell: |
-              $InstallerArguments = "modify --quiet --norestart --productId Microsoft.VisualStudio.Product.Enterprise --channelId VisualStudio.17.Release --add Microsoft.VisualStudio.Component.VC.14.31.17.1.x86.x64 --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ARM64 --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL.ARM64"
-              Start-Process -FilePath "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe" -Wait -ArgumentList $InstallerArguments
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
@@ -427,7 +414,7 @@ stages:
           - task: BatchScript@1
             inputs:
               filename: $(VsDevCmd)
-              arguments: -no_logo -arch=amd64 -host_arch=amd64 -vcvars_ver=14.31
+              arguments: -no_logo -arch=amd64 -host_arch=amd64
               modifyEnvironment: true
             condition: eq(variables['BUILD_TOOLS'], 'NO')
           - task: CMake@1
@@ -454,7 +441,7 @@ stages:
           - task: BatchScript@1
             inputs:
               filename: $(VsDevCmd)
-              arguments: -no_logo -arch=$(arch) -host_arch=amd64 -vcvars_ver=14.31
+              arguments: -no_logo -arch=$(arch) -host_arch=amd64
               modifyEnvironment: true
           - task: CMake@1
             inputs:
@@ -820,16 +807,6 @@ stages:
             fetchDepth: 1
           - checkout: apple/swift-syntax
             fetchDepth: 1
-          - powershell: |
-              if ("$(arch)" -eq "amd64" -Or "$(arch)" -eq "x86") {
-                $ArchComponent = ".x86.x64"
-                $AtlArchComponent = ""
-              } else {
-                $ArchComponent = ".ARM64"
-                $AtlArchComponent = ".ARM64"
-              }
-              $InstallerArguments = "modify --quiet --norestart --productId Microsoft.VisualStudio.Product.Enterprise --channelId VisualStudio.17.Release --add Microsoft.VisualStudio.Component.VC.14.31.17.1$ArchComponent --add Microsoft.VisualStudio.Component.VC.14.31.17.1.ATL$AtlArchComponent"
-              Start-Process -FilePath "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe" -Wait -ArgumentList $InstallerArguments
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
@@ -843,7 +820,7 @@ stages:
           - task: BatchScript@1
             inputs:
               filename: $(VsDevCmd)
-              arguments: -no_logo -arch=$(arch) -host_arch=amd64 -vcvars_ver=14.31
+              arguments: -no_logo -arch=$(arch) -host_arch=amd64
               modifyEnvironment: true
           - task: PowerShell@2
             inputs:


### PR DESCRIPTION
Tested locally with Visual Studio 17.3.4, it seems the toolset incompatibility problem has gone.

However, this release hasn't been rolled into the runner image yet, so we need to hold on to next release date to verify it on CI.