### PR TITLE
build.ps1: Add help, including /? support for build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,9 @@
 @echo off
 setlocal
+if "%1"=="/?" (
+    powershell.exe -Command "& Get-Help -Detailed .\build.ps1"
+    exit /b
+)
+
 powershell.exe -ExecutionPolicy RemoteSigned -File "%~dp0\build.ps1" %*
 endlocal

--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,50 @@
 # Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
 # Copyright 2023 Tristan Labelle <tristan@thebrowser.company>
 
+<#
+.SYNOPSIS
+Builds the Swift toolchain, installers, and optionally runs tests.
+
+.DESCRIPTION
+This script performs various steps associated with building the Swift toolchain:
+
+- Builds the redistributable, SDK, devtools and toolchain binaries and files
+- Builds the msi's and installer executable
+- Creates a mock installation under S:\Program Files and S:\Library for local toolchain use
+- Optionally runs tests for supported projects
+- Optionally stages build artifacts for CI
+
+.PARAMETER SourceCache
+The path to a directory where projects contributing to the Swift.
+toolchain have been cloned.
+
+.PARAMETER BinaryCache
+The path to a directory where to write build system files and outputs.
+
+.PARAMETER SDKs
+An array of architectures for which the Swift SDK should be built.
+
+.PARAMETER ProductVersion
+The product version to be used when building the installer.
+Supports semantic version strings.
+
+.PARAMETER Test
+An array of names of projects to run tests for.
+'*' runs all tests
+
+.PARAMETER Stage
+The path to a directory where built msi's and the installer executable should be staged (for CI).
+
+.PARAMETER ToBatch
+When set, runs the script in a special mode which outputs a listing of command invocations
+in batch file format instead of executing them.
+
+.EXAMPLE
+PS> .\Build.ps1
+
+.EXAMPLE
+PS> .\Build.ps1 -SDKs x64 -ProductVersion 1.2.3 -Test foundation,xctest
+#>
 [CmdletBinding(PositionalBinding = $false)]
 param(
   [string] $SourceCache = "S:\SourceCache",


### PR DESCRIPTION
Adds `Get-Help` support to `build.ps1`, proxied by `/?` support to `build.cmd`.

Sample output:

```
S:\SourceCache\swift-build>build /?

NAME
    S:\SourceCache\swift-build\build.ps1

SYNOPSIS
    Builds the Swift toolchain, installers, and optionally runs tests.


SYNTAX
    S:\SourceCache\swift-build\build.ps1 [-SourceCache <String>] [-BinaryCache <String>] [-SDKs <String[]>]
    [-ProductVersion <String>] [-Test <String[]>] [-Stage <String>] [-ToBatch] [<CommonParameters>]


DESCRIPTION
    This script performs various steps associated with building the Swift toolchain:

    - Builds the redistributable, SDK, devtools and toolchain binaries and files
    - Builds the msi's and installer executable
    - Creates a mock installation under S:\Program Files and S:\Library for local toolchain use
    - Optionally runs tests for supported projects
    - Optionally stages build artifacts for CI


PARAMETERS
    -SourceCache <String>
        The path to a directory where projects contributing to the Swift.
        toolchain have been cloned.

    -BinaryCache <String>
        The path to a directory where to write build system files and outputs.

    -SDKs <String[]>
        An array of architectures for which the Swift SDK should be built.

    -ProductVersion <String>
        The product version to be used when building the installer.
        Supports semantic version strings.

    -Test <String[]>
        An array of names of projects to run tests for.
        '*' runs all tests

    -Stage <String>
        The path to a directory where built msi's and the installer executable should be staged (for CI).

    -ToBatch [<SwitchParameter>]
        When set, runs the script in a special mode which outputs a listing of command invocations
        in batch file format instead of executing them.

    <CommonParameters>
        This cmdlet supports the common parameters: Verbose, Debug,
        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
        OutBuffer, PipelineVariable, and OutVariable. For more information, see
        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).

    -------------------------- EXAMPLE 1 --------------------------

    PS>.\Build.ps1






    -------------------------- EXAMPLE 2 --------------------------

    PS>.\Build.ps1 -SDKs x64 -ProductVersion 1.2.3 -Test foundation,xctest






REMARKS
    To see the examples, type: "get-help S:\SourceCache\swift-build\build.ps1 -examples".
    For more information, type: "get-help S:\SourceCache\swift-build\build.ps1 -detailed".
    For technical information, type: "get-help S:\SourceCache\swift-build\build.ps1 -full".
```