### PR TITLE
azure: various changes to the build rules

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -1352,7 +1352,7 @@ stages:
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                 -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
                 -G Ninja
-                -S $(Build.SourcesDirectory)/swift-package-manager
+                -S $(Build.SourcesDirectory)/swift-certificates
                 -D dispatch_DIR=$(Agent.BuildDirectory)/libdispatch/cmake/modules
                 -D Foundation_DIR=$(Agent.BuildDirectory)/foundation/cmake/modules
                 -D SwiftASN1_DIR=$(Agent.BuildDirectory)/swift-asn1/cmake/modules

--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -102,6 +102,16 @@ resources:
       name: apple/swift-tools-support-core
       ref: refs/heads/main
       type: github
+    - repository: apple/swift-asn1
+      endpoint: GitHub
+      name: apple/swift-asn1
+      ref: refs/heads/main
+      type: github
+    - repository: apple/swift-certificates
+      endpoint: GitHub
+      name: apple/swift-certificates
+      ref: refs/heads/main
+      type: github
     - repository: curl/curl
       endpoint: GitHub
       name: curl/curl
@@ -181,7 +191,7 @@ stages:
                 -S $(Build.SourcesDirectory)/llvm-project/llvm
                 -D LLVM_ENABLE_ASSERTIONS=NO
                 -D LLVM_ENABLE_LIBEDIT=NO
-                -D LLVM_ENABLE_PROJECTS="clang;lldb"
+                -D LLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lldb"
                 -D LLVM_EXTERNAL_PROJECTS="cmark;swift"
                 -D LLVM_EXTERNAL_CMARK_SOURCE_DIR=$(Build.SourcesDirectory)/swift-cmark
                 -D LLVM_EXTERNAL_SWIFT_SOURCE_DIR=$(Build.SourcesDirectory)/swift
@@ -203,6 +213,14 @@ stages:
             inputs:
               cmakeArgs:
                 --build $(Agent.BuildDirectory)/0 --target clang-tblgen
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                --build $(Agent.BuildDirectory)/0 --target clang-pseudo-gen
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                --build $(Agent.BuildDirectory)/0 --target clang-tidy-confusable-chars-gen
           - task: CMake@1
             inputs:
               cmakeArgs:
@@ -229,6 +247,8 @@ stages:
               Contents: |
                 bin/llvm-tblgen.exe
                 bin/clang-tblgen.exe
+                bin/clang-pseudo-gen.exe
+                bin/clang-tidy-confusable-chars-gen.exe
                 bin/lldb-tblgen.exe
                 bin/llvm-config.exe
                 bin/swift-def-to-strings-converter.exe
@@ -248,11 +268,11 @@ stages:
             'x64':
               arch: amd64
               platform: x86_64
-              EXTRA_CMAKE_ARGS: -D Python3_ROOT_DIR=$(PYTHON_ROOT) -D Python3_INCLUDE_DIR=$(PYTHON_ROOT)/include -D Python3_LIBRARY=$(PYTHON_ROOT)/libs/python310.lib -D LLDB_PYTHON_EXE_RELATIVE_PATH=python.exe -D LLDB_PYTHON_EXT_SUFFIX=.pyd
+              EXTRA_CMAKE_ARGS:
             'arm64':
               arch: arm64
               platform: arm64
-              EXTRA_CMAKE_ARGS: -D CMAKE_SYSTEM_NAME=Windows -D CMAKE_SYSTEM_PROCESSOR=ARM64 -D "SWIFT_CLANG_LOCATION=C:/Program Files/LLVM/bin" -D Python3_ROOT_DIR=$(PYTHON_ROOT) -D Python3_INCLUDE_DIR=$(PYTHON_ROOT)\include -D Python3_LIBRARY=$(PYTHON_ROOT)\libs\python310.lib -D LLDB_PYTHON_EXE_RELATIVE_PATH=python.exe -D LLDB_PYTHON_EXT_SUFFIX=.pyd
+              EXTRA_CMAKE_ARGS: -D CMAKE_SYSTEM_NAME=Windows -D CMAKE_SYSTEM_PROCESSOR=ARM64 -D "SWIFT_CLANG_LOCATION=C:/Program Files/LLVM/bin"
         steps:
           - download: current
             artifact: build-tools
@@ -342,34 +362,41 @@ stages:
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
                 -G Ninja
                 -S $(Build.SourcesDirectory)/llvm-project/llvm
-                -D PACKAGE_VENDOR=compnerd.org
-                -D CLANG_VENDOR=compnerd.org
-                -D CLANG_VENDOR_UTI=org.compnerd.dt
-                -D SWIFT_VENDOR=compnerd.org
-                -D LLVM_APPEND_VC_REV=NO
-                -D LLVM_VERSION_SUFFIX=""
-                -D LLDB_PYTHON_RELATIVE_PATH=lib/site-packages
+                -D CLANG_TABLEGEN=$(Pipeline.Workspace)/build-tools/bin/clang-tblgen.exe
+                -D CLANG_TIDY_CONFUSABLE_CHARS_GEN=$(Pipeline.Workspace)/build-tools/bin/clang-tidy-confusable-chars-gen.exe
+                -D LLDB_TABLEGEN=$(Pipeline.Workspace)/build-tools/bin/lldb-tblgen.exe
+                -D LLVM_CONFIG_PATH=$(Pipeline.Workspace)/build-tools/bin/llvm-config.exe
+                -D LLVM_EXTERNAL_CMARK_SOURCE_DIR=$(Build.SourcesDirectory)/swift-cmark
+                -D LLVM_EXTERNAL_SWIFT_SOURCE_DIR=$(Build.SourcesDirectory)/swift
+                -D LLVM_NATIVE_TOOL_DIR=$(Pipeline.Workspace)/build-tools/bin
+                -D LLVM_TABLEGEN=$(Pipeline.Workspace)/build-tools/bin/llvm-tblgen.exe
+                -D LLVM_USE_HOST_TOOLS=NO
+                -D SWIFT_BUILD_DYNAMIC_SDK_OVERLAY=NO
+                -D SWIFT_BUILD_DYNAMIC_STDLIB=NO
+                -D SWIFT_BUILD_REMOTE_MIRROR=NO
                 -D SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=YES
                 -D SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED=YES
                 -D SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING=YES
                 -D SWIFT_ENABLE_EXPERIMENTAL_REFLECTION=YES
                 -D SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING=YES
-                -D LLVM_EXTERNAL_CMARK_SOURCE_DIR=$(Build.SourcesDirectory)/swift-cmark
-                -D LLVM_EXTERNAL_SWIFT_SOURCE_DIR=$(Build.SourcesDirectory)/swift
-                -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE=$(Build.SourcesDirectory)/swift-corelibs-libdispatch
-                -D SWIFT_PATH_TO_STRING_PROCESSING_SOURCE=$(Build.SourcesDirectory)/swift-experimental-string-processing
-                -D LLVM_USE_HOST_TOOLS=NO
-                -D LLVM_TABLEGEN=$(Pipeline.Workspace)/build-tools/bin/llvm-tblgen.exe
-                -D CLANG_TABLEGEN=$(Pipeline.Workspace)/build-tools/bin/clang-tblgen.exe
-                -D LLDB_TABLEGEN=$(Pipeline.Workspace)/build-tools/bin/lldb-tblgen.exe
-                -D LLVM_CONFIG_PATH=$(Pipeline.Workspace)/build-tools/bin/llvm-config.exe
                 -D SWIFT_NATIVE_SWIFT_TOOLS_PATH=$(Pipeline.Workspace)/build-tools/bin
+                -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE=$(Build.SourcesDirectory)/swift-corelibs-libdispatch
+                -D SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE=$(Build.SourcesDirectory)/swift-syntax
+                -D SWIFT_PATH_TO_STRING_PROCESSING_SOURCE=$(Build.SourcesDirectory)/swift-experimental-string-processing
+                -D CLANG_VENDOR=compnerd.org
+                -D CLANG_VENDOR_UTI=org.compnerd.dt
+                -D PACKAGE_VENDOR=compnerd.org
+                -D SWIFT_VENDOR=compnerd.org
                 -D LLVM_PARALLEL_LINK_JOBS=2
                 -D SWIFT_PARALLEL_LINK_JOBS=2
-                -D SWIFT_BUILD_DYNAMIC_STDLIB=NO
-                -D SWIFT_BUILD_DYNAMIC_SDK_OVERLAY=NO
-                -D SWIFT_BUILD_REMOTE_MIRROR=NO
-                -D SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE=$(Build.SourcesDirectory)/swift-syntax
+                -D LLVM_APPEND_VC_REV=NO
+                -D LLVM_VERSION_SUFFIX=""
+                -D LLDB_PYTHON_EXE_RELATIVE_PATH=python.exe
+                -D LLDB_PYTHON_EXT_SUFFIX=.pyd
+                -D LLDB_PYTHON_RELATIVE_PATH=lib/site-packages
+                -D Python3_ROOT_DIR=$(PYTHON_ROOT)
+                -D Python3_INCLUDE_DIR=$(PYTHON_ROOT)/include
+                -D Python3_LIBRARY=$(PYTHON_ROOT)/libs/python310.lib
                 $(EXTRA_CMAKE_ARGS)
           - task: CMake@1
             inputs:
@@ -828,14 +855,6 @@ stages:
               filename: $(VsDevCmd)
               arguments: -no_logo -arch=$(arch) -host_arch=amd64
               modifyEnvironment: true
-          - task: PowerShell@2
-            inputs:
-              targetType: inline
-              script: |
-                Copy-Item "$(Build.SourcesDirectory)\swift\stdlib\public\Platform\ucrt.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\ucrt\module.modulemap"
-                Copy-Item "$(Build.SourcesDirectory)\swift\stdlib\public\Platform\vcruntime.modulemap" -destination "$env:VCToolsInstallDir\include\module.modulemap"
-                Copy-Item "$(Build.SourcesDirectory)\swift\stdlib\public\Platform\vcruntime.apinotes" -destination "$env:VCToolsInstallDir\include\vcruntime.apinotes"
-                Copy-Item "$(Build.SourcesDirectory)\swift\stdlib\public\Platform\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
           - bash: |
               echo "##vso[task.setvariable variable=root;isOutput=true]$(cygpath -m '$(Pipeline.Workspace)')"
             name: workspace
@@ -912,7 +931,7 @@ stages:
                 -D CMAKE_SYSTEM_PROCESSOR=$(platform)
                 -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
+                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Agent.BuildDirectory)/swift/stdlib/windows-vfs-overlay.yaml"
                 -G Ninja
                 -S $(Build.SourcesDirectory)/swift-corelibs-libdispatch
                 -D BUILD_TESTING=NO
@@ -941,7 +960,7 @@ stages:
                 -D CMAKE_SYSTEM_PROCESSOR=$(platform)
                 -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
+                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Agent.BuildDirectory)/swift/stdlib/windows-vfs-overlay.yaml"
                 -G Ninja
                 -S $(Build.SourcesDirectory)/swift-corelibs-foundation
                 -D BUILD_TESTING=NO
@@ -978,7 +997,7 @@ stages:
                 -D CMAKE_SYSTEM_PROCESSOR=$(platform)
                 -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
+                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Agent.BuildDirectory)/swift/stdlib/windows-vfs-overlay.yaml"
                 -G Ninja
                 -S $(Build.SourcesDirectory)/swift-corelibs-xctest
                 -D BUILD_TESTING=NO
@@ -1068,6 +1087,10 @@ stages:
           - checkout: jpsim/Yams
             fetchDepth: 1
           - checkout: apple/swift-syntax
+            fetchDepth: 1
+          - checkout: apple/swift-asn1
+            fetchDepth: 1
+          - checkout: apple/swift-certificates
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
@@ -1302,114 +1325,153 @@ stages:
                 --build $(Agent.BuildDirectory)/swift-driver
           - task: CMake@1
             inputs:
-             cmakeArgs:
-               -B $(Agent.BuildDirectory)/swift-package-manager
-               -D BUILD_SHARED_LIBS=YES
-               -D BUILD_TESTING=NO
-               -D CMAKE_BUILD_TYPE=Release
-               -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
-               -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-               -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-               -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
-               -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-               -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
-               -D CMAKE_MT=mt
-               -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-               -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
-               -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-               -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
-               -G Ninja
-               -S $(Build.SourcesDirectory)/swift-package-manager
-               -D ArgumentParser_DIR=$(Agent.BuildDirectory)/swift-argument-parser/cmake/modules
-               -D LLBuild_DIR=$(Agent.BuildDirectory)/swift-llbuild/cmake/modules
-               -D SwiftCollections_DIR=$(Agent.BuildDirectory)/swift-collections/cmake/modules
-               -D SwiftCrypto_DIR=$(Agent.BuildDirectory)/swift-crypto/cmake/modules
-               -D SwiftDriver_DIR=$(Agent.BuildDirectory)/swift-driver/cmake/modules
-               -D SwiftSystem_DIR=$(Agent.BuildDirectory)/swift-system/cmake/modules
-               -D TSC_DIR=$(Agent.BuildDirectory)/swift-tools-support-core/cmake/modules
-               -D Yams_DIR=$(Agent.BuildDirectory)/Yams/cmake/modules
-               -D SQLite3_LIBRARY=$(Pipeline.Workspace)/sqlite-$(arch)-3.36.0/Library/sqlite-3.36.0/usr/lib/SQLite3.lib
-               -D SQLite3_INCLUDE_DIR=$(Pipeline.Workspace)/sqlite-$(arch)-3.36.0/Library/sqlite-3.36.0/usr/include
+              cmakeArgs:
+                -B $(Agent.BuildDirectory)/swift-asn1
+                -D BUILD_SHARED_LIBS=NO
+                -D CMAKE_BUILD_TYPE=Release
+                -D CMAKE_MT=mt
+                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
+                -G Ninja
+                -S $(Build.SourcesDirectory)/swift-asn1
+                -D dispatch_DIR=$(Agent.BuildDirectory)/libdispatch/cmake/modules
+                -D Foundation_DIR=$(Agent.BuildDirectory)/foundation/cmake/modules
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                --build $(Agent.BuildDirectory)/swift-asn1
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                -B $(Agent.BuildDirectory)/swift-certificates
+                -D BUILD_SHARED_LIBS=NO
+                -D CMAKE_BUILD_TYPE=Release
+                -D CMAKE_MT=mt
+                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
+                -G Ninja
+                -S $(Build.SourcesDirectory)/swift-package-manager
+                -D dispatch_DIR=$(Agent.BuildDirectory)/libdispatch/cmake/modules
+                -D Foundation_DIR=$(Agent.BuildDirectory)/foundation/cmake/modules
+                -D SwiftASN1_DIR=$(Agent.BuildDirectory)/swift-asn1/cmake/modules
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                --build $(Agent.BuildDirectory)/swift-certificates
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                -B $(Agent.BuildDirectory)/swift-package-manager
+                -D BUILD_SHARED_LIBS=YES
+                -D BUILD_TESTING=NO
+                -D CMAKE_BUILD_TYPE=Release
+                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
+                -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
+                -D CMAKE_MT=mt
+                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
+                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
+                -G Ninja
+                -S $(Build.SourcesDirectory)/swift-package-manager
+                -D ArgumentParser_DIR=$(Agent.BuildDirectory)/swift-argument-parser/cmake/modules
+                -D LLBuild_DIR=$(Agent.BuildDirectory)/swift-llbuild/cmake/modules
+                -D SwiftCollections_DIR=$(Agent.BuildDirectory)/swift-collections/cmake/modules
+                -D SwiftCrypto_DIR=$(Agent.BuildDirectory)/swift-crypto/cmake/modules
+                -D SwiftDriver_DIR=$(Agent.BuildDirectory)/swift-driver/cmake/modules
+                -D SwiftSystem_DIR=$(Agent.BuildDirectory)/swift-system/cmake/modules
+                -D TSC_DIR=$(Agent.BuildDirectory)/swift-tools-support-core/cmake/modules
+                -D Yams_DIR=$(Agent.BuildDirectory)/Yams/cmake/modules
+                -D SQLite3_LIBRARY=$(Pipeline.Workspace)/sqlite-$(arch)-3.36.0/Library/sqlite-3.36.0/usr/lib/SQLite3.lib
+                -D SQLite3_INCLUDE_DIR=$(Pipeline.Workspace)/sqlite-$(arch)-3.36.0/Library/sqlite-3.36.0/usr/include
+                -D SwiftASN1_DIR=$(Agent.BuildDirectory)/swift-asn1/cmake/modules
+                -D SwiftCertificates_DIR=$(Agent.BuildDirectory)/swift-certificates/cmake/modules
           - task: CMake@1
             inputs:
               cmakeArgs:
                 --build $(Agent.BuildDirectory)/swift-package-manager
           - task: CMake@1
             inputs:
-             cmakeArgs:
-               -B $(Agent.BuildDirectory)/indexstore-db
-               -D BUILD_SHARED_LIBS=YES
-               -D BUILD_TESTING=NO
-               -D CMAKE_BUILD_TYPE=Release
-               -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
-               -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-               -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/Block"
-               -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
-               -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-               -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/Block"
-               -D CMAKE_MT=mt
-               -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-               -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
-               -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-               -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -I$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -I$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/Block"
-               -G Ninja
-               -S $(Build.SourcesDirectory)/indexstore-db
+              cmakeArgs:
+                -B $(Agent.BuildDirectory)/indexstore-db
+                -D BUILD_SHARED_LIBS=YES
+                -D BUILD_TESTING=NO
+                -D CMAKE_BUILD_TYPE=Release
+                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/Block"
+                -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/Block"
+                -D CMAKE_MT=mt
+                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
+                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -I$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -I$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/Block"
+                -G Ninja
+                -S $(Build.SourcesDirectory)/indexstore-db
           - task: CMake@1
             inputs:
               cmakeArgs:
                 --build $(Agent.BuildDirectory)/indexstore-db
           - task: CMake@1
             inputs:
-             cmakeArgs:
-               -B $(Agent.BuildDirectory)/swift-syntax
-               -D BUILD_SHARED_LIBS=NO
-               -D BUILD_TESTING=NO
-               -D CMAKE_BUILD_TYPE=Release
-               -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
-               -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-               -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-               -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
-               -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-               -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
-               -D CMAKE_MT=mt
-               -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-               -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
-               -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-               -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
-               -G Ninja
-               -S $(Build.SourcesDirectory)/swift-syntax
+              cmakeArgs:
+                -B $(Agent.BuildDirectory)/swift-syntax
+                -D BUILD_SHARED_LIBS=NO
+                -D BUILD_TESTING=NO
+                -D CMAKE_BUILD_TYPE=Release
+                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
+                -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
+                -D CMAKE_MT=mt
+                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
+                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
+                -G Ninja
+                -S $(Build.SourcesDirectory)/swift-syntax
           - task: CMake@1
             inputs:
               cmakeArgs:
                 --build $(Agent.BuildDirectory)/swift-syntax
           - task: CMake@1
             inputs:
-             cmakeArgs:
-               -B $(Agent.BuildDirectory)/sourcekit-lsp
-               -D BUILD_SHARED_LIBS=YES
-               -D BUILD_TESTING=NO
-               -D CMAKE_BUILD_TYPE=Release
-               -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
-               -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-               -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code"
-               -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
-               -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-               -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code"
-               -D CMAKE_MT=mt
-               -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-               -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
-               -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-               -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
-               -G Ninja
-               -S $(Build.SourcesDirectory)/sourcekit-lsp
-               -D ArgumentParser_DIR=$(Agent.BuildDirectory)/swift-argument-parser/cmake/modules
-               -D IndexStoreDB_DIR=$(Agent.BuildDirectory)/indexstore-db/cmake/modules
-               -D LLBuild_DIR=$(Agent.BuildDirectory)/swift-llbuild/cmake/modules
-               -D SwiftCollections_DIR=$(Agent.BuildDirectory)/swift-collections/cmake/modules
-               -D SwiftPM_DIR=$(Agent.BuildDirectory)/swift-package-manager/cmake/modules
-               -D SwiftSystem_DIR=$(Agent.BuildDirectory)/swift-system/cmake/modules
-               -D TSC_DIR=$(Agent.BuildDirectory)/swift-tools-support-core/cmake/modules
-               -D SwiftSyntax_DIR=$(Agent.BuildDirectory)/swift-syntax/cmake/modules
+              cmakeArgs:
+                -B $(Agent.BuildDirectory)/sourcekit-lsp
+                -D BUILD_SHARED_LIBS=YES
+                -D BUILD_TESTING=NO
+                -D CMAKE_BUILD_TYPE=Release
+                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code"
+                -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code"
+                -D CMAKE_MT=mt
+                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
+                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows"
+                -G Ninja
+                -S $(Build.SourcesDirectory)/sourcekit-lsp
+                -D ArgumentParser_DIR=$(Agent.BuildDirectory)/swift-argument-parser/cmake/modules
+                -D IndexStoreDB_DIR=$(Agent.BuildDirectory)/indexstore-db/cmake/modules
+                -D LLBuild_DIR=$(Agent.BuildDirectory)/swift-llbuild/cmake/modules
+                -D SwiftCollections_DIR=$(Agent.BuildDirectory)/swift-collections/cmake/modules
+                -D SwiftPM_DIR=$(Agent.BuildDirectory)/swift-package-manager/cmake/modules
+                -D SwiftSystem_DIR=$(Agent.BuildDirectory)/swift-system/cmake/modules
+                -D TSC_DIR=$(Agent.BuildDirectory)/swift-tools-support-core/cmake/modules
+                -D SwiftSyntax_DIR=$(Agent.BuildDirectory)/swift-syntax/cmake/modules
           - task: CMake@1
             inputs:
               cmakeArgs:


### PR DESCRIPTION
Update the build rules for the rebranch and VS changes.  We no longer modify the installed Visual Studio copy as much, add in new dependencies, checkouts, builds, update paths, update build tools, update flags for the compilers build.