### PR TITLE
Add -restore to msbuild invocations for WiX v4 compatibility

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -1555,10 +1555,9 @@ stages:
               platform: $(platform)
               configuration: Release
               maximumCpuCount: true
-              restoreNugetPackages: false
+              restoreNugetPackages: true
               createLogFile: true
               msbuildArguments:
-                -restore
                 -p:RunWixToolsOutOfProc=true
                 -p:CERTIFICATE=$(certificate.secureFilePath)
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
@@ -1623,8 +1622,8 @@ stages:
               platform: $(platform)
               configuration: Release
               maximumCpuCount: true
+              restoreNugetPackages: true
               msbuildArguments:
-                -restore
                 -p:RunWixToolsOutOfProc=true
                 -p:ProductArchitecture=$(arch)
                 -p:CERTIFICATE=$(certificate.secureFilePath)
@@ -1640,8 +1639,8 @@ stages:
               platform: $(platform)
               configuration: Release
               maximumCpuCount: true
+              restoreNugetPackages: true
               msbuildArguments:
-                -restore
                 -p:RunWixToolsOutOfProc=true
                 -p:ProductArchitecture=$(arch)
                 -p:CERTIFICATE=$(certificate.secureFilePath)
@@ -1700,10 +1699,9 @@ stages:
               platform: $(platform)
               configuration: Release
               maximumCpuCount: true
-              restoreNugetPackages: false
+              restoreNugetPackages: true
               createLogFile: true
               msbuildArguments:
-                -restore
                 -p:RunWixToolsOutOfProc=true
                 -p:CERTIFICATE=$(certificate.secureFilePath)
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
@@ -1773,10 +1771,9 @@ stages:
               platform: $(platform)
               configuration: Release
               maximumCpuCount: true
-              restoreNugetPackages: false
+              restoreNugetPackages: true
               createLogFile: true
               msbuildArguments:
-                -restore
                 -p:RunWixToolsOutOfProc=true
                 -p:RequiredChain=runtime.msi%3Btoolchain.msi%3Bdevtools.msi%3Bsdk.msi
                 -p:CERTIFICATE=$(certificate.secureFilePath)

--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -1558,6 +1558,7 @@ stages:
               restoreNugetPackages: false
               createLogFile: true
               msbuildArguments:
+                -restore
                 -p:RunWixToolsOutOfProc=true
                 -p:CERTIFICATE=$(certificate.secureFilePath)
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
@@ -1623,6 +1624,7 @@ stages:
               configuration: Release
               maximumCpuCount: true
               msbuildArguments:
+                -restore
                 -p:RunWixToolsOutOfProc=true
                 -p:ProductArchitecture=$(arch)
                 -p:CERTIFICATE=$(certificate.secureFilePath)
@@ -1639,6 +1641,7 @@ stages:
               configuration: Release
               maximumCpuCount: true
               msbuildArguments:
+                -restore
                 -p:RunWixToolsOutOfProc=true
                 -p:ProductArchitecture=$(arch)
                 -p:CERTIFICATE=$(certificate.secureFilePath)
@@ -1700,6 +1703,7 @@ stages:
               restoreNugetPackages: false
               createLogFile: true
               msbuildArguments:
+                -restore
                 -p:RunWixToolsOutOfProc=true
                 -p:CERTIFICATE=$(certificate.secureFilePath)
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
@@ -1772,6 +1776,7 @@ stages:
               restoreNugetPackages: false
               createLogFile: true
               msbuildArguments:
+                -restore
                 -p:RunWixToolsOutOfProc=true
                 -p:RequiredChain=runtime.msi%3Btoolchain.msi%3Bdevtools.msi%3Bsdk.msi
                 -p:CERTIFICATE=$(certificate.secureFilePath)

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1616,7 +1616,7 @@ jobs:
 
       - name: Package
         run: |
-          msbuild -nologo `
+          msbuild -nologo -restore `
               -p:Configuration=Release `
               -p:RunWixToolsOutOfProc=true `
               -p:OutputPath=${{ github.workspace }}\BinaryCache\toolchain\ `
@@ -1689,7 +1689,7 @@ jobs:
 
       - name: Package Runtime
         run: |
-          msbuild -nologo `
+          msbuild -nologo -restore `
               -p:Configuration=Release `
               -p:RunWixToolsOutOfProc=true `
               -p:OutputPath=${{ github.workspace }}\BinaryCache\runtime\ `
@@ -1747,7 +1747,7 @@ jobs:
 
       - name: Package
         run: |
-          msbuild -nologo `
+          msbuild -nologo -restore `
               -p:Configuration=Release `
               -p:RunWixToolsOutOfProc=true `
               -p:OutputPath=${{ github.workspace }}\BinaryCache\devtools\ `
@@ -1811,7 +1811,7 @@ jobs:
 
       - name: Package
         run: |
-          msbuild -nologo `
+          msbuild -nologo -restore `
               -p:Configuration=Release `
               -p:RunWixToolsOutOfProc=true `
               -p:OutputPath=${{ github.workspace }}\BinaryCache\installer\ `

--- a/build.ps1
+++ b/build.ps1
@@ -368,6 +368,7 @@ function Build-WiXProject()
 
   $MSBuildArgs = @("$SourceCache\swift-installer-scripts\platforms\Windows\$FileName")
   $MSBuildArgs += "-noLogo"
+  $MSBuildArgs += "-restore"
   foreach ($Property in $Properties.GetEnumerator()) {
     $MSBuildArgs += "-p:$($Property.Key)=$($Property.Value)"
   }


### PR DESCRIPTION
Prepares the CI definitions for the migration of the Windows installer to WiX v4, which relies on Nuget and so require a package restore step: https://github.com/apple/swift-installer-scripts/pull/184