### PR TITLE
Fix dispatch headers for sdk.wixproj

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -538,12 +538,13 @@ function Build-Dispatch($Arch)
       BUILD_TESTING = "NO";
     }
 
-  # Restructure BlocksRuntime, dispatch headers
+  # Restructure BlocksRuntime, dispatch headers to match the installed layout
+  # but keep the original files so the installer build can find them.
   foreach ($module in ("Block", "dispatch", "os"))
   {
     Remove-Item -Recurse -Force -ErrorAction Ignore `
       $SDKInstallRoot\usr\include\$module
-    Move-Item -Force `
+    Copy-Item -Force `
       $SDKInstallRoot\usr\lib\swift\$module `
       $SDKInstallRoot\usr\include\
   }


### PR DESCRIPTION
Copies dispatch headers to the installed layout location instead of moving them such that the installer can still find them where they are initially installed by cmake.

This helps unblock the installer but a better fix would be to check if we can change this:
https://github.com/apple/swift-corelibs-libdispatch/blob/e7c44163ce06a916f0641a8446e392ef28929309/CMakeLists.txt#L294