### PR TITLE
build.ps1: Work around limitations in passing arrays from cmd

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -86,6 +86,10 @@ if (-not (Test-Path $python))
   }
 }
 
+# Work around limitations of cmd passing in arrays to PowerShell
+if ($SDKs.Length -eq 1) { $SDKs = $SDKs[0].Split(",") }
+if ($Test.Length -eq 1) { $Test = $Test[0].Split(",") }
+
 if ($Test -contains "*")
 {
   $Test = @("swift", "dispatch", "foundation", "xctest")

--- a/build.ps1
+++ b/build.ps1
@@ -86,7 +86,7 @@ if (-not (Test-Path $python))
   }
 }
 
-# Work around limitations of cmd passing in arrays to PowerShell
+# Work around limitations of cmd passing in array arguments via powershell.exe -File
 if ($SDKs.Length -eq 1) { $SDKs = $SDKs[0].Split(",") }
 if ($Test.Length -eq 1) { $Test = $Test[0].Split(",") }
 


### PR DESCRIPTION
From PowerShell, this will work: `& build.ps1 -Test foo,bar` and be interpreted as `$Test = @("foo", "bar")`. However, from cmd, this: `powershell.exe -File build.ps1 -Test foo,bar` will be interpreted as `$Test = @("foo,bar")` and there is no way to disambiguate and pass in a two-entry array. Since we don't expect commas in our array element names, we can work around this in PowerShell by splitting on the comma ourselves.