### PR TITLE
build: use updated project names for packaging

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1345,7 +1345,22 @@ function Install-HostToolchain()
 
 function Build-Installer()
 {
-  Build-WiXProject toolchain.wixproj -Arch $HostArch -Properties @{
+  Build-WiXProject bld.wixproj -Arch $HostArch -Properties @{
+    DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
+    TOOLCHAIN_ROOT = "$($HostArch.ToolchainInstallRoot)\";
+  }
+
+  Build-WiXProject cli.wixproj -Arch $HostArch -Properties @{
+    DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
+    TOOLCHAIN_ROOT = "$($HostArch.ToolchainInstallRoot)\";
+  }
+
+  Build-WiXProject dbg.wixproj -Arch $HostArch -Properties @{
+    DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
+    TOOLCHAIN_ROOT = "$($HostArch.ToolchainInstallRoot)\";
+  }
+
+  Build-WiXProject ide.wixproj -Arch $HostArch -Properties @{
     DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
     TOOLCHAIN_ROOT = "$($HostArch.ToolchainInstallRoot)\";
   }
@@ -1361,10 +1376,6 @@ function Build-Installer()
       SDK_ROOT = "$($Arch.SDKInstallRoot)\";
       SWIFT_SOURCE_DIR = "$SourceCache\swift\";
     }
-  }
-
-  Build-WiXProject devtools.wixproj -Arch $HostArch -Properties @{
-    DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
   }
 
   Build-WiXProject installer.wixproj -Arch $HostArch -Bundle -Properties @{


### PR DESCRIPTION
The rules for the packaging have been changed to reflect the split MSIs:
- bld (Build Tools)
- cli (CLI Tools)
- dbg (Debugging Tools)
- ide (IDE Integration Tools)
- sdk (Platform SDKs)
- runtime (Platform runtime)