### PR TITLE
GHA,Azure: alter terminology for upcoming restructuring

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -238,7 +238,7 @@ stages:
           - publish: $(Build.StagingDirectory)/build-tools
             artifact: build-tools
 
-  - stage: toolchain
+  - stage: compilers
     dependsOn: [tools]
     jobs:
       - job: build
@@ -381,7 +381,7 @@ stages:
               cmakeArgs:
                 --build $(Agent.BuildDirectory)/1 --target install-distribution-stripped
           - publish: $(Build.StagingDirectory)
-            artifact: toolchain-$(arch)
+            artifact: compilers-$(arch)
 
   - stage: icu
     dependsOn: []
@@ -772,7 +772,7 @@ stages:
             artifact: libxml2-$(arch)-2.9.12
 
   - stage: sdk
-    dependsOn: [icu, libxml2, curl, zlib, toolchain]
+    dependsOn: [icu, libxml2, curl, zlib, compilers]
     jobs:
       - job: build
         strategy:
@@ -799,7 +799,7 @@ stages:
           - download: current
             artifact: zlib-$(arch)-1.2.11
           - download: current
-            artifact: toolchain-amd64
+            artifact: compilers-amd64
           - checkout: apple/llvm-project
             fetchDepth: 1
           - checkout: apple/swift
@@ -862,10 +862,10 @@ stages:
                 -B $(Agent.BuildDirectory)/swift
                 -C $(Build.SourcesDirectory)/swift/cmake/caches/Runtime-Windows-$(platform).cmake
                 -D CMAKE_BUILD_TYPE=Release
-                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_C_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                 -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                 -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-                -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_CXX_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                 -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                 -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
                 -D CMAKE_MT=mt
@@ -876,7 +876,7 @@ stages:
                 -S $(Build.SourcesDirectory)/swift
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                 -D LLVM_DIR=$(Agent.BuildDirectory)/llvm/lib/cmake/llvm
-                -D SWIFT_NATIVE_SWIFT_TOOLS_PATH=$(Workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin
+                -D SWIFT_NATIVE_SWIFT_TOOLS_PATH=$(Workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin
                 -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE=$(Build.SourcesDirectory)/swift-corelibs-libdispatch
                 -D SWIFT_PATH_TO_STRING_PROCESSING_SOURCE=$(Build.SourcesDirectory)/swift-experimental-string-processing
                 -D SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=YES
@@ -901,17 +901,17 @@ stages:
                 -B $(Agent.BuildDirectory)/libdispatch
                 -D BUILD_SHARED_LIBS=YES
                 -D CMAKE_BUILD_TYPE=Release
-                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_C_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                 -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                 -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-                -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_CXX_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                 -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                 -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
                 -D CMAKE_MT=mt
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr
                 -D CMAKE_SYSTEM_NAME=Windows
                 -D CMAKE_SYSTEM_PROCESSOR=$(platform)
-                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+                -D CMAKE_Swift_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                 -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
                 -G Ninja
@@ -928,10 +928,10 @@ stages:
                 -B $(Agent.BuildDirectory)/foundation
                 -D BUILD_SHARED_LIBS=YES
                 -D CMAKE_BUILD_TYPE=Release
-                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_C_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                 -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                 -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-                -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_CXX_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                 -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                 -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
                 -D CMAKE_ASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreadedDLL="/MD"
@@ -940,7 +940,7 @@ stages:
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr
                 -D CMAKE_SYSTEM_NAME=Windows
                 -D CMAKE_SYSTEM_PROCESSOR=$(platform)
-                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+                -D CMAKE_Swift_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                 -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
                 -G Ninja
@@ -967,17 +967,17 @@ stages:
                 -B $(Agent.BuildDirectory)/xctest
                 -D BUILD_SHARED_LIBS=YES
                 -D CMAKE_BUILD_TYPE=Release
-                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_C_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                 -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                 -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-                -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_CXX_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                 -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                 -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
                 -D CMAKE_MT=mt
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/Library/XCTest-development/usr
                 -D CMAKE_SYSTEM_NAME=Windows
                 -D CMAKE_SYSTEM_PROCESSOR=$(platform)
-                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+                -D CMAKE_Swift_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                 -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
                 -G Ninja
@@ -1023,7 +1023,7 @@ stages:
             artifact: windows-sdk-$(arch)
 
   - stage: devtools
-    dependsOn: [sqlite, toolchain, sdk]
+    dependsOn: [sqlite, compilers, sdk]
     jobs:
       - job: build
         strategy:
@@ -1041,7 +1041,7 @@ stages:
           - download: current
             artifact: sqlite-$(arch)-3.36.0
           - download: current
-            artifact: toolchain-amd64
+            artifact: compilers-amd64
           - download: current
             artifact: windows-sdk-$(arch)
           - checkout: apple/indexstore-db
@@ -1103,15 +1103,15 @@ stages:
                -D BUILD_SHARED_LIBS=YES
                -D BUILD_TESTING=NO
                -D CMAKE_BUILD_TYPE=Release
-               -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_C_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-               -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_CXX_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
                -D CMAKE_MT=mt
                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-               -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+               -D CMAKE_Swift_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
                -G Ninja
@@ -1127,15 +1127,15 @@ stages:
                -D BUILD_SHARED_LIBS=YES
                -D BUILD_TESTING=NO
                -D CMAKE_BUILD_TYPE=Release
-               -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_C_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-               -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_CXX_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
                -D CMAKE_MT=mt
                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-               -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+               -D CMAKE_Swift_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
                -G Ninja
@@ -1151,15 +1151,15 @@ stages:
                -D BUILD_SHARED_LIBS=YES
                -D BUILD_TESTING=NO
                -D CMAKE_BUILD_TYPE=Release
-               -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_C_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-               -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_CXX_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
                -D CMAKE_MT=mt
                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-               -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+               -D CMAKE_Swift_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
                -G Ninja
@@ -1175,15 +1175,15 @@ stages:
                -D BUILD_SHARED_LIBS=NO
                -D BUILD_TESTING=NO
                -D CMAKE_BUILD_TYPE=Release
-               -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_C_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-               -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_CXX_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
                -D CMAKE_MT=mt
                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-               -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+               -D CMAKE_Swift_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
                -G Ninja
@@ -1199,15 +1199,15 @@ stages:
                -D BUILD_SHARED_LIBS=YES
                -D BUILD_TESTING=NO
                -D CMAKE_BUILD_TYPE=Release
-               -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_C_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code"
-               -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_CXX_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code"
                -D CMAKE_MT=mt
                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-               -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+               -D CMAKE_Swift_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
                -G Ninja
@@ -1226,15 +1226,15 @@ stages:
                -D BUILD_SHARED_LIBS=YES
                -D BUILD_TESTING=NO
                -D CMAKE_BUILD_TYPE=Release
-               -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_C_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-               -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_CXX_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
                -D CMAKE_MT=mt
                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-               -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+               -D CMAKE_Swift_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
                -G Ninja
@@ -1250,15 +1250,15 @@ stages:
                -D BUILD_SHARED_LIBS=YES
                -D BUILD_TESTING=NO
                -D CMAKE_BUILD_TYPE=Release
-               -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_C_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-               -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_CXX_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
                -D CMAKE_MT=mt
                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-               -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+               -D CMAKE_Swift_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
                -G Ninja
@@ -1277,15 +1277,15 @@ stages:
                -D BUILD_SHARED_LIBS=YES
                -D BUILD_TESTING=NO
                -D CMAKE_BUILD_TYPE=Release
-               -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_C_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-               -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_CXX_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
                -D CMAKE_MT=mt
                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-               -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+               -D CMAKE_Swift_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
                -G Ninja
@@ -1308,15 +1308,15 @@ stages:
                -D BUILD_SHARED_LIBS=YES
                -D BUILD_TESTING=NO
                -D CMAKE_BUILD_TYPE=Release
-               -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_C_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-               -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_CXX_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
                -D CMAKE_MT=mt
                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-               -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+               -D CMAKE_Swift_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
                -G Ninja
@@ -1342,15 +1342,15 @@ stages:
                -D BUILD_SHARED_LIBS=YES
                -D BUILD_TESTING=NO
                -D CMAKE_BUILD_TYPE=Release
-               -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_C_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/Block"
-               -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_CXX_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/Block"
                -D CMAKE_MT=mt
                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-               -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+               -D CMAKE_Swift_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -I$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -I$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/Block"
                -G Ninja
@@ -1366,15 +1366,15 @@ stages:
                -D BUILD_SHARED_LIBS=NO
                -D BUILD_TESTING=NO
                -D CMAKE_BUILD_TYPE=Release
-               -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_C_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-               -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_CXX_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
                -D CMAKE_MT=mt
                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-               -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+               -D CMAKE_Swift_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
                -G Ninja
@@ -1390,15 +1390,15 @@ stages:
                -D BUILD_SHARED_LIBS=YES
                -D BUILD_TESTING=NO
                -D CMAKE_BUILD_TYPE=Release
-               -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_C_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code"
-               -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+               -D CMAKE_CXX_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code"
                -D CMAKE_MT=mt
                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-               -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+               -D CMAKE_Swift_COMPILER=$(workspace.root)/compilers-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
                -G Ninja
@@ -1458,9 +1458,9 @@ stages:
           - publish: $(Build.StagingDirectory)
             artifact: devtools-$(arch)
 
-  - stage: package_toolchain
-    displayName: Toolchain MSI
-    dependsOn: [toolchain, devtools]
+  - stage: package_compilers
+    displayName: Compilers MSI
+    dependsOn: [compilers, devtools]
     jobs:
       - job: build
         strategy:
@@ -1468,13 +1468,13 @@ stages:
             'x64':
               arch: amd64
               platform: x64
-            # TODO(compnerd) enable AArch64 toolchain
+            # TODO(compnerd) enable AArch64 compilers
             # 'arm64':
             #  arch: arm64
             #  platform: aarch64
         steps:
           - download: current
-            artifact: toolchain-$(arch)
+            artifact: compilers-$(arch)
           - download: current
             artifact: devtools-$(arch)
           - checkout: apple/swift-installer-scripts
@@ -1495,7 +1495,7 @@ stages:
               msbuildArguments:
                 -p:RunWixToolsOutOfProc=true
                 -p:DEVTOOLS_ROOT=$(Pipeline.Workspace)/devtools-$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
-                -p:TOOLCHAIN_ROOT=$(Pipeline.Workspace)/toolchain-$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
+                -p:TOOLCHAIN_ROOT=$(Pipeline.Workspace)/compilers-$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
                 -p:IntermediateOutputPath=$(Agent.BuildDirectory)\
                 -p:OutputPath=$(Agent.BuildDirectory)\
           - script: |
@@ -1520,7 +1520,7 @@ stages:
           - script: |
               signtool sign /f $(certificate.secureFilePath) /p "$(CERTIFICATE_PASSWORD)" /tr http://timestamp.digicert.com /fd sha256 /td sha256 $(Agent.BuildDirectory)/toolchain.msi
           - publish: $(Agent.BuildDirectory)/toolchain.msi
-            artifact: toolchain-$(arch)-msi
+            artifact: compilers-$(arch)-msi
 
   - stage: package_sdk_runtime
     displayName: SDK/Runtime MSI
@@ -1679,7 +1679,7 @@ stages:
             artifact: devtools-$(arch)-msi
 
   - stage: installer
-    dependsOn: [package_toolchain, package_sdk_runtime, package_devtools]
+    dependsOn: [package_compilers, package_sdk_runtime, package_devtools]
     jobs:
       - job: build
         strategy:
@@ -1693,7 +1693,7 @@ stages:
             #  platform: aarch64
         steps:
           - download: current
-            artifact: toolchain-$(arch)-msi
+            artifact: compilers-$(arch)-msi
           - download: current
             artifact: runtime-windows-$(arch)-msi
           - download: current
@@ -1706,7 +1706,7 @@ stages:
             inputs:
               SourceFolder: $(Pipeline.Workspace)
               Contents: |
-                toolchain-$(arch)-msi/toolchain.msi
+                compilers-$(arch)-msi/toolchain.msi
                 runtime-windows-$(arch)-msi/runtime.msi
                 sdk-windows-$(arch)-msi/sdk.msi
                 devtools-$(arch)-msi/devtools.msi

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -385,7 +385,7 @@ jobs:
             ${{ github.workspace }}/BinaryCache/0/bin/swift-serialize-diagnostics.exe
             ${{ github.workspace }}/BinaryCache/0/bin/swift-compatibility-symbols.exe
 
-  toolchain:
+  compilers:
     runs-on: windows-latest
     needs: [context, build_tools]
 
@@ -550,7 +550,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: toolchain-${{ matrix.arch }}
+          name: compilers-${{ matrix.arch }}
           path: |
             ${{ github.workspace }}/BuildRoot/Library
             !${{ github.workspace }}/BuildRoot/Library/icu-69.1
@@ -559,7 +559,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: false # ${{ needs.context.outputs.debug_info }}
         with:
-          name: toolchain-${{ matrix.arch }}-debug-info
+          name: compilers-${{ matrix.arch }}-debug-info
           path: |
             ${{ github.workspace }}/BinaryCache/1/**/*.pdb
 
@@ -745,7 +745,7 @@ jobs:
   sdk:
     continue-on-error: ${{ matrix.arch != 'amd64' }}
     runs-on: windows-latest
-    needs: [context, icu, libxml2, curl, zlib, toolchain]
+    needs: [context, icu, libxml2, curl, zlib, compilers]
 
     strategy:
       fail-fast: false
@@ -782,7 +782,7 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library/zlib-1.2.11/usr
       - uses: actions/download-artifact@v3
         with:
-          name: toolchain-amd64
+          name: compilers-amd64
           path: ${{ github.workspace }}/BuildRoot/Library
 
       - uses: actions/checkout@v3
@@ -1023,7 +1023,7 @@ jobs:
 
   devtools:
     runs-on: windows-latest
-    needs: [context, sqlite, toolchain, sdk]
+    needs: [context, sqlite, compilers, sdk]
 
     strategy:
       fail-fast: false
@@ -1044,7 +1044,7 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library/sqlite-3.36.0/usr
       - uses: actions/download-artifact@v3
         with:
-          name: toolchain-amd64
+          name: compilers-amd64
           path: ${{ github.workspace }}/BuildRoot/Library
       - uses: actions/download-artifact@v3
         with:
@@ -1515,9 +1515,9 @@ jobs:
           name: devtools-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot-DevTools/Library
 
-  package_toolchain:
+  package_compilers:
     runs-on: windows-latest
-    needs: [context, toolchain, devtools]
+    needs: [context, compilers, devtools]
 
     strategy:
       fail-fast: false
@@ -1527,7 +1527,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: toolchain-${{ matrix.arch }}
+          name: compilers-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library
       - uses: actions/download-artifact@v3
         with:
@@ -1558,8 +1558,8 @@ jobs:
           msbuild -nologo `
               -p:Configuration=Release `
               -p:RunWixToolsOutOfProc=true `
-              -p:OutputPath=${{ github.workspace }}\BinaryCache\toolchain\ `
-              -p:IntermediateOutputPath=${{ github.workspace }}\BinaryCache\toolchain\obj\ `
+              -p:OutputPath=${{ github.workspace }}\BinaryCache\compilers\ `
+              -p:IntermediateOutputPath=${{ github.workspace }}\BinaryCache\compilers\obj\ `
               -p:SignOutput=true `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
@@ -1569,8 +1569,8 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: toolchain-${{ matrix.arch }}-msi
-          path: ${{ github.workspace }}/BinaryCache/toolchain/toolchain.msi
+          name: compilers-${{ matrix.arch }}-msi
+          path: ${{ github.workspace }}/BinaryCache/compilers/toolchain.msi
 
   package_sdk_runtime:
     runs-on: windows-latest
@@ -1710,7 +1710,7 @@ jobs:
 
   installer:
     runs-on: windows-latest
-    needs: [context, package_toolchain, package_sdk_runtime, package_devtools]
+    needs: [context, package_compilers, package_sdk_runtime, package_devtools]
 
     strategy:
       fail-fast: false
@@ -1720,7 +1720,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: toolchain-${{ matrix.arch }}-msi
+          name: compilers-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BuildRoot
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Prepare for some restructuring of the toolchain distribution to allow us to package things better for redistribution and installation purposes.