### PR TITLE
build: mark installers for the host platform

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1378,6 +1378,7 @@ function Build-Installer() {
     }
 
     Build-WiXProject sdk.wixproj -Arch $Arch -Properties @{
+      InstallerPlatform = $HostArch.ShortName;
       PLATFORM_ROOT = "$($Arch.PlatformInstallRoot)\";
       SDK_ROOT = "$($Arch.SDKInstallRoot)\";
       SWIFT_SOURCE_DIR = "$SourceCache\swift\";


### PR DESCRIPTION
The SDK installer is marked for the host platform irrespective of the SDK content.  This is required to permit installation of the foreign architecture SDK.