### PR TITLE
Update XCTest lib paths

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -649,20 +649,13 @@ function Build-XCTest($Arch)
     $InstallDir\bin `
     $InstallDir\$($Arch.BinaryDir)
 
-  # Restructure Import Libraries
-  New-Item -ErrorAction Ignore -Type Directory `
-    -Path $InstallDir\lib\swift\windows\$($Arch.LLVMName)
-  Move-Item -Force `
-    $InstallDir\lib\swift\windows\XCTest.lib `
-    $InstallDir\lib\swift\windows\$($Arch.LLVMName)\XCTest.lib
-
-  # Restructure Module
+  # Restructure module, keeping the original files for the installer build
   New-Item -ErrorAction Ignore -Type Directory `
     -Path $InstallDir\lib\swift\windows\XCTest.swiftmodule
-  Move-Item -Force `
+  Copy-Item -Force `
     $InstallDir\lib\swift\windows\$($Arch.LLVMName)\XCTest.swiftdoc `
     $InstallDir\lib\swift\windows\XCTest.swiftmodule\$($Arch.LLVMTarget).swiftdoc
-  Move-Item -Force `
+  Copy-Item -Force `
     $InstallDir\lib\swift\windows\$($Arch.LLVMName)\XCTest.swiftmodule `
     $InstallDir\lib\swift\windows\XCTest.swiftmodule\$($Arch.LLVMTarget).swiftmodule
 }


### PR DESCRIPTION
Update XCTest lib paths to account for https://github.com/apple/swift-corelibs-xctest/pull/434 and https://github.com/apple/swift-installer-scripts/pull/181 (codependent change).

Also copies the modules instead of moving them so the installer build still finds the files in their original location. The real fix would be to teach CMake about swift module installation.