### PR TITLE
Add SDKs param to script allowing building a subset of architectures

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -2,7 +2,7 @@
 # Copyright 2023 Tristan Labelle <tristan@thebrowser.company>
 
 param(
-  [string[]] $Archs = @("X64","X86","Arm64")
+  [string[]] $SDKs = @("X64","X86","Arm64")
 )
 
 $ErrorActionPreference = "Stop"
@@ -55,7 +55,7 @@ $HostArch = switch (${Env:PROCESSOR_ARCHITECTURE}) {
 }
 
 # Resolve the architectures received as argument
-[hashtable[]]$Archs = $Archs | ForEach-Object {
+$SDKArchs = $SDKs | ForEach-Object {
   switch ($_) {
     "X64" { $ArchX64 }
     "X86" { $ArchX86 }
@@ -916,7 +916,7 @@ function Build-SourceKitLSP($Arch)
 
 Build-Compilers $HostArch
 
-foreach ($Arch in $Archs)
+foreach ($Arch in $SDKArchs)
 {
   Build-ZLib $Arch
   Build-XML2 $Arch

--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,10 @@
 # Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
 # Copyright 2023 Tristan Labelle <tristan@thebrowser.company>
 
+param(
+  [string[]] $Archs = @("X64","X86","Arm64")
+)
+
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 3.0
 
@@ -48,6 +52,16 @@ $ArchARM64 = @{
 $HostArch = switch (${Env:PROCESSOR_ARCHITECTURE}) {
   'ARM64' { $ArchARM64 }
   default { $ArchX64 }
+}
+
+# Resolve the architectures received as argument
+[hashtable[]]$Archs = $Archs | ForEach-Object {
+  switch ($_) {
+    "X64" { $ArchX64 }
+    "X86" { $ArchX86 }
+    "Arm64" { $ArchArm64 }
+    default { throw "Unknown architecture $_" }
+  }
 }
 
 $CurrentVSDevShellTargetArch = $null
@@ -902,7 +916,7 @@ function Build-SourceKitLSP($Arch)
 
 Build-Compilers $HostArch
 
-foreach ($Arch in $ArchX64,$ArchX86,$ArchARM64)
+foreach ($Arch in $Archs)
 {
   Build-ZLib $Arch
   Build-XML2 $Arch


### PR DESCRIPTION
This allows calling the script with `build -SDKs X64,X86` to build only for a subset of architectures.