### PR TITLE
build.ps1: Fix extra -Encoding UTF8 in -ToBatch output

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -153,7 +153,7 @@ function Invoke-Program()
       $OutputLine += " > `"$OutFile`""
     }
 
-    Write-Output -Encoding UTF8 $OutputLine
+    Write-Output $OutputLine
   }
   else
   {


### PR DESCRIPTION
This ended up printed literally:

```
[...]
   -D CMAKE_Swift_FLAGS_RELEASE=-O ^
   -D LLBUILD_SUPPORT_BINDINGS=Swift ^
   -D SQLite3_INCLUDE_DIR=S:\Library\sqlite-3.36.0\usr\include ^
-Encoding
UTF8
   -D SQLite3_LIBRARY=S:\Library\sqlite-3.36.0\usr\lib\SQLite3.lib
-Encoding
UTF8
"cmake.exe" --build S:\b\4
```