### PR TITLE
build.ps1: Support running LLBuild tests

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -507,7 +507,7 @@ function Build-BuildTools($Arch)
     -Src $SourceCache\llvm-project\llvm `
     -Bin $BinaryCache\0 `
     -Arch $Arch `
-    -BuildTargets llvm-tblgen,clang-tblgen,clang-pseudo-gen,clang-tidy-confusable-chars-gen,lldb-tblgen,llvm-config,swift-def-to-strings-converter,swift-serialize-diagnostics,swift-compatibility-symbols,FileCheck `
+    -BuildTargets llvm-tblgen,clang-tblgen,clang-pseudo-gen,clang-tidy-confusable-chars-gen,lldb-tblgen,llvm-config,swift-def-to-strings-converter,swift-serialize-diagnostics,swift-compatibility-symbols `
     -Defines @{
       LLDB_ENABLE_PYTHON = "NO";
       LLDB_INCLUDE_TESTS = "NO";
@@ -1039,6 +1039,12 @@ function Build-LLBuild($Arch, [switch]$Test = $false)
   Isolate-EnvVars {
     if ($Test)
     {
+      # Build additional llvm executables needed by tests
+      Isolate-EnvVars {
+        Invoke-VsDevShell $HostArch
+        Invoke-Program ninja.exe -C "$BinaryCache\0" FileCheck not
+      }
+
       $Targets = @("default", "test-llbuild")
       $TestingDefines = @{
         FILECHECK_EXECUTABLE = "$BinaryCache\0\bin\FileCheck.exe";

--- a/build.ps1
+++ b/build.ps1
@@ -1063,13 +1063,13 @@ function Build-LLBuild($Arch, [switch]$Test = $false)
     Build-CMakeProject `
       -Src $SourceCache\llbuild `
       -Bin $BinaryCache\4 `
-      -InstallTo "$($Arch.ToolchainInstallRoot)\usr" `
       -Arch $Arch `
       -UseMSVCCompilers CXX `
       -UseBuiltCompilers Swift `
       -SwiftSDK $SDKInstallRoot `
       -BuildTargets $Targets `
       -Defines ($TestingDefines + @{
+        CMAKE_INSTALL_PREFIX = "$($Arch.ToolchainInstallRoot)\usr";
         BUILD_SHARED_LIBS = "YES";
         LLBUILD_SUPPORT_BINDINGS = "Swift";
         SQLite3_INCLUDE_DIR = "$LibraryRoot\sqlite-3.36.0\usr\include";


### PR DESCRIPTION
Add support for `-Test llbuild` but does not include it in `-Test *` since tests are known to not be Windows-friendly. Current results are:

```
Testing Time: 15.49s
  Unsupported:  15
  Passed     :  71
  Unresolved : 134
  Failed     :  12
```