### PR TITLE
Add swift-format stage

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -57,6 +57,11 @@ resources:
       name: apple/swift-cmark
       ref: refs/heads/gfm
       type: github
+    - repository: apple/swift-format
+      endpoint: GitHub
+      name: apple/swift-format
+      ref: refs/heads/main
+      type: github
     - repository: apple/swift-corelibs-libdispatch
       endpoint: GitHub
       name: apple/swift-corelibs-libdispatch
@@ -1540,9 +1545,122 @@ stages:
           - publish: $(Build.StagingDirectory)
             artifact: devtools-$(arch)
 
+  - stage: swift_format
+    dependsOn: [toolchain, sdk, devtools]
+    jobs:
+      - job: build
+        strategy:
+          matrix:
+            'x64':
+              arch: amd64
+              platform: x86_64
+              binDir: bin64
+            # TODO(compnerd) enable AArch64 toolchain
+            # 'arm64':
+            #   arch: arm64
+            #   platform: aarch64
+            #   binDir: bin64a
+        steps:
+          - download: current
+            artifact: toolchain-amd64
+          - download: current
+            artifact: windows-sdk-$(arch)
+          - download: current
+            artifact: devtools-amd64
+          - checkout: apple/swift-format
+            fetchDepth: 1
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                $LibraryRoot = "$(Agent.BuildDirectory)/Library"
+                $ToolchainInstallRoot = "$LibraryRoot/Developer/Toolchains/unknown-Asserts-development.xctoolchain"
+                $PlatformInstallRoot = "$LibraryRoot/Developer/Platforms/Windows.platform"
+                $SDKInstallRoot = "$PlatformInstallRoot/Developer/SDKs/Windows.sdk"
+                $ToolchainBinaryCache = "$(Agent.BuildDirectory)/toolchain-amd64"
+                $DevtoolsBinaryCache = "$(Agent.BuildDirectory)/devtools-amd64"
+                $PlatformBinaryCache = "$(Agent.BuildDirectory)/windows-sdk-$(arch)"
+
+                $SDKSourceRoot = "$PlatformBinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
+                $XCTestSourceRoot = "$PlatformBinaryCache/Library/Developer/Platforms/Windows.platform/Developer/Library/XCTest-development"
+
+                function Move-File($Src, $Dst) {
+                  $DstDir = [IO.Path]::GetDirectoryName($Dst)
+                  New-Item -ItemType Directory -ErrorAction Ignore $DstDir | Out-Null
+                  Move-Item -Force $Src $Dst
+                }
+
+                function Move-Directory($Src, $Dst) {
+                  New-Item -ItemType Directory -ErrorAction Ignore $Dst | Out-Null
+                  Get-Item $Src | ForEach-Object {
+                    $DstPath = Join-Path $Dst $_.Name
+                    if (!(Test-Path -Path $DstPath)) {
+                      Move-Item $_ $Dst
+                    } else {
+                      Get-ChildItem $_ -File | Move-Item -Force -Destination $DstPath
+                      Get-ChildItem $_ -Directory | ForEach-Object { Move-Directory $_.FullName $DstPath }
+                      Remove-Item $_
+                    }
+                  }
+                }
+
+                Remove-Item $LibraryRoot -Recurse -ErrorAction Ignore
+
+                # Install toolchain
+                #-----------------------------------------------------------------------------
+                Move-Directory $ToolchainBinaryCache/Library/Developer $LibraryRoot
+                Move-Directory $ToolchainInstallRoot/usr/lib/swift/_InternalSwiftScan $ToolchainInstallRoot/usr/include
+                Move-File $ToolchainInstallRoot/usr/lib/swift/windows/_InternalSwiftScan.lib $ToolchainInstallRoot/usr/lib/
+                Move-Directory $DevtoolsBinaryCache/Library/Developer $LibraryRoot
+                Move-File $ToolchainInstallRoot/usr/bin/swift-driver.exe $ToolchainInstallRoot/usr/bin/swift.exe
+                Copy-Item -Force $ToolchainInstallRoot/usr/bin/swift.exe $ToolchainInstallRoot/usr/bin/swiftc.exe
+
+                # Install platform
+                #-----------------------------------------------------------------------------
+                Move-Directory $SDKSourceRoot/usr/include/swift/SwiftRemoteMirror $SDKInstallRoot/usr/include/swift
+                Move-Directory $SDKSourceRoot/usr/lib/swift/shims $SDKInstallRoot/usr/lib/swift
+                foreach ($Module in ("Block", "dispatch", "os")) {
+                  Move-Directory $SDKSourceRoot/usr/lib/swift/$Module $SDKInstallRoot/usr/include
+                }
+                Move-File $SDKSourceRoot/usr/share/*.* $SDKInstallRoot/usr/share/
+
+                $WindowsLibSrc = "$SDKSourceRoot/usr/lib/swift/windows"
+                $WindowsLibDst = "$SDKInstallRoot/usr/lib/swift/windows"
+                Move-File $WindowsLibSrc/*.lib $WindowsLibDst/$(platform)/
+                Move-File $WindowsLibSrc/$(platform)/*.lib $WindowsLibDst/$(platform)/
+                Move-Directory $WindowsLibSrc/*.swiftmodule $WindowsLibDst
+
+                Get-ChildItem -Recurse $WindowsLibSrc/$(platform) | ForEach-Object {
+                  if (".swiftmodule", ".swiftdoc", ".swiftinterface" -contains $_.Extension) {
+                    $DstDir = "$WindowsLibDst/$($_.BaseName).swiftmodule"
+                    Move-File $_.FullName $DstDir/$(platform)-unknown-windows-msvc$($_.Extension)
+                  } else {
+                    Move-File $_.FullName $WindowsLibDst/$(platform)/
+                  }
+                }
+
+                $XCTestInstallRoot = "$PlatformInstallRoot/Developer/Library/XCTest-development"
+                Move-File $XCTestSourceRoot/usr/bin/XCTest.dll $XCTestInstallRoot/usr/$(binDir)/
+                Move-File $XCTestSourceRoot/usr/lib/swift/windows/XCTest.lib $XCTestInstallRoot/usr/lib/swift/windows/$(platform)/
+                Move-File $XCTestSourceRoot/usr/lib/swift/windows/$(platform)/XCTest.swiftmodule $XCTestInstallRoot/usr/lib/swift/windows/XCTest.swiftmodule/$(platform)-unknown-windows-msvc.swiftmodule
+                Move-File $XCTestSourceRoot/usr/lib/swift/windows/$(platform)/XCTest.swiftdoc $XCTestInstallRoot/usr/lib/swift/windows/XCTest.swiftmodule/$(platform)-unknown-windows-msvc.swiftdoc
+
+                Move-File $PlatformBinaryCache/Library/Developer/Platforms/Windows.platform/Info.plist $PlatformInstallRoot/
+                Move-File $SDKSourceRoot/SDKSettings.plist $SDKInstallRoot/
+
+                # Set up environment
+                #-----------------------------------------------------------------------------
+                Write-Host "##vso[task.setvariable variable=PATH;]$(Agent.BuildDirectory)\windows-sdk-$(arch)\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk\usr\bin;$(Agent.BuildDirectory)\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin;${env:Path}"
+                Write-Host "##vso[task.setvariable variable=SDKROOT;]$(Agent.BuildDirectory)\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk"
+          - script: |
+              cd $(Build.SourcesDirectory)
+              swift build -c release --scratch-path $(Agent.BuildDirectory)/swift-format -Xswiftc -gnone
+          - publish: $(Agent.BuildDirectory)/swift-format/release
+            artifact: swift-format-$(arch)
+
   - stage: package_tools
     displayName: Tools MSIs
-    dependsOn: [toolchain, devtools]
+    dependsOn: [toolchain, devtools, swift_format]
     jobs:
       - job: build
         strategy:
@@ -1559,6 +1677,8 @@ stages:
             artifact: toolchain-$(arch)
           - download: current
             artifact: devtools-$(arch)
+          - download: current
+            artifact: swift-format-$(arch)
           - checkout: apple/swift-installer-scripts
             fetchDepth: 1
           - script: |
@@ -1595,6 +1715,8 @@ stages:
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
                 -p:DEVTOOLS_ROOT=$(Pipeline.Workspace)/devtools-$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
                 -p:TOOLCHAIN_ROOT=$(Pipeline.Workspace)/toolchain-$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
+                -p:SWIFT_FORMAT_BUILD=$(Pipeline.Workspace)/swift-format-$(arch)/release
+                -p:INCLUDE_SWIFT_FORMAT=true
                 -p:IntermediateOutputPath=$(Agent.BuildDirectory)\
                 -p:OutputPath=$(Agent.BuildDirectory)\
                 -p:ProductVersion=${{ parameters.ProductVersion }}


### PR DESCRIPTION
This attempt uses `build.ps1` as the tool to restructure SDK/Toolchain. While we probably want to avoid using `build.ps1` this way, this still works and proves the concept. I would continue working on standalone restructuring step.

Also, I didn't manage to run the whole pipeline on Azure-hosted agent (i.e. just like original pipeline), because it exceeded 6h quota again😔But testing partially on self-hosted runner demonstrated promising results.
