### PR TITLE
GHA: update some action versions

### DIFF
--- a/.github/workflows/swift-format.yml
+++ b/.github/workflows/swift-format.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       # Build
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
           ref: refs/tags/swift-5.7.2-RELEASE
@@ -35,14 +35,14 @@ jobs:
           swift build -c release -Xcc -IC:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\include -Xlinker -LC:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\lib
 
       # Package
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
           ref: refs/heads/main
           repository: apple/swift-installer-scripts
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
 
-      - uses: microsoft/setup-msbuild@v1.0.3
+      - uses: microsoft/setup-msbuild@v1.3.1
 
       - name: package
         run: |


### PR DESCRIPTION
Update the version of the actions for SwiftFormat workflow to reduce the amount of warnings due to the use of deprecated node.js versions.