### PR TITLE
Azure: add build tag support for development builds

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -152,6 +152,10 @@ parameters:
     type: string
     default: '3.9.10'
 
+  - name: BuildTag
+    type: string
+    default: ''
+
 stages:
   - stage: tools
     dependsOn: []
@@ -1813,6 +1817,6 @@ stages:
                 -p:MSI_LOCATION=$(Build.SourcesDirectory)
                 -p:IntermediateOutputPath=$(Agent.BuildDirectory)\
                 -p:OutputPath=$(Agent.BuildDirectory)\
-                -p:ProductVersion=${{ parameters.ProductVersion }}
+                -p:ProductVersion=${{ parameters.ProductVersion }}${{ parameters.BuildTag }}
           - publish: $(Agent.BuildDirectory)/installer.exe
             artifact: installer-$(arch)


### PR DESCRIPTION
This replicates the build tag support for the main branch snapshots.