### PR TITLE
Add a build workaround for the swift-inspect release build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1357,7 +1357,8 @@ function Build-Inspect() {
     -Src $SourceCache\swift\tools\swift-inspect `
     -Bin $OutDir `
     -Arch $HostArch `
-    -Xcc "-I$($HostArch.SDKInstallRoot)\usr\include\swift\SwiftRemoteMirror" -Xlinker "$($HostArch.SDKInstallRoot)\usr\lib\swift\windows\$($HostArch.LLVMName)\swiftRemoteMirror.lib"
+    -Xcc "-I$($HostArch.SDKInstallRoot)\usr\include\swift\SwiftRemoteMirror" -Xlinker "$($HostArch.SDKInstallRoot)\usr\lib\swift\windows\$($HostArch.LLVMName)\swiftRemoteMirror.lib" `
+    -Xcc -Xclang -Xcc -fno-split-cold-code # Workaround https://github.com/llvm/llvm-project/issues/40056
 }
 
 function Build-Format() {


### PR DESCRIPTION
swift-inspect will fail to build in release mode after the dump-arrays PR (https://github.com/apple/swift/pull/66973) due to an llvm bug (https://github.com/llvm/llvm-project/issues/40056). This is a workaround for it.