### PR TITLE
build: repair the build of the ARM64 SDK

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -944,6 +944,7 @@ function Install-Redist($Arch) {
   if ($ToBatch) { return }
 
   $RedistInstallRoot = Get-RuntimeInstallRoot $Arch
+  if ($null -eq $RedistInstallRoot) { return }
 
   Remove-Item -Force -Recurse $RedistInstallRoot -ErrorAction Ignore
   Copy-Directory "$($Arch.SDKInstallRoot)\usr\bin" "$RedistInstallRoot\usr"


### PR DESCRIPTION
This is needed when testing the full packaging rules.  We had accidentally regressed this build.