### PR TITLE
GHA: correct a typo in the tag

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1852,7 +1852,7 @@ jobs:
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:MSI_LOCATION=${{ github.workspace }}/BuildRoot `
-              -p:ProductVersion=${{ needs.context.outputs.swift_version }}${{ needs.context.otuputs.swift_tag }} `
+              -p:ProductVersion=${{ needs.context.outputs.swift_version }}${{ needs.context.outputs.swift_tag }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/installer.wixproj
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Correct a typo that is responsible for applying the tag to the build version information.