### PR TITLE
name GH steps for easier parsing in GH's UI & drop icu special casing

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -576,12 +576,11 @@ jobs:
       - name: Install Compiler Distribution
         run: cmake --build ${{ github.workspace }}/BinaryCache/1 --target install-distribution-stripped
 
-      - uses: actions/upload-artifact@v3
+      - name: Upload Compilers
+        uses: actions/upload-artifact@v3
         with:
           name: compilers-${{ matrix.arch }}
-          path: |
-            ${{ github.workspace }}/BuildRoot/Library
-            !${{ github.workspace }}/BuildRoot/Library/icu-69.1
+          path: ${{ github.workspace }}/BuildRoot/Library
 
       # TODO(compnerd) this takes ~1h due to the size, see if we can compress first
       - uses: actions/upload-artifact@v3
@@ -808,7 +807,8 @@ jobs:
         with:
           name: zlib-${{ matrix.arch }}-1.2.11
           path: ${{ github.workspace }}/BuildRoot/Library/zlib-1.2.11/usr
-      - uses: actions/download-artifact@v3
+      - name: Download Compilers
+        uses: actions/download-artifact@v3
         with:
           name: compilers-amd64
           path: ${{ github.workspace }}/BuildRoot/Library
@@ -1067,7 +1067,8 @@ jobs:
         with:
           name: sqlite-${{ matrix.arch }}-3.36.0
           path: ${{ github.workspace }}/BuildRoot/Library/sqlite-3.36.0/usr
-      - uses: actions/download-artifact@v3
+      - name: Download Compilers
+        uses: actions/download-artifact@v3
         with:
           name: compilers-amd64
           path: ${{ github.workspace }}/BuildRoot/Library
@@ -1621,7 +1622,8 @@ jobs:
         arch: ['amd64'] # , 'arm64']
 
     steps:
-      - uses: actions/download-artifact@v3
+      - name: Download Compilers
+        uses: actions/download-artifact@v3
         with:
           name: compilers-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library


### PR DESCRIPTION
This PR came out of a test to see if compressing & uploading the compilers would be faster.
Turns out it's not, but zipping and then uploading takes a bit longer (~9 vs. 8 minutes).

While at it though, let's:

* name GH actions steps, for easier parsing in GH's UI
* drop excluding icu-69.1 - it's not there (anymore)