### PR TITLE
CI: switch Yams to static linking on Windows

### DIFF
--- a/.ci/vs2022.yml
+++ b/.ci/vs2022.yml
@@ -1170,7 +1170,7 @@ stages:
             inputs:
              cmakeArgs:
                -B $(Agent.BuildDirectory)/Yams
-               -D BUILD_SHARED_LIBS=YES
+               -D BUILD_SHARED_LIBS=NO
                -D BUILD_TESTING=NO
                -D CMAKE_BUILD_TYPE=Release
                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
@@ -1425,10 +1425,6 @@ stages:
             inputs:
               cmakeArgs:
                 --build $(Agent.BuildDirectory)/swift-crypto --target install
-          - task: CMake@1
-            inputs:
-              cmakeArgs:
-                --build $(Agent.BuildDirectory)/Yams --target install
           - task: CMake@1
             inputs:
               cmakeArgs:

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1134,7 +1134,7 @@ jobs:
           $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
 
           cmake -B ${{ github.workspace }}/BinaryCache/yams `
-                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_SHARED_LIBS=NO `
                 -D BUILD_TESTING=NO `
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
@@ -1414,8 +1414,6 @@ jobs:
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-collections --target install
       - name: Install swift-crypto
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-crypto --target install
-      - name: Install Yams
-        run: cmake --build ${{ github.workspace }}/BinaryCache/yams --target install
       - name: Install swift-llbuild
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-llbuild --target install
       - name: Install swift-system


### PR DESCRIPTION
```
dynamic:
  2,313,728 SwiftDriver.dll
    623,616 Yams.dll
static:
  2,712,064 SwiftDriver.dll
```

This saves 225,280 bytes in the actual release build.