### PR TITLE
[vs2022] build swift-compatibility-symbols tool

### DIFF
--- a/.ci/vs2022.yml
+++ b/.ci/vs2022.yml
@@ -220,6 +220,10 @@ stages:
             inputs:
              cmakeArgs:
                --build $(Agent.BuildDirectory)/0 --target swift-serialize-diagnostics
+          - task: CMake@1
+            inputs:
+             cmakeArgs:
+               --build $(Agent.BuildDirectory)/0 --target swift-compatibility-symbols
           - task: CopyFiles@2
             inputs:
               SourceFolder: $(Agent.BuildDirectory)/0
@@ -230,6 +234,7 @@ stages:
                 bin/llvm-config.exe
                 bin/swift-def-to-strings-converter.exe
                 bin/swift-serialize-diagnostics.exe
+                bin/swift-compatibility-symbols.exe
               TargetFolder: $(Build.StagingDirectory)/build-tools
           - publish: $(Build.StagingDirectory)/build-tools
             artifact: build-tools


### PR DESCRIPTION
Looks like we need one more tool now.