### PR TITLE
Update swift-toolchain.yml

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1487,7 +1487,7 @@ jobs:
           ref: refs/heads/main
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
 
-      - uses: microsoft/setup-msbuild@v1.0.3
+      - uses: microsoft/setup-msbuild@v1.1.3
 
       - name: Package
         run: |
@@ -1602,7 +1602,7 @@ jobs:
           ref: refs/heads/main
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
 
-      - uses: microsoft/setup-msbuild@v1.0.3
+      - uses: microsoft/setup-msbuild@v1.1.3
 
       - name: Package
         run: |
@@ -1654,7 +1654,7 @@ jobs:
           ref: refs/heads/main
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
 
-      - uses: microsoft/setup-msbuild@v1.0.3
+      - uses: microsoft/setup-msbuild@v1.1.3
 
       - name: Package
         run: |


### PR DESCRIPTION
Bump up the version of `setup-msbuild` to avoid the deprecation warnings from GitHub.