### PR TITLE
build.ps1 -ProductVersion

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,10 +1,12 @@
 # Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
 # Copyright 2023 Tristan Labelle <tristan@thebrowser.company>
 
+[CmdletBinding(PositionalBinding = $false)]
 param(
-  [string[]] $SDKs = @("X64","X86","Arm64"),
   [string] $SourceCache = "S:\SourceCache",
   [string] $BinaryCache = "S:\b",
+  [string[]] $SDKs = @("X64","X86","Arm64"),
+  [string] $ProductVersion = "0.0.0",
   [switch] $ToBatch
 )
 
@@ -362,6 +364,7 @@ function Build-WiXProject()
 
   $Properties = $Properties.Clone()
   TryAdd-KeyValue $Properties ProductArchitecture $ArchName
+  TryAdd-KeyValue $Properties ProductVersion $ProductVersion
   TryAdd-KeyValue $Properties RunWixToolsOutOfProc true
   TryAdd-KeyValue $Properties OutputPath $BinaryCache\msi\$ArchName\
   TryAdd-KeyValue $Properties IntermediateOutputPath BinaryCache\$Name\$ArchName\


### PR DESCRIPTION
Support a `-ProductVersion` parameter which gets passed down when building the WiX projects.