### PR TITLE
Fix python version for arm64 installation

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -416,7 +416,8 @@ jobs:
     needs: [context, build_tools]
 
     env:
-      PYTHON_VERSION: 3.9
+      # Must be a full version string from https://www.nuget.org/packages/pythonarm64
+      PYTHON_VERSION: 3.9.10
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
For arm64, we install python through nuget and the nuget cli only supports specifying the full version, so `3.9` becomes `3.9.10`