### PR TITLE
Update swift-format.yml

### DIFF
--- a/.github/workflows/swift-format.yml
+++ b/.github/workflows/swift-format.yml
@@ -58,6 +58,6 @@ jobs:
           prerelease: true
           name: swift-format-${{ matrix.tag }}
           tag_name: swift-format-${{ matrix.tag }}
-          files:
+          files: |
             .build/x86_64-unknown-windows-msvc/release/swift-format.exe
             ${{ env.MSI_PATH }}

--- a/.github/workflows/swift-format.yml
+++ b/.github/workflows/swift-format.yml
@@ -49,28 +49,15 @@ jobs:
           msbuild ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/swift-format.wixproj -nologo -restore -p:Configuration=Release -p:ProductVersion=5.8 -p:SWIFT_FORMAT_BUILD=${{ github.workspace }}\.build\release -p:OutputPath=${{ github.workspace }}\artifacts -p:RunWixToolsOutOfProc=true
 
       # Release
-      - uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        id: create_release
+      - run: |
+          $MSI_PATH = cygpath -m ${{ github.workspace }}\artifacts\swift-format.msi
+          Echo MSI_PATH=$MSI_PATH | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+      - uses: softprops/action-gh-release@v1
         with:
           draft: true
           prerelease: true
-          release_name: swift-format-${{ matrix.tag }}
+          name: swift-format-${{ matrix.tag }}
           tag_name: swift-format-${{ matrix.tag }}
-      - uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          asset_content_type: application/octet-stream
-          asset_name: swift-format.exe
-          asset_path: .build\x86_64-unknown-windows-msvc\release\swift-format.exe
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-      - uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          asset_content_type: application/octet-stream
-          asset_name: swift-format.msi
-          asset_path: ${{ github.workspace }}\artifacts\swift-format.msi
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          files:
+            .build/x86_64-unknown-windows-msvc/release/swift-format.exe
+            ${{ env.MSI_PATH }}


### PR DESCRIPTION
Update the release path in the workflow to use softprops/action-gh-release rather than the actions workflows as the latter have been deprecated.