### PR TITLE
build.ps1: Fix VsDevCmd.bat invocation in -ToBatch output

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -210,7 +210,7 @@ function Invoke-VsDevShell($Arch)
 {
   if ($ToBatch)
   {
-    Write-Output "`"$VSInstallRoot\Common7\Tools\VsDevCmd.bat`" -no_logo -host_arch=amd64 -arch=$($Arch.VSName)"
+    Write-Output "`call "$VSInstallRoot\Common7\Tools\VsDevCmd.bat`" -no_logo -host_arch=amd64 -arch=$($Arch.VSName)"
   }
   else
   {


### PR DESCRIPTION
Without `call`, the batch file doesn't properly continue executing