### PR TITLE
build.ps1: Fix bad escaping

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -210,7 +210,7 @@ function Invoke-VsDevShell($Arch)
 {
   if ($ToBatch)
   {
-    Write-Output "`call "$VSInstallRoot\Common7\Tools\VsDevCmd.bat`" -no_logo -host_arch=amd64 -arch=$($Arch.VSName)"
+    Write-Output "call `"$VSInstallRoot\Common7\Tools\VsDevCmd.bat`" -no_logo -host_arch=amd64 -arch=$($Arch.VSName)"
   }
   else
   {


### PR DESCRIPTION
Due to badly replicated fix in the GitHub UI. Oops.