### PR TITLE
build: add a workaround for the C++ driver

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -432,6 +432,7 @@ function Build-CMakeProject {
 
     # Workaround CMake 3.26+ enabling `-wmo` by default on release builds
     Append-FlagsDefine $Defines CMAKE_Swift_FLAGS_RELEASE "-O"
+    Append-FlagsDefine $Defines CMAKE_Swift_FLAGS_RELWITHDEBINFO "-O"
   }
   if ("" -ne $InstallTo) {
     TryAdd-KeyValue $Defines CMAKE_INSTALL_PREFIX $InstallTo


### PR DESCRIPTION
Add a wrokaround for RelWithDebInfo builds which use the C++ driver during the bootstrap phase.  The old driver is unable to properly handle the WMO optimization, treating the bitcode improperly.  Disable WMO on RelWithDebInfo builds as a workaround.