### PR TITLE
build: ensure that we write out the content in UTF-8

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -143,7 +143,7 @@ function Invoke-Program()
       # Break lines after non-switch arguments
       $ShouldBreakLine = -not $Arg.StartsWith("-")
     }
-    
+
     if ($OutNull)
     {
       $OutputLine += " > nul"
@@ -153,7 +153,7 @@ function Invoke-Program()
       $OutputLine += " > `"$OutFile`""
     }
 
-    Write-Output $OutputLine
+    Write-Output -Encoding UTF8 $OutputLine
   }
   else
   {
@@ -163,7 +163,7 @@ function Invoke-Program()
     }
     elseif ("" -ne $OutFile)
     {
-      & $Executable @Args | Out-File $OutFile
+      & $Executable @Args | Out-File -Encoding UTF8 $OutFile
     }
     else
     {


### PR DESCRIPTION
We expect the content to be UTF-8, explicitly specify the encoding for the files that are being created.  This is important to enable the use of VSCode.