### PR TITLE
Specify CMAKE_Swift_COMPILER_TARGET when building the runtime

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -504,6 +504,7 @@ function Build-Runtime($Arch)
     -BuildDefaultTarget `
     -Defines @{
       CMAKE_INSTALL_BINDIR = Get-RuntimeInstallDir $Arch "usr\bin";
+      CMAKE_Swift_COMPILER_TARGET = $Arch.LLVMTarget;
       LLVM_DIR = "$LLVMBuildDir\lib\cmake\llvm";
       SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY = "YES";
       SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING = "YES";


### PR DESCRIPTION
This flag was missing when compared with the official build. See 
https://github.com/compnerd/swift-build/blob/67af2270d0b605f8c7691e32b2abf5b5bb298cec/.azure/vs2022.yml#L876