### PR TITLE
Fix paths to wixproj files

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -1582,7 +1582,7 @@ stages:
             name: certificate
           - task: MSBuild@1
             inputs:
-              solution: $(Build.SourcesDirectory)/platforms/Windows/bld.wixproj
+              solution: $(Build.SourcesDirectory)/platforms/Windows/bld/bld.wixproj
               msbuildArchitecture: $(arch)
               platform: $(platform)
               configuration: Release
@@ -1600,7 +1600,7 @@ stages:
                 -p:ProductVersion=${{ parameters.ProductVersion }}
           - task: MSBuild@1
             inputs:
-              solution: $(Build.SourcesDirectory)/platforms/Windows/cli.wixproj
+              solution: $(Build.SourcesDirectory)/platforms/Windows/cli/cli.wixproj
               msbuildArchitecture: $(arch)
               platform: $(platform)
               configuration: Release
@@ -1618,7 +1618,7 @@ stages:
                 -p:ProductVersion=${{ parameters.ProductVersion }}
           - task: MSBuild@1
             inputs:
-              solution: $(Build.SourcesDirectory)/platforms/Windows/dbg.wixproj
+              solution: $(Build.SourcesDirectory)/platforms/Windows/dbg/dbg.wixproj
               msbuildArchitecture: $(arch)
               platform: $(platform)
               configuration: Release
@@ -1636,7 +1636,7 @@ stages:
                 -p:ProductVersion=${{ parameters.ProductVersion }}
           - task: MSBuild@1
             inputs:
-              solution: $(Build.SourcesDirectory)/platforms/Windows/ide.wixproj
+              solution: $(Build.SourcesDirectory)/platforms/Windows/ide/ide.wixproj
               msbuildArchitecture: $(arch)
               platform: $(platform)
               configuration: Release
@@ -1710,7 +1710,7 @@ stages:
             name: certificate
           - task: MSBuild@1
             inputs:
-              solution: $(Build.SourcesDirectory)/platforms/Windows/sdk.wixproj
+              solution: $(Build.SourcesDirectory)/platforms/Windows/sdk/sdk.wixproj
               msbuildArchitecture: $(arch)
               platform: $(platform)
               configuration: Release
@@ -1729,7 +1729,7 @@ stages:
                 -p:ProductVersion=${{ parameters.ProductVersion }}
           - task: MSBuild@1
             inputs:
-              solution: $(Build.SourcesDirectory)/platforms/Windows/runtime.wixproj
+              solution: $(Build.SourcesDirectory)/platforms/Windows/runtime/runtime.wixproj
               msbuildArchitecture: $(arch)
               platform: $(platform)
               configuration: Release
@@ -1811,7 +1811,7 @@ stages:
             name: certificate
           - task: MSBuild@1
             inputs:
-              solution: $(Build.SourcesDirectory)/platforms/Windows/installer.wixproj
+              solution: $(Build.SourcesDirectory)/platforms/Windows/bundle/installer.wixproj
               msbuildArchitecture: $(arch)
               platform: $(platform)
               configuration: Release

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1688,7 +1688,7 @@ jobs:
               -p:DEVTOOLS_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
               -p:TOOLCHAIN_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
               -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bld.wixproj
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bld/bld.wixproj
 
       - name: Package CLI Tools
         run: |
@@ -1703,7 +1703,7 @@ jobs:
               -p:DEVTOOLS_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
               -p:TOOLCHAIN_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
               -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/cli.wixproj
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/cli/cli.wixproj
 
       - name: Package Debugging Tools
         run: |
@@ -1718,7 +1718,7 @@ jobs:
               -p:DEVTOOLS_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
               -p:TOOLCHAIN_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
               -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/dbg.wixproj
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/dbg/dbg.wixproj
 
       - name: Package IDE Tools
         run: |
@@ -1733,7 +1733,7 @@ jobs:
               -p:DEVTOOLS_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
               -p:TOOLCHAIN_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
               -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/ide.wixproj
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/ide/ide.wixproj
 
       - uses: actions/upload-artifact@v3
         with:
@@ -1808,7 +1808,7 @@ jobs:
               -p:SDK_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk `
               -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
               -p:InstallerPlatform=${{ matrix.platform }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/sdk.wixproj
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/sdk/sdk.wixproj
 
       - name: Package Runtime
         run: |
@@ -1823,7 +1823,7 @@ jobs:
               -p:PLATFORM_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform `
               -p:SDK_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk `
               -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/runtime.wixproj
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/runtime/runtime.wixproj
 
       - uses: actions/upload-artifact@v3
         with:
@@ -1900,7 +1900,7 @@ jobs:
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:MSI_LOCATION=${{ github.workspace }}/BuildRoot `
               -p:ProductVersion=${{ needs.context.outputs.swift_version }}-${{ needs.context.outputs.swift_tag }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/installer.wixproj
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bundle/installer.wixproj
 
       - uses: actions/upload-artifact@v3
         with:

--- a/build.ps1
+++ b/build.ps1
@@ -1381,32 +1381,36 @@ function Build-DocC() {
 }
 
 function Build-Installer() {
-  Build-WiXProject bld.wixproj -Arch $HostArch -Properties @{
+  Build-WiXProject bld\bld.wixproj -Arch $HostArch -Properties @{
     DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
     TOOLCHAIN_ROOT = "$($HostArch.ToolchainInstallRoot)\";
   }
 
-  Build-WiXProject cli.wixproj -Arch $HostArch -Properties @{
+  Build-WiXProject cli\cli.wixproj -Arch $HostArch -Properties @{
     DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
     TOOLCHAIN_ROOT = "$($HostArch.ToolchainInstallRoot)\";
+    INCLUDE_SWIFT_FORMAT = "true";
+    SWIFT_FORMAT_BUILD = "$($HostArch.BinaryRoot)\swift-format\release";
   }
 
-  Build-WiXProject dbg.wixproj -Arch $HostArch -Properties @{
+  Build-WiXProject dbg\dbg.wixproj -Arch $HostArch -Properties @{
     DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
     TOOLCHAIN_ROOT = "$($HostArch.ToolchainInstallRoot)\";
+    INCLUDE_SWIFT_INSPECT = "true";
+    SWIFT_INSPECT_BUILD = "$($HostArch.BinaryRoot)\swift-inspect\release";
   }
 
-  Build-WiXProject ide.wixproj -Arch $HostArch -Properties @{
+  Build-WiXProject ide\ide.wixproj -Arch $HostArch -Properties @{
     DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
     TOOLCHAIN_ROOT = "$($HostArch.ToolchainInstallRoot)\";
   }
 
   foreach ($Arch in $SDKArchs) {
-    Build-WiXProject runtime.wixproj -Arch $Arch -Properties @{
+    Build-WiXProject runtime\runtime.wixproj -Arch $Arch -Properties @{
       SDK_ROOT = "$($Arch.SDKInstallRoot)\";
     }
 
-    Build-WiXProject sdk.wixproj -Arch $Arch -Properties @{
+    Build-WiXProject sdk\sdk.wixproj -Arch $Arch -Properties @{
       InstallerPlatform = $HostArch.ShortName;
       PLATFORM_ROOT = "$($Arch.PlatformInstallRoot)\";
       SDK_ROOT = "$($Arch.SDKInstallRoot)\";
@@ -1414,15 +1418,7 @@ function Build-Installer() {
     }
   }
 
-  Build-WiXProject swift-format.wixproj -Arch $HostArch -Properties @{
-    SWIFT_FORMAT_BUILD = "$($HostArch.BinaryRoot)\swift-format\release"
-  }
-
-  Build-WiXProject swift-inspect.wixproj -Arch $HostArch -Properties @{
-    SWIFT_INSPECT_BUILD = "$($HostArch.BinaryRoot)\swift-inspect\release"
-  }
-
-  Build-WiXProject installer.wixproj -Arch $HostArch -Bundle -Properties @{
+  Build-WiXProject bundle\installer.wixproj -Arch $HostArch -Bundle -Properties @{
     OutputPath = "$($HostArch.BinaryRoot)\";
     MSI_LOCATION = "$($HostArch.BinaryRoot)\msi\";
   }


### PR DESCRIPTION
To account for https://github.com/apple/swift-installer-scripts/pull/215

Some follow-up work will be required for the CI since swift-format and swift-lint are now packaged in cli/dbg msi's.