### PR TITLE
build.ps1: Make cmake invocation explicit for version testing

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -331,7 +331,7 @@ function Append-FlagsDefine([hashtable]$Defines, [string]$Name, [string]$Value) 
 }
 
 function Test-CMakeAtLeast([int]$Major, [int]$Minor, [int]$Patch = 0) {
-  $CMakeVersionString = @(cmake --version)[0]
+  $CMakeVersionString = @(& cmake.exe --version)[0]
   if (-not ($CMakeVersionString -match "^cmake version (\d+)\.(\d+)(?:\.(\d+))?")) {
     throw "Unexpected CMake version string format"
   }


### PR DESCRIPTION
`&` tells powershell that we're executing a command and not looking for a function.