### PR TITLE
build.ps1: fail quickly if run in a Developer shell instead of failing 30m later due to architecture mismatch.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -84,6 +84,13 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 3.0
 
+# Avoid being run in a "Developer" shell since this script launches its own sub-shells targeting
+# different architectures, and these variables cause confusion.
+if ($env:VSCMD_ARG_HOST_ARCH -ne $null -or $env:VSCMD_ARG_TGT_ARCH -ne $null)
+{
+  throw "At least one of VSCMD_ARG_HOST_ARCH and VSCMD_ARG_TGT_ARCH is set, which is incompatible with this script. Likely need to run outside of a Developer shell."
+}
+
 # Prevent elsewhere-installed swift modules from confusing our builds.
 $Env:SDKROOT = ""
 $NativeProcessorArchName = $env:PROCESSOR_ARCHITEW6432


### PR DESCRIPTION
Example failure this prevents:
```
-- The C compiler identification is Clang 16.0.0 with MSVC-like command-line
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - failed
-- Check for working C compiler: S:/b/1/bin/clang-cl.exe
-- Check for working C compiler: S:/b/1/bin/clang-cl.exe - broken
CMake Error at C:/Program Files/CMake/share/cmake-3.26/Modules/CMakeTestCCompiler.cmake:67 (message):
  The C compiler

    "S:/b/1/bin/clang-cl.exe"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: S:/b/201/CMakeFiles/CMakeScratch/TryCompile-iqrula

    Run Build Command(s):C:/PROGRA~1/MICROS~2/2022/COMMUN~1/Common7/IDE/COMMON~1/MICROS~1/CMake/Ninja/ninja.exe -v cmTC_9369d && [1/2] S:\b\1\bin\clang-cl.exe --target=i686-unknown-windows-msvc  /nologo   /GS- /Gw /Gy /Oi /Oy /Zi /Zc:inline  /Zi /Ob0 /Od /RTC1 -MDd /showIncludes /FoCMakeFiles\cmTC_9369d.dir\testCCompiler.c.obj /FdCMakeFiles\cmTC_9369d.dir\ -c -- S:\b\201\CMakeFiles\CMakeScratch\TryCompile-iqrula\testCCompiler.c
    [2/2] cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_exe --intdir=CMakeFiles\cmTC_9369d.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100220~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100220~1.0\x64\mt.exe --manifests  -- S:\b\1\bin\lld-link.exe /nologo CMakeFiles\cmTC_9369d.dir\testCCompiler.c.obj  /out:cmTC_9369d.exe /implib:cmTC_9369d.lib /pdb:cmTC_9369d.pdb /version:0.0 /machine:X86  /debug /INCREMENTAL /subsystem:console  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && cd ."
    FAILED: cmTC_9369d.exe
    cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_exe --intdir=CMakeFiles\cmTC_9369d.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100220~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100220~1.0\x64\mt.exe --manifests  -- S:\b\1\bin\lld-link.exe /nologo CMakeFiles\cmTC_9369d.dir\testCCompiler.c.obj  /out:cmTC_9369d.exe /implib:cmTC_9369d.lib /pdb:cmTC_9369d.pdb /version:0.0 /machine:X86  /debug /INCREMENTAL /subsystem:console  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && cd ."
    LINK Pass 1: command "S:\b\1\bin\lld-link.exe /nologo CMakeFiles\cmTC_9369d.dir\testCCompiler.c.obj /out:cmTC_9369d.exe /implib:cmTC_9369d.lib /pdb:cmTC_9369d.pdb /version:0.0 /machine:X86 /debug /INCREMENTAL /subsystem:console kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:CMakeFiles\cmTC_9369d.dir/intermediate.manifest CMakeFiles\cmTC_9369d.dir/manifest.res" failed (exit code 1) with the following output:
    lld-link: error: <root>: undefined symbol: _mainCRTStartup
    ninja: build stopped: subcommand failed.
```