### PR TITLE
Use XCTEST_ROOT for sdk.wixproj

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -1574,6 +1574,7 @@ stages:
                 -p:ProductArchitecture=$(arch)
                 -p:PLATFORM_ROOT=$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform
                 -p:SDK_ROOT=$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk
+                -p:XCTEST_ROOT=$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/Library/XCTest-development
                 -p:SWIFT_SOURCE_DIR=$(Build.SourcesDirectory)/swift
                 -p:IntermediateOutputPath=$(Agent.BuildDirectory)\
                 -p:OutputPath=$(Agent.BuildDirectory)\

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1643,6 +1643,7 @@ jobs:
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:PLATFORM_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform `
               -p:SDK_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk `
+              -p:XCTEST_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/Library/XCTest-development `
               -p:SWIFT_SOURCE_DIR=${{ github.workspace }}/SourceCache/swift `
               -p:PlatformToolset=v142 `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/sdk.wixproj

--- a/build.ps1
+++ b/build.ps1
@@ -966,6 +966,7 @@ function Build-Installer()
     # Build-WiXProject sdk.wixproj -Properties @{
     #   PLATFORM_ROOT = "$PlatformInstallRoot\";
     #   SDK_ROOT = "$SDKInstallRoot\";
+    #   XCTEST_ROOT = "$PlatformInstallRoot\Developer\Library\XCTest-development\";
     #   SWIFT_SOURCE_DIR = "$SourceCache\swift\";
     # }
   }


### PR DESCRIPTION
Updates Windows build scripts in this repo to use `XCTEST_ROOT` as introduced by https://github.com/apple/swift-installer-scripts/pull/180