### PR TITLE
Switch to explicit msbuild -restore for AzDO build

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -1577,9 +1577,9 @@ stages:
               platform: $(platform)
               configuration: Release
               maximumCpuCount: true
-              restoreNugetPackages: true
               createLogFile: true
               msbuildArguments:
+                -restore
                 -p:RunWixToolsOutOfProc=true
                 -p:CERTIFICATE=$(certificate.secureFilePath)
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
@@ -1645,8 +1645,8 @@ stages:
               platform: $(platform)
               configuration: Release
               maximumCpuCount: true
-              restoreNugetPackages: true
               msbuildArguments:
+                -restore
                 -p:RunWixToolsOutOfProc=true
                 -p:ProductArchitecture=$(arch)
                 -p:CERTIFICATE=$(certificate.secureFilePath)
@@ -1663,8 +1663,8 @@ stages:
               platform: $(platform)
               configuration: Release
               maximumCpuCount: true
-              restoreNugetPackages: true
               msbuildArguments:
+                -restore
                 -p:RunWixToolsOutOfProc=true
                 -p:ProductArchitecture=$(arch)
                 -p:CERTIFICATE=$(certificate.secureFilePath)
@@ -1724,9 +1724,9 @@ stages:
               platform: $(platform)
               configuration: Release
               maximumCpuCount: true
-              restoreNugetPackages: true
               createLogFile: true
               msbuildArguments:
+                -restore
                 -p:RunWixToolsOutOfProc=true
                 -p:CERTIFICATE=$(certificate.secureFilePath)
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
@@ -1797,9 +1797,9 @@ stages:
               platform: $(platform)
               configuration: Release
               maximumCpuCount: true
-              restoreNugetPackages: true
               createLogFile: true
               msbuildArguments:
+                -restore
                 -p:RunWixToolsOutOfProc=true
                 -p:RequiredChain=runtime.msi%3Btoolchain.msi%3Bdevtools.msi%3Bsdk.msi
                 -p:CERTIFICATE=$(certificate.secureFilePath)


### PR DESCRIPTION
`restoreNugetPackages` is deprecated, causes a warning, and invokes a separate `nuget.exe`, whereas `-restore` is now natively integrated into `msbuild`, which seems safer for WiX v4 SDK-style projects