### PR TITLE
build: repair the ARM64 build of ICU on ARM64

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -759,7 +759,7 @@ function Build-ICU($Arch) {
     }
   }
 
-  if ($Arch -eq $ArchARM64) {
+  if ($Arch -eq $ArchARM64 -and $HostArch -ne $ArchARM64) {
     # Use previously built x64 tools
     $BuildToolsDefines = @{
       BUILD_TOOLS = "NO";


### PR DESCRIPTION
When building on ARM64 ensure that we build the tools as there is no need to have the X64 variant be used for this.