### PR TITLE
build: add DocC to the default built

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1341,6 +1341,16 @@ function Build-Format() {
     -Arch $HostArch
 }
 
+function Build-DocC() {
+  $OutDir = Join-Path -Path $HostArch.BinaryRoot -ChildPath swift-docc
+
+  Build-SPMProject `
+    -Src $SourceCache\swift-docc `
+    -Bin $OutDir `
+    -Arch $HostArch `
+    --product docc
+}
+
 function Build-Installer() {
   Build-WiXProject bld.wixproj -Arch $HostArch -Properties @{
     DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
@@ -1446,6 +1456,7 @@ Install-HostToolchain
 if (-not $SkipBuild) {
   Build-Inspect $HostArch
   Build-Format $HostArch
+  Build-DocC $HostArch
 }
 
 if (-not $SkipPackaging) {


### PR DESCRIPTION
DocC is not yet part of the distribution on Windows as we are progressing towards passing the test suite.  However, other products were released before the test suites were completely passing and that would remain an option here.  Begin building this tool as part of the build as it is meant to be part of the distribution.