### PR TITLE
build.ps1: Replace Launch-VsDevShell with a VS2019-compatible equivalent

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -266,7 +266,7 @@ function Invoke-VsDevShell($Arch)
   }
   else
   {
-    # This path is valid for VS2019 and VS2022, but the was dll is under a vsdevcmd subfolder in VS2017 
+    # This dll path is valid for VS2019 and VS2022, but the was dll is under a vsdevcmd subfolder in VS2017 
     Import-Module "$VSInstallRoot\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
     Enter-VsDevShell -VsInstallPath $VSInstallRoot -SkipAutomaticLocation -DevCmdArguments "-no_logo -host_arch=$($HostArch.VSName) -arch=$($Arch.VSName)"
   }

--- a/build.ps1
+++ b/build.ps1
@@ -262,11 +262,13 @@ function Invoke-VsDevShell($Arch)
 {
   if ($ToBatch)
   {
-    Write-Output "call `"$VSInstallRoot\Common7\Tools\VsDevCmd.bat`" -no_logo -host_arch=amd64 -arch=$($Arch.VSName)"
+    Write-Output "call `"$VSInstallRoot\Common7\Tools\VsDevCmd.bat`" -no_logo -host_arch=$($HostArch.VSName) -arch=$($Arch.VSName)"
   }
   else
   {
-    & "$VSInstallRoot\Common7\Tools\Launch-VsDevShell.ps1" -VsInstallationPath $VSInstallRoot -HostArch amd64 -Arch $Arch.VSName | Out-Null
+    # This path is valid for VS2019 and VS2022, but the was dll is under a vsdevcmd subfolder in VS2017 
+    Import-Module "$VSInstallRoot\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+    Enter-VsDevShell -VsInstallPath $VSInstallRoot -SkipAutomaticLocation -DevCmdArguments "-no_logo -host_arch=$($HostArch.VSName) -arch=$($Arch.VSName)"
   }
 }
 


### PR DESCRIPTION
The VS2019 version of `Launch-VsDevShell.ps1` does not support the `-HostArch` and `-Arch` parameters, but both end up calling the same powershell module dll which is compatible through VS2022.