### PR TITLE
Azure: mark IndexStoreDB as static builds

### DIFF
--- a/.azure/vs2022-swift-5.9.yml
+++ b/.azure/vs2022-swift-5.9.yml
@@ -1425,7 +1425,7 @@ stages:
             inputs:
               cmakeArgs:
                 -B $(Agent.BuildDirectory)/indexstore-db
-                -D BUILD_SHARED_LIBS=YES
+                -D BUILD_SHARED_LIBS=NO
                 -D BUILD_TESTING=NO
                 -D CMAKE_BUILD_TYPE=Release
                 -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe

--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -1422,7 +1422,7 @@ stages:
             inputs:
               cmakeArgs:
                 -B $(Agent.BuildDirectory)/indexstore-db
-                -D BUILD_SHARED_LIBS=YES
+                -D BUILD_SHARED_LIBS=NO
                 -D BUILD_TESTING=NO
                 -D CMAKE_BUILD_TYPE=Release
                 -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe


### PR DESCRIPTION
These are expected to be built statically with
https://github.com/apple/swift-installer-scripts/pull/165.