### PR TITLE
build: add a workaround for CMake 3.26.0

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -381,6 +381,9 @@ function Build-CMakeProject {
   if ($UseBuiltCompilers.Contains("C")) {
     TryAdd-KeyValue $Defines CMAKE_C_COMPILER "$BinaryCache\1\bin\clang-cl.exe"
     TryAdd-KeyValue $Defines CMAKE_C_COMPILER_TARGET $Arch.LLVMTarget
+
+    TryAdd-KeyValue $Defines CMAKE_CL_SHOWINCLUDES_PREFIX "Note: including file: "
+
     if ($GenerateDebugInfo -and $CDebugFormat -eq "dwarf") {
       Append-FlagsDefine $Defines CMAKE_C_FLAGS -gdwarf
     }
@@ -389,6 +392,9 @@ function Build-CMakeProject {
   if ($UseBuiltCompilers.Contains("CXX")) {
     TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER "$BinaryCache\1\bin\clang-cl.exe"
     TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER_TARGET $Arch.LLVMTarget
+
+    TryAdd-KeyValue $Defines CMAKE_CL_SHOWINCLUDES_PREFIX "Note: including file: "
+
     if ($GenerateDebugInfo -and $CDebugFormat -eq "dwarf") {
       Append-FlagsDefine $Defines CMAKE_CXX_FLAGS -gdwarf
     }


### PR DESCRIPTION
MSVC distributes CMake 3.26.0, which does not properly handle `clang-cl`'s output for `/showIncludes`.  Add a workaround until MSVC updates the CMake distributed to 3.26.3 or newer.

See: ninja-build/ninja#2280