### PR TITLE
build.ps1: add test running (swift + dispatch + foundation + xctest)

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1167,7 +1167,7 @@ function Build-Installer()
       DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
     }
 
-    Build-WiXProject installer.wixproj -Arch $HostArch -Properties @{
+    Build-WiXProject installer.wixproj -Arch $HostArch -Bundle -Properties @{
       OutputPath = "$BinaryCache\";
       MSI_LOCATION = "$($HostArch.MSIRoot)\";
     }
@@ -1175,9 +1175,6 @@ function Build-Installer()
 }
 
 #-------------------------------------------------------------------
-
-Build-Foundation $HostArch -Test
-exit
 
 Build-BuildTools $HostArch
 Build-Compilers $HostArch


### PR DESCRIPTION
Adds support for running the same tests as in the Apple CI: swift, dispatch, foundation and xctest. This is controlled by an optional `-Test` parameter which supports a `*` wildcard.

A few swift tests currently fail, but those are known:
```
Failed Tests (14):
  Swift(windows-x86_64) :: Concurrency/Runtime/startOnMainActor.swift
  Swift(windows-x86_64) :: Interop/Cxx/class/custom-new-operator-irgen.swift
  Swift(windows-x86_64) :: Interop/Cxx/class/memory-layout-execution.swift
  Swift(windows-x86_64) :: Interop/Cxx/class/memory-layout-silgen.swift
  Swift(windows-x86_64) :: Interop/Cxx/stdlib/msvcprt-module-interface.swift
  Swift(windows-x86_64) :: Interop/Cxx/stdlib/overlay/custom-collection-module-interface.swift
  Swift(windows-x86_64) :: Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
  Swift(windows-x86_64) :: Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
  Swift(windows-x86_64) :: Interop/Cxx/stdlib/use-std-string.swift
  Swift(windows-x86_64) :: Interop/SwiftToCxxToSwift/hide-swift-module-namespace-in-swift.swift
  Swift(windows-x86_64) :: ModuleInterface/ModuleCache/force-module-loading-mode-archs.swift
  Swift(windows-x86_64) :: ModuleInterface/ModuleCache/force-module-loading-mode-framework.swift
  Swift(windows-x86_64) :: ModuleInterface/ModuleCache/force-module-loading-mode.swift
  Swift(windows-x86_64) :: ModuleInterface/ModuleCache/module-cache-bad-version.swift
```