### PR TITLE
build.ps1: Make S:\Library path customizable

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -21,6 +21,10 @@ toolchain have been cloned.
 .PARAMETER BinaryCache
 The path to a directory where to write build system files and outputs.
 
+.PARAMETER LibraryRoot
+The path to a directory where built libraries should be placed,
+similar to the /Library or ~/Library directories on macOS.
+
 .PARAMETER BuildType
 The CMake build type to use, one of: Release, RelWithDebInfo, Debug.
 
@@ -60,6 +64,7 @@ PS> .\Build.ps1 -SDKs x64 -ProductVersion 1.2.3 -Test foundation,xctest
 param(
   [string] $SourceCache = "S:\SourceCache",
   [string] $BinaryCache = "S:\b",
+  [switch] $LibraryRoot = "S:\Library",
   [string] $BuildType = "Release",
   [string[]] $SDKs = @("X64","X86","Arm64"),
   [string] $ProductVersion = "0.0.0",
@@ -72,11 +77,6 @@ param(
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 3.0
-
-$InstallRoot = "S:\Library"
-$ToolchainInstallRoot = "$InstallRoot\Developer\Toolchains\unknown-Asserts-development.xctoolchain"
-$PlatformInstallRoot = "$InstallRoot\Developer\Platforms\Windows.platform"
-$SDKInstallRoot = "$PlatformInstallRoot\Developer\SDKs\Windows.sdk"
 
 $vswhere = "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
 $VSInstallRoot = & $vswhere -nologo -latest -products "*" -all -prerelease -property installationPath
@@ -585,13 +585,13 @@ function Build-ZLib($Arch)
   Build-CMakeProject `
     -Src $SourceCache\zlib `
     -Bin "$($Arch.BinaryRoot)\zlib-1.2.11" `
-    -InstallTo $InstallRoot\zlib-1.2.11\usr `
+    -InstallTo $LibraryRoot\zlib-1.2.11\usr `
     -Arch $Arch `
     -BuildTargets default `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
-      INSTALL_BIN_DIR = "$InstallRoot\zlib-1.2.11\usr\bin\$ArchName";
-      INSTALL_LIB_DIR = "$InstallRoot\zlib-1.2.11\usr\lib\$ArchName";
+      INSTALL_BIN_DIR = "$LibraryRoot\zlib-1.2.11\usr\bin\$ArchName";
+      INSTALL_LIB_DIR = "$LibraryRoot\zlib-1.2.11\usr\lib\$ArchName";
     }
 }
 
@@ -602,7 +602,7 @@ function Build-XML2($Arch)
   Build-CMakeProject `
     -Src $SourceCache\libxml2 `
     -Bin "$($Arch.BinaryRoot)\libxml2-2.9.12" `
-    -InstallTo "$InstallRoot\libxml2-2.9.12\usr" `
+    -InstallTo "$LibraryRoot\libxml2-2.9.12\usr" `
     -Arch $Arch `
     -BuildTargets default `
     -Defines @{
@@ -626,7 +626,7 @@ function Build-CURL($Arch)
   Build-CMakeProject `
     -Src $SourceCache\curl `
     -Bin "$($Arch.BinaryRoot)\curl-7.77.0" `
-    -InstallTo "$InstallRoot\curl-7.77.0\usr" `
+    -InstallTo "$LibraryRoot\curl-7.77.0\usr" `
     -Arch $Arch `
     -BuildTargets default `
     -Defines @{
@@ -654,8 +654,8 @@ function Build-CURL($Arch)
       CURL_ZLIB = "YES";
       ENABLE_UNIX_SOCKETS = "NO";
       ENABLE_THREADED_RESOLVER = "NO";
-      ZLIB_ROOT = "$InstallRoot\zlib-1.2.11\usr";
-      ZLIB_LIBRARY = "$InstallRoot\zlib-1.2.11\usr\lib\$ArchName\zlibstatic.lib";
+      ZLIB_ROOT = "$LibraryRoot\zlib-1.2.11\usr";
+      ZLIB_LIBRARY = "$LibraryRoot\zlib-1.2.11\usr\lib\$ArchName\zlibstatic.lib";
     }
 }
 
@@ -688,7 +688,7 @@ function Build-ICU($Arch)
   Build-CMakeProject `
     -Src $SourceCache\icu\icu4c `
     -Bin "$($Arch.BinaryRoot)\icu-69.1" `
-    -InstallTo "$InstallRoot\icu-69.1\usr" `
+    -InstallTo "$LibraryRoot\icu-69.1\usr" `
     -Arch $Arch `
     -BuildTargets default `
     -Defines ($BuildToolsDefines + @{
@@ -781,16 +781,16 @@ function Build-Foundation($Arch, [switch]$Test = $false)
         CMAKE_INSTALL_PREFIX = "$($Arch.SDKInstallRoot)\usr";
         CMAKE_SYSTEM_NAME = "Windows";
         CMAKE_SYSTEM_PROCESSOR = $Arch.CMakeName;
-        CURL_DIR = "$InstallRoot\curl-7.77.0\usr\lib\$ShortArch\cmake\CURL";
-        ICU_DATA_LIBRARY_RELEASE = "$InstallRoot\icu-69.1\usr\lib\$ShortArch\sicudt69.lib";
-        ICU_I18N_LIBRARY_RELEASE = "$InstallRoot\icu-69.1\usr\lib\$ShortArch\sicuin69.lib";
-        ICU_ROOT = "$InstallRoot\icu-69.1\usr";
-        ICU_UC_LIBRARY_RELEASE = "$InstallRoot\icu-69.1\usr\lib\$ShortArch\sicuuc69.lib";
-        LIBXML2_LIBRARY = "$InstallRoot\libxml2-2.9.12\usr\lib\$ShortArch\libxml2s.lib";
-        LIBXML2_INCLUDE_DIR = "$InstallRoot\libxml2-2.9.12\usr\include\libxml2";
+        CURL_DIR = "$LibraryRoot\curl-7.77.0\usr\lib\$ShortArch\cmake\CURL";
+        ICU_DATA_LIBRARY_RELEASE = "$LibraryRoot\icu-69.1\usr\lib\$ShortArch\sicudt69.lib";
+        ICU_I18N_LIBRARY_RELEASE = "$LibraryRoot\icu-69.1\usr\lib\$ShortArch\sicuin69.lib";
+        ICU_ROOT = "$LibraryRoot\icu-69.1\usr";
+        ICU_UC_LIBRARY_RELEASE = "$LibraryRoot\icu-69.1\usr\lib\$ShortArch\sicuuc69.lib";
+        LIBXML2_LIBRARY = "$LibraryRoot\libxml2-2.9.12\usr\lib\$ShortArch\libxml2s.lib";
+        LIBXML2_INCLUDE_DIR = "$LibraryRoot\libxml2-2.9.12\usr\include\libxml2";
         LIBXML2_DEFINITIONS = "/DLIBXML_STATIC";
-        ZLIB_LIBRARY = "$InstallRoot\zlib-1.2.11\usr\lib\$ShortArch\zlibstatic.lib";
-        ZLIB_INCLUDE_DIR = "$InstallRoot\zlib-1.2.11\usr\include";
+        ZLIB_LIBRARY = "$LibraryRoot\zlib-1.2.11\usr\lib\$ShortArch\zlibstatic.lib";
+        ZLIB_INCLUDE_DIR = "$LibraryRoot\zlib-1.2.11\usr\include";
         dispatch_DIR = "$DispatchBinDir\cmake\modules";
       } + $TestingDefines)
   }
@@ -890,9 +890,17 @@ function Install-Redist($Arch)
 # Copies files installed by CMake from the arch-specific platform root,
 # where they follow the layout expected by the installer,
 # to the final platform root, following the installer layout.
-function Install-Platform($Arch)
+function Install-Platform($Arch, [switch] $Clean = $false)
 {
   if ($ToBatch) { return }
+
+  $PlatformInstallRoot = "$LibraryRoot\Developer\Platforms\Windows.platform"
+  $SDKInstallRoot = "$PlatformInstallRoot\Developer\SDKs\Windows.sdk"
+
+  if ($Clean)
+  {
+    Remove-Item -Force -Recurse $PlatformInstallRoot -ErrorAction Ignore
+  }
 
   New-Item -ItemType Directory -ErrorAction Ignore $SDKInstallRoot\usr | Out-Null
 
@@ -968,7 +976,7 @@ function Build-SQLite($Arch)
   Build-CMakeProject `
     -Src $SourceCache\sqlite-3.36.0 `
     -Bin "$($Arch.BinaryRoot)\sqlite-3.36.0" `
-    -InstallTo $InstallRoot\sqlite-3.36.0\usr `
+    -InstallTo $LibraryRoot\sqlite-3.36.0\usr `
     -Arch $Arch `
     -BuildTargets default `
     -Defines @{
@@ -1004,8 +1012,8 @@ function Build-ToolsSupportCore($Arch)
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
       SwiftSystem_DIR = "$BinaryCache\2\cmake\modules";
-      SQLite3_INCLUDE_DIR = "$InstallRoot\sqlite-3.36.0\usr\include";
-      SQLite3_LIBRARY = "$InstallRoot\sqlite-3.36.0\usr\lib\SQLite3.lib";
+      SQLite3_INCLUDE_DIR = "$LibraryRoot\sqlite-3.36.0\usr\include";
+      SQLite3_LIBRARY = "$LibraryRoot\sqlite-3.36.0\usr\lib\SQLite3.lib";
     }
 }
 
@@ -1023,8 +1031,8 @@ function Build-LLBuild($Arch)
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
       LLBUILD_SUPPORT_BINDINGS = "Swift";
-      SQLite3_INCLUDE_DIR = "$InstallRoot\sqlite-3.36.0\usr\include";
-      SQLite3_LIBRARY = "$InstallRoot\sqlite-3.36.0\usr\lib\SQLite3.lib";
+      SQLite3_INCLUDE_DIR = "$LibraryRoot\sqlite-3.36.0\usr\include";
+      SQLite3_LIBRARY = "$LibraryRoot\sqlite-3.36.0\usr\lib\SQLite3.lib";
     }
 }
 
@@ -1076,8 +1084,8 @@ function Build-Driver($Arch)
       LLBuild_DIR = "$BinaryCache\4\cmake\modules";
       Yams_DIR = "$BinaryCache\5\cmake\modules";
       ArgumentParser_DIR = "$BinaryCache\6\cmake\modules";
-      SQLite3_INCLUDE_DIR = "$InstallRoot\sqlite-3.36.0\usr\include";
-      SQLite3_LIBRARY = "$InstallRoot\sqlite-3.36.0\usr\lib\SQLite3.lib";
+      SQLite3_INCLUDE_DIR = "$LibraryRoot\sqlite-3.36.0\usr\include";
+      SQLite3_LIBRARY = "$LibraryRoot\sqlite-3.36.0\usr\lib\SQLite3.lib";
     }
 }
 
@@ -1162,8 +1170,8 @@ function Build-PackageManager($Arch)
       SwiftCollections_DIR = "$BinaryCache\9\cmake\modules";
       SwiftASN1_DIR = "$BinaryCache\10\cmake\modules";
       SwiftCertificates_DIR = "$BinaryCache\11\cmake\modules";
-      SQLite3_INCLUDE_DIR = "$InstallRoot\sqlite-3.36.0\usr\include";
-      SQLite3_LIBRARY = "$InstallRoot\sqlite-3.36.0\usr\lib\SQLite3.lib";
+      SQLite3_INCLUDE_DIR = "$LibraryRoot\sqlite-3.36.0\usr\include";
+      SQLite3_LIBRARY = "$LibraryRoot\sqlite-3.36.0\usr\lib\SQLite3.lib";
     }
 }
 
@@ -1223,6 +1231,8 @@ function Build-SourceKitLSP($Arch)
 function Install-HostToolchain()
 {
   if ($ToBatch) { return }
+  
+  $ToolchainInstallRoot = "$LibraryRoot\Developer\Toolchains\unknown-Asserts-development.xctoolchain"
 
   Remove-Item -Force -Recurse $ToolchainInstallRoot -ErrorAction Ignore
   Copy-Directory "$($HostArch.ToolchainInstallRoot)\usr" $ToolchainInstallRoot\
@@ -1297,10 +1307,11 @@ foreach ($Arch in $SDKArchs)
 
 if (-not $SkipInstall -and -not $ToBatch)
 {
-  Remove-Item -Force -Recurse $PlatformInstallRoot -ErrorAction Ignore
+  $InstallArgs = @("-Clean")
   foreach ($Arch in $SDKArchs)
   {
-    Install-Platform $Arch
+    Install-Platform $Arch @InstallArgs
+    $InstallArgs = @()
   }
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -1225,7 +1225,7 @@ function Build-SourceKitLSP($Arch)
 function Install-HostToolchain()
 {
   if ($ToBatch) { return }
-  
+
   Remove-Item -Force -Recurse $ToolchainInstallRoot -ErrorAction Ignore
   Copy-Directory "$($HostArch.ToolchainInstallRoot)\usr" $ToolchainInstallRoot\
 

--- a/build.ps1
+++ b/build.ps1
@@ -76,9 +76,9 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 3.0
 
+$ToolchainInstallRoot = "$LibraryRoot\Developer\Toolchains\unknown-Asserts-development.xctoolchain"
 $PlatformInstallRoot = "$LibraryRoot\Developer\Platforms\Windows.platform"
 $SDKInstallRoot = "$PlatformInstallRoot\Developer\SDKs\Windows.sdk"
-$ToolchainInstallRoot = "$LibraryRoot\Developer\Toolchains\unknown-Asserts-development.xctoolchain"
 
 $vswhere = "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
 $VSInstallRoot = & $vswhere -nologo -latest -products "*" -all -prerelease -property installationPath

--- a/build.ps1
+++ b/build.ps1
@@ -64,7 +64,7 @@ PS> .\Build.ps1 -SDKs x64 -ProductVersion 1.2.3 -Test foundation,xctest
 param(
   [string] $SourceCache = "S:\SourceCache",
   [string] $BinaryCache = "S:\b",
-  [switch] $LibraryRoot = "S:\Library",
+  [string] $LibraryRoot = "S:\Library",
   [string] $BuildType = "Release",
   [string[]] $SDKs = @("X64","X86","Arm64"),
   [string] $ProductVersion = "0.0.0",


### PR DESCRIPTION
The Apple CI cannot write to this path so this changes adds a `$LibraryRoot` parameter to customize that path.

We also cannot fully skip the install step because later build steps require the restructured SDK, so `$SkipInstall` becomes `$SkipRedistInstall` to avoid writing to `S:\Program Files`.