### PR TITLE
build: use DWARF for the SDK builds

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -389,11 +389,13 @@ function Build-CMakeProject
   if ($UseBuiltCompilers.Contains("C")) {
     TryAdd-KeyValue $Defines CMAKE_C_COMPILER "$BinaryCache\1\bin\clang-cl.exe"
     TryAdd-KeyValue $Defines CMAKE_C_COMPILER_TARGET $Arch.LLVMTarget
+    Append-FlagsDefine $Defines CMAKE_C_FLAGS -gdwarf
     Append-FlagsDefine $Defines CMAKE_C_FLAGS $CFlags
   }
   if ($UseBuiltCompilers.Contains("CXX")) {
     TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER "$BinaryCache\1\bin\clang-cl.exe"
     TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER_TARGET $Arch.LLVMTarget
+    Append-FlagsDefine $Defines CMAKE_CXX_FLAGS -gdwarf
     Append-FlagsDefine $Defines CMAKE_CXX_FLAGS $CXXFlags
   }
   if ($UseBuiltCompilers.Contains("Swift")) {
@@ -414,9 +416,11 @@ function Build-CMakeProject
     }
 
     # Debug Information
-    $SwiftArgs.Add("-g -debug-info-format=codeview") | Out-Null
+    # $SwiftArgs.Add("-g -debug-info-format=codeview") | Out-Null
+    $SwiftArgs.Add("-g") | Out-Null
+    $SwiftArgs.Add("-use-ld=lld-link") | Out-Null
     $SwiftArgs.Add("-Xlinker /INCREMENTAL:NO") | Out-Null
-    $SwiftArgs.Add("-Xlinker /DEBUG") | Out-Null
+    $SwiftArgs.Add("-Xlinker /DEBUG:DWARF") | Out-Null
 
     # Swift Requries COMDAT folding and de-duplication
     $SwiftArgs.Add("-Xlinker /OPT:REF") | Out-Null


### PR DESCRIPTION
This adjusts the builds for the SDK to switch to DWARF.  This is problematic in many ways:
  - it adds code bloat
  - it slows down linking
  - it slightly reduces incremental builds
  - the debug information is not possible to be saved
  - the resultant binaries are in violation of the COFF specification

Given all the issues, this is still valuable as a change to enable easier debugging.  The official builds remain building with CodeView which means that the PDBs can be linked in parallel, we do not bloat the released binaries, while we get a better debugging experience locally.