### PR TITLE
Update swift-format.yml

### DIFF
--- a/.github/workflows/swift-format.yml
+++ b/.github/workflows/swift-format.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: package
         run: |
-          msbuild ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/swift-format.wixproj -nologo -p:Configuration=Release -p:ProductVersion=5.7.2 -p:SWIFT_FORMAT_BUILD=${{ github.workspace }}\SourceCache\swift-format\.build\release -p:OutputPath=${{ github.workspace }}\artifacts -p:RunWixToolsOutOfProc=true
+          msbuild ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/swift-format.wixproj -nologo -p:Configuration=Release -p:ProductVersion=5.7.2 -p:SWIFT_FORMAT_BUILD=${{ github.workspace }}\.build\release -p:OutputPath=${{ github.workspace }}\artifacts -p:RunWixToolsOutOfProc=true
 
       # Release
       - uses: actions/create-release@v1


### PR DESCRIPTION
Apply a variety of changes to the swift-format build.  We now use the swift-installer-scripts repository to package the code formatter into a distributable MSI.  Update the product version tag in the package.

Hoist the checkout steps to the initial operations rather than delaying the location as this was done to workaround the `swift build` invocation.  Instead we now explicitly change to the appropriate location prior to building.