### PR TITLE
GHA: be more aggressive about disabling debug information

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2026,7 +2026,7 @@ jobs:
       - run: swift test
         working-directory: ${{ github.workspace }}/SourceCache/swift-format
 
-      - run: swift build -c release -Xswiftc -gnone
+      - run: swift build -debug-info-format none -c release
         working-directory: ${{ github.workspace }}/SourceCache/swift-format
 
       - uses: actions/checkout@v3
@@ -2110,7 +2110,7 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/swift
 
       - run: |
-          swift build -c release -Xswiftc -gnone -Xcc -I"${env:SDKROOT}"\usr\include\swift\SwiftRemoteMirror -Xlinker ${env:SDKROOT}\usr\lib\swift\windows\${{ matrix.cpu }}\swiftRemoteMirror.lib
+          swift build -debug-info-format none -c release -Xcc -I"${env:SDKROOT}"\usr\include\swift\SwiftRemoteMirror -Xlinker ${env:SDKROOT}\usr\lib\swift\windows\${{ matrix.cpu }}\swiftRemoteMirror.lib
         working-directory: ${{ github.workspace }}\SourceCache\swift\tools\swift-inspect
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
`-debug-info-format none` is more accurate about disabling the debug information generation.  We would previously generate the debug information for part of the code whereas this should entirely strip debug information.