### PR TITLE
GHA,Azure: begin migration towards unadulterated Visual Studio

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -829,14 +829,6 @@ stages:
               filename: $(VsDevCmd)
               arguments: -no_logo -arch=$(arch) -host_arch=amd64
               modifyEnvironment: true
-          - task: PowerShell@2
-            inputs:
-              targetType: inline
-              script: |
-                Copy-Item "$(Build.SourcesDirectory)\swift\stdlib\public\Platform\ucrt.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\ucrt\module.modulemap"
-                Copy-Item "$(Build.SourcesDirectory)\swift\stdlib\public\Platform\vcruntime.modulemap" -destination "$env:VCToolsInstallDir\include\module.modulemap"
-                Copy-Item "$(Build.SourcesDirectory)\swift\stdlib\public\Platform\vcruntime.apinotes" -destination "$env:VCToolsInstallDir\include\vcruntime.apinotes"
-                Copy-Item "$(Build.SourcesDirectory)\swift\stdlib\public\Platform\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
           - bash: |
               echo "##vso[task.setvariable variable=root;isOutput=true]$(cygpath -m '$(Pipeline.Workspace)')"
             name: workspace
@@ -913,7 +905,7 @@ stages:
                 -D CMAKE_SYSTEM_PROCESSOR=$(platform)
                 -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
+                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Agent.BuildDirectory)/swift/stdlib/windows-vfs-overlay.yaml"
                 -G Ninja
                 -S $(Build.SourcesDirectory)/swift-corelibs-libdispatch
                 -D BUILD_TESTING=NO
@@ -942,7 +934,7 @@ stages:
                 -D CMAKE_SYSTEM_PROCESSOR=$(platform)
                 -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
+                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Agent.BuildDirectory)/swift/stdlib/windows-vfs-overlay.yaml"
                 -G Ninja
                 -S $(Build.SourcesDirectory)/swift-corelibs-foundation
                 -D BUILD_TESTING=NO
@@ -979,7 +971,7 @@ stages:
                 -D CMAKE_SYSTEM_PROCESSOR=$(platform)
                 -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
+                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Agent.BuildDirectory)/swift/stdlib/windows-vfs-overlay.yaml"
                 -G Ninja
                 -S $(Build.SourcesDirectory)/swift-corelibs-xctest
                 -D BUILD_TESTING=NO

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -473,13 +473,6 @@ jobs:
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
-      - name: 'Copy Support Files'
-        run: |
-          Copy-Item "${{ github.workspace }}\SourceCache\swift\stdlib\public\Platform\ucrt.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\ucrt\module.modulemap"
-          Copy-Item "${{ github.workspace }}\SourceCache\swift\stdlib\public\Platform\vcruntime.modulemap" -destination "$env:VCToolsInstallDir\include\module.modulemap"
-          Copy-Item "${{ github.workspace }}\SourceCache\swift\stdlib\public\Platform\vcruntime.apinotes" -destination "$env:VCToolsInstallDir\include\vcruntime.apinotes"
-          Copy-Item "${{ github.workspace }}\SourceCache\swift\stdlib\public\Platform\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
-
       # TODO(compnerd) switch this to Python 3.6.8
       - name: Configure Toolchain
         run: |
@@ -827,13 +820,6 @@ jobs:
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
-      - name: 'Copy Support Files'
-        run: |
-          Copy-Item "${{ github.workspace }}\SourceCache\swift\stdlib\public\Platform\ucrt.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\ucrt\module.modulemap"
-          Copy-Item "${{ github.workspace }}\SourceCache\swift\stdlib\public\Platform\vcruntime.modulemap" -destination "$env:VCToolsInstallDir\include\module.modulemap"
-          Copy-Item "${{ github.workspace }}\SourceCache\swift\stdlib\public\Platform\vcruntime.apinotes" -destination "$env:VCToolsInstallDir\include\vcruntime.apinotes"
-          Copy-Item "${{ github.workspace }}\SourceCache\swift\stdlib\public\Platform\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
-
       - name: Configure LLVM
         run:
           cmake -B ${{ github.workspace }}/BinaryCache/llvm `
@@ -905,7 +891,7 @@ jobs:
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr `
                 -D CMAKE_SWIFT_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows" `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay ${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml" `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -D MSVC_C_ARCHITECTURE_ID=${{ matrix.arch }} `
@@ -938,7 +924,7 @@ jobs:
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows" `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay ${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml" `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -D MSVC_C_ARCHITECTURE_ID=${{ matrix.arch }} `
@@ -980,7 +966,7 @@ jobs:
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/Library/XCTest-development/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows" `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay ${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml" `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `


### PR DESCRIPTION
Begin the process of altering the build configuration to use the SDK generated VFS overlay.  The toolchain migration is a bit more complicated as the VFS overlay does not exist and needs to be generated.