### PR TITLE
azure: look for VS BuildTools as well

### DIFF
--- a/.azure/vs2022-swift-5.9.yml
+++ b/.azure/vs2022-swift-5.9.yml
@@ -176,7 +176,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -306,7 +306,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -451,7 +451,7 @@ stages:
               copy $(Build.SourcesDirectory)\swift-installer-scripts\shared\ICU\CMakeLists.txt $(Build.SourcesDirectory)\icu\icu4c\CMakeLists.txt
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -554,7 +554,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -615,7 +615,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -710,7 +710,7 @@ stages:
               TargetFolder: $(Build.SourcesDirectory)/sqlite-3.36.0
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -767,7 +767,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -857,7 +857,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -1113,7 +1113,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -1562,7 +1562,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -1630,7 +1630,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -1709,7 +1709,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -1782,7 +1782,7 @@ stages:
               flattenFolders: true
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"

--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -177,7 +177,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -307,7 +307,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -452,7 +452,7 @@ stages:
               copy $(Build.SourcesDirectory)\swift-installer-scripts\shared\ICU\CMakeLists.txt $(Build.SourcesDirectory)\icu\icu4c\CMakeLists.txt
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -555,7 +555,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -616,7 +616,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -711,7 +711,7 @@ stages:
               TargetFolder: $(Build.SourcesDirectory)/sqlite-3.36.0
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -768,7 +768,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -858,7 +858,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -1114,7 +1114,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -1563,7 +1563,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -1691,7 +1691,7 @@ stages:
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
@@ -1792,7 +1792,7 @@ stages:
               flattenFolders: true
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-              FOR /f "usebackq delims=" %%i IN (`%vswhere% -latest -property installationPath`) DO (
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
                 SET vs="%%i"
                 IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
                   SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"


### PR DESCRIPTION
A bit of quality of life improvement. I have BuildTools installed, not Visual Studio. `vswhere` ignores BuildTools by default😔. This is one of the changes I have to make every time I try to run pipelines on a self-hosted runner. Would be nice to have it in the base🙏