### PR TITLE
Sort cmake -D's for ToBatch

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -280,7 +280,7 @@ function Build-CMakeProject
   if ("" -ne $CacheScript) {
     $cmakeGenerateArgs += @("-C", $CacheScript)
   }
-  foreach ($Define in $Defines.GetEnumerator()) {
+  foreach ($Define in ($Defines.GetEnumerator() | Sort-Object Name)) {
     $cmakeGenerateArgs += @("-D", "$($Define.Key)=$($Define.Value)")
   }
 


### PR DESCRIPTION
Currently the order is nondeterministic because it's using a hash table.