### PR TITLE
Disable swift-format and swift-inspect builds

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -43,7 +43,7 @@ jobs:
       swift_crypto_revision: ${{ steps.context.outputs.swift_crypto_revision }}
       swift_driver_revision: ${{ steps.context.outputs.swift_driver_revision }}
       swift_experimental_string_processing_revision: ${{ steps.context.outputs.swift_experimental_string_processing_revision }}
-      swift_format_revision: ${{ steps.context.outputs.swift_format_revision }}
+      # swift_format_revision: ${{ steps.context.outputs.swift_format_revision }}
       swift_installer_scripts_revision: ${{ steps.context.outputs.swift_installer_scripts_revision }}
       swift_llbuild_revision: ${{ steps.context.outputs.swift_llbuild_revision }}
       swift_package_manager_revision: ${{ steps.context.outputs.swift_package_manager_revision }}
@@ -1702,6 +1702,7 @@ jobs:
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:DEVTOOLS_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
               -p:TOOLCHAIN_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
+              -p:SWIFT_FORMAT_BUILD=false `
               -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/cli/cli.wixproj
 
@@ -1717,6 +1718,7 @@ jobs:
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:DEVTOOLS_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
               -p:TOOLCHAIN_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
+              -p:SWIFT_INSPECT_BUILD=false `
               -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/dbg/dbg.wixproj
 
@@ -1963,179 +1965,179 @@ jobs:
       - run: swift test -Xswiftc -DENABLE_TESTING
         working-directory: ${{ github.workspace }}/SourceCache/swift-win32
 
-  swift_format:
-    runs-on: windows-latest
-    needs: [context, installer]
+  # swift_format:
+  #   runs-on: windows-latest
+  #   needs: [context, installer]
 
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: 'amd64'
-            cpu: 'x86_64'
-            triple: 'x86_64-unknown-windows-msvc'
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - arch: 'amd64'
+  #           cpu: 'x86_64'
+  #           triple: 'x86_64-unknown-windows-msvc'
 
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: installer-${{ matrix.arch }}
-          path: ${{ github.workspace }}/tmp
+  #   steps:
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: installer-${{ matrix.arch }}
+  #         path: ${{ github.workspace }}/tmp
 
-      # TODO(compnerd) can this be done via a re-usage workflow for swift-format?
+  #     # TODO(compnerd) can this be done via a re-usage workflow for swift-format?
 
-      # TODO(compnerd): migrate this to compnerd/gha-setup-swift after the work that @mangini is doing is completed
-      - run: |
-          function Update-EnvironmentVariables {
-            foreach ($level in "Machine", "User") {
-              [Environment]::GetEnvironmentVariables($level).GetEnumerator() | % {
-                # For Path variables, append the new values, if they're not already in there
-                if ($_.Name -Match 'Path$') {
-                  $_.Value = ($((Get-Content "Env:$($_.Name)") + ";$($_.Value)") -Split ';' | Select -Unique) -Join ';'
-                }
-                $_
-              } | Set-Content -Path { "Env:$($_.Name)" }
-            }
-          }
+  #     # TODO(compnerd): migrate this to compnerd/gha-setup-swift after the work that @mangini is doing is completed
+  #     - run: |
+  #         function Update-EnvironmentVariables {
+  #           foreach ($level in "Machine", "User") {
+  #             [Environment]::GetEnvironmentVariables($level).GetEnumerator() | % {
+  #               # For Path variables, append the new values, if they're not already in there
+  #               if ($_.Name -Match 'Path$') {
+  #                 $_.Value = ($((Get-Content "Env:$($_.Name)") + ";$($_.Value)") -Split ';' | Select -Unique) -Join ';'
+  #               }
+  #               $_
+  #             } | Set-Content -Path { "Env:$($_.Name)" }
+  #           }
+  #         }
 
-          try {
-            Write-Host "Starting Install installer.exe..."
-            $Process = Start-Process -FilePath ${{ github.workspace }}/tmp/installer.exe -ArgumentList ("-q") -Wait -PassThru
-            $ExitCode = $Process.ExitCode
-            if ($ExitCode -eq 0 -or $ExitCode -eq 3010) {
-              Write-Host "Installation successful"
-            } else {
-              Write-Host "non-zero exit code returned by the installation process: $ExitCode"
-              exit $ExitCode
-            }
-          } catch {
-            Write-Host "Failed to install: $($_.Exception.Message)"
-            exit 1
-          }
-          Update-EnvironmentVariables
+  #         try {
+  #           Write-Host "Starting Install installer.exe..."
+  #           $Process = Start-Process -FilePath ${{ github.workspace }}/tmp/installer.exe -ArgumentList ("-q") -Wait -PassThru
+  #           $ExitCode = $Process.ExitCode
+  #           if ($ExitCode -eq 0 -or $ExitCode -eq 3010) {
+  #             Write-Host "Installation successful"
+  #           } else {
+  #             Write-Host "non-zero exit code returned by the installation process: $ExitCode"
+  #             exit $ExitCode
+  #           }
+  #         } catch {
+  #           Write-Host "Failed to install: $($_.Exception.Message)"
+  #           exit 1
+  #         }
+  #         Update-EnvironmentVariables
 
-          # Reset Path and environment
-          echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-          Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
+  #         # Reset Path and environment
+  #         echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+  #         Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
 
-      - uses: actions/checkout@v3
-        with:
-          repository: apple/swift-format
-          ref: ${{ needs.context.outputs.swift_format_revision }}
-          path: ${{ github.workspace }}/SourceCache/swift-format
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         repository: apple/swift-format
+  #         ref: ${{ needs.context.outputs.swift_format_revision }}
+  #         path: ${{ github.workspace }}/SourceCache/swift-format
 
-      - run: swift test
-        working-directory: ${{ github.workspace }}/SourceCache/swift-format
+  #     - run: swift test
+  #       working-directory: ${{ github.workspace }}/SourceCache/swift-format
 
-      - run: swift build -debug-info-format none -c release
-        working-directory: ${{ github.workspace }}/SourceCache/swift-format
+  #     - run: swift build -debug-info-format none -c release
+  #       working-directory: ${{ github.workspace }}/SourceCache/swift-format
 
-      - uses: actions/checkout@v3
-        with:
-          repository: apple/swift-installer-scripts
-          ref: ${{ needs.context.outputs.swift_installer_scripts_revision }}
-          path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         repository: apple/swift-installer-scripts
+  #         ref: ${{ needs.context.outputs.swift_installer_scripts_revision }}
+  #         path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
 
-      - uses: microsoft/setup-msbuild@v1.3.1
+  #     - uses: microsoft/setup-msbuild@v1.3.1
 
-      - run: msbuild ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/swift-format.wixproj -nologo -restore -p:Configuration=Release -p:SWIFT_FORMAT_BUILD=${{ github.workspace }}\SourceCache\swift-format\.build\release -p:OutputPath=${{ github.workspace }}\artifacts -p:RunWixToolsOutOfProc=true
+  #     - run: msbuild ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/swift-format.wixproj -nologo -restore -p:Configuration=Release -p:SWIFT_FORMAT_BUILD=${{ github.workspace }}\SourceCache\swift-format\.build\release -p:OutputPath=${{ github.workspace }}\artifacts -p:RunWixToolsOutOfProc=true
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: swift-format-msi
-          path: ${{ github.workspace }}/artifacts/swift-format.msi
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: swift-format-msi
+  #         path: ${{ github.workspace }}/artifacts/swift-format.msi
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: swift-format.exe
-          path: ${{ github.workspace }}/SourceCache/swift-format/.build/${{ matrix.triple }}/release/swift-format.exe
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: swift-format.exe
+  #         path: ${{ github.workspace }}/SourceCache/swift-format/.build/${{ matrix.triple }}/release/swift-format.exe
 
-  swift_inspect:
-    runs-on: windows-latest
-    needs: [context, installer]
+  # swift_inspect:
+  #   runs-on: windows-latest
+  #   needs: [context, installer]
 
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: 'amd64'
-            cpu: 'x86_64'
-            triple: 'x86_64-unknown-windows-msvc'
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - arch: 'amd64'
+  #           cpu: 'x86_64'
+  #           triple: 'x86_64-unknown-windows-msvc'
 
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: installer-${{ matrix.arch }}
-          path: ${{ github.workspace }}/tmp
+  #   steps:
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: installer-${{ matrix.arch }}
+  #         path: ${{ github.workspace }}/tmp
 
-      # TODO(compnerd) can this be done via a re-usage workflow for swift-format?
+  #     # TODO(compnerd) can this be done via a re-usage workflow for swift-format?
 
-      # TODO(compnerd): migrate this to compnerd/gha-setup-swift after the work that @mangini is doing is completed
-      - run: |
-          function Update-EnvironmentVariables {
-            foreach ($level in "Machine", "User") {
-              [Environment]::GetEnvironmentVariables($level).GetEnumerator() | % {
-                # For Path variables, append the new values, if they're not already in there
-                if ($_.Name -Match 'Path$') {
-                  $_.Value = ($((Get-Content "Env:$($_.Name)") + ";$($_.Value)") -Split ';' | Select -Unique) -Join ';'
-                }
-                $_
-              } | Set-Content -Path { "Env:$($_.Name)" }
-            }
-          }
-          try {
-            Write-Host "Starting Install installer.exe..."
-            $Process = Start-Process -FilePath ${{ github.workspace }}/tmp/installer.exe -ArgumentList ("-q") -Wait -PassThru
-            $ExitCode = $Process.ExitCode
-            if ($ExitCode -eq 0 -or $ExitCode -eq 3010) {
-              Write-Host "Installation successful"
-            } else {
-              Write-Host "non-zero exit code returned by the installation process: $ExitCode"
-              exit $ExitCode
-            }
-          } catch {
-            Write-Host "Failed to install: $($_.Exception.Message)"
-            exit 1
-          }
-          Update-EnvironmentVariables
-          # Reset Path and environment
-          echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-          Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
+  #     # TODO(compnerd): migrate this to compnerd/gha-setup-swift after the work that @mangini is doing is completed
+  #     - run: |
+  #         function Update-EnvironmentVariables {
+  #           foreach ($level in "Machine", "User") {
+  #             [Environment]::GetEnvironmentVariables($level).GetEnumerator() | % {
+  #               # For Path variables, append the new values, if they're not already in there
+  #               if ($_.Name -Match 'Path$') {
+  #                 $_.Value = ($((Get-Content "Env:$($_.Name)") + ";$($_.Value)") -Split ';' | Select -Unique) -Join ';'
+  #               }
+  #               $_
+  #             } | Set-Content -Path { "Env:$($_.Name)" }
+  #           }
+  #         }
+  #         try {
+  #           Write-Host "Starting Install installer.exe..."
+  #           $Process = Start-Process -FilePath ${{ github.workspace }}/tmp/installer.exe -ArgumentList ("-q") -Wait -PassThru
+  #           $ExitCode = $Process.ExitCode
+  #           if ($ExitCode -eq 0 -or $ExitCode -eq 3010) {
+  #             Write-Host "Installation successful"
+  #           } else {
+  #             Write-Host "non-zero exit code returned by the installation process: $ExitCode"
+  #             exit $ExitCode
+  #           }
+  #         } catch {
+  #           Write-Host "Failed to install: $($_.Exception.Message)"
+  #           exit 1
+  #         }
+  #         Update-EnvironmentVariables
+  #         # Reset Path and environment
+  #         echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+  #         Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
 
-      - uses: microsoft/setup-msbuild@v1.3.1
+  #     - uses: microsoft/setup-msbuild@v1.3.1
 
-      - uses: actions/checkout@v3
-        with:
-          repository: apple/swift
-          ref: ${{ needs.context.outputs.swift_revision }}
-          path: ${{ github.workspace }}/SourceCache/swift
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         repository: apple/swift
+  #         ref: ${{ needs.context.outputs.swift_revision }}
+  #         path: ${{ github.workspace }}/SourceCache/swift
 
-      - run: |
-          swift build -debug-info-format none -c release -Xcc -I"${env:SDKROOT}"\usr\include\swift\SwiftRemoteMirror -Xlinker ${env:SDKROOT}\usr\lib\swift\windows\${{ matrix.cpu }}\swiftRemoteMirror.lib
-        working-directory: ${{ github.workspace }}\SourceCache\swift\tools\swift-inspect
+  #     - run: |
+  #         swift build -debug-info-format none -c release -Xcc -I"${env:SDKROOT}"\usr\include\swift\SwiftRemoteMirror -Xlinker ${env:SDKROOT}\usr\lib\swift\windows\${{ matrix.cpu }}\swiftRemoteMirror.lib
+  #       working-directory: ${{ github.workspace }}\SourceCache\swift\tools\swift-inspect
 
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ needs.context.outputs.swift_installer_scripts_revision }}
-          repository: apple/swift-installer-scripts
-          path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         ref: ${{ needs.context.outputs.swift_installer_scripts_revision }}
+  #         repository: apple/swift-installer-scripts
+  #         path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
 
-      - name: Package
-        run: |
-          msbuild -nologo -restore -p:Configuration=Release -p:RunWixToolsOutOfProc=true -p:OutputPath=${{ github.workspace }}\artifacts -p:ProductVersion=${{ needs.context.outputs.swift_version }} -p:SWIFT_INSPECT_BUILD=${{ github.workspace }}\SourceCache\swift\tools\swift-inspect\.build\release ${{ github.workspace }}\SourceCache\swift-installer-scripts\platforms\Windows\swift-inspect.wixproj
+  #     - name: Package
+  #       run: |
+  #         msbuild -nologo -restore -p:Configuration=Release -p:RunWixToolsOutOfProc=true -p:OutputPath=${{ github.workspace }}\artifacts -p:ProductVersion=${{ needs.context.outputs.swift_version }} -p:SWIFT_INSPECT_BUILD=${{ github.workspace }}\SourceCache\swift\tools\swift-inspect\.build\release ${{ github.workspace }}\SourceCache\swift-installer-scripts\platforms\Windows\swift-inspect.wixproj
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: swift-inspect-msi
-          path: ${{ github.workspace }}/artifacts/swift-inspect.msi
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: swift-inspect-msi
+  #         path: ${{ github.workspace }}/artifacts/swift-inspect.msi
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: swift-inspect.exe
-          path: ${{ github.workspace }}/SourceCache/swift/tools/swift-inspect/.build/${{ matrix.triple }}/release/swift-inspect.exe
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: swift-inspect.exe
+  #         path: ${{ github.workspace }}/SourceCache/swift/tools/swift-inspect/.build/${{ matrix.triple }}/release/swift-inspect.exe
 
   snapshot:
     runs-on: ubuntu-latest
-    needs: [context, smoke_test, swift_format, swift_inspect]
+    needs: [context, smoke_test] # , swift_format, swift_inspect]
 
     steps:
       - uses: actions/checkout@v3
@@ -2157,7 +2159,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [context, smoke_test, swift_format, swift_inspect]
+    needs: [context, smoke_test] #, swift_format, swift_inspect]
 
     steps:
       - uses: actions/download-artifact@v3
@@ -2165,15 +2167,15 @@ jobs:
           name: installer-amd64
           path: ${{ github.workspace }}/tmp
 
-      - uses: actions/download-artifact@v3
-        with:
-          name: swift-format-msi
-          path: ${{ github.workspace }}/tmp
+      # - uses: actions/download-artifact@v3
+      #   with:
+      #     name: swift-format-msi
+      #     path: ${{ github.workspace }}/tmp
 
-      - uses: actions/download-artifact@v3
-        with:
-          name: swift-inspect-msi
-          path: ${{ github.workspace }}/tmp
+      # - uses: actions/download-artifact@v3
+      #   with:
+      #     name: swift-inspect-msi
+      #     path: ${{ github.workspace }}/tmp
 
       - uses: actions/create-release@v1
         env:
@@ -2193,20 +2195,19 @@ jobs:
           asset_name: installer-amd64.exe
           asset_path: ${{ github.workspace }}/tmp/installer.exe
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-      - uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          asset_content_type: application/octet-stream
-          asset_name: swift-format.msi
-          asset_path: ${{ github.workspace }}/tmp/swift-format.msi
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-      - uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          asset_content_type: application/octet-stream
-          asset_name: swift-inspect.msi
-          asset_path: ${{ github.workspace }}/tmp/swift-inspect.msi
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-
+      # - uses: actions/upload-release-asset@v1.0.2
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     asset_content_type: application/octet-stream
+      #     asset_name: swift-format.msi
+      #     asset_path: ${{ github.workspace }}/tmp/swift-format.msi
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      # - uses: actions/upload-release-asset@v1.0.2
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     asset_content_type: application/octet-stream
+      #     asset_name: swift-inspect.msi
+      #     asset_path: ${{ github.workspace }}/tmp/swift-inspect.msi
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -43,7 +43,6 @@ jobs:
       swift_crypto_revision: ${{ steps.context.outputs.swift_crypto_revision }}
       swift_driver_revision: ${{ steps.context.outputs.swift_driver_revision }}
       swift_experimental_string_processing_revision: ${{ steps.context.outputs.swift_experimental_string_processing_revision }}
-      # swift_format_revision: ${{ steps.context.outputs.swift_format_revision }}
       swift_installer_scripts_revision: ${{ steps.context.outputs.swift_installer_scripts_revision }}
       swift_llbuild_revision: ${{ steps.context.outputs.swift_llbuild_revision }}
       swift_package_manager_revision: ${{ steps.context.outputs.swift_package_manager_revision }}
@@ -89,7 +88,6 @@ jobs:
           swift_crypto_revision=refs/tags/2.4.0
           swift_driver_revision=refs/tags/${{ github.event.inputs.swift_tag }}
           swift_experimental_string_processing_revision=refs/tags/${{ github.event.inputs.swift_tag }}
-          swift_format_revision=refs/tags/${{ github.event.inputs.swift_tag }}
           swift_installer_scripts_revision=refs/heads/main
           swift_llbuild_revision=refs/tags/${{ github.event.inputs.swift_tag }}
           swift_package_manager_revision=refs/tags/${{ github.event.inputs.swift_tag }}
@@ -1965,179 +1963,9 @@ jobs:
       - run: swift test -Xswiftc -DENABLE_TESTING
         working-directory: ${{ github.workspace }}/SourceCache/swift-win32
 
-  # swift_format:
-  #   runs-on: windows-latest
-  #   needs: [context, installer]
-
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - arch: 'amd64'
-  #           cpu: 'x86_64'
-  #           triple: 'x86_64-unknown-windows-msvc'
-
-  #   steps:
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         name: installer-${{ matrix.arch }}
-  #         path: ${{ github.workspace }}/tmp
-
-  #     # TODO(compnerd) can this be done via a re-usage workflow for swift-format?
-
-  #     # TODO(compnerd): migrate this to compnerd/gha-setup-swift after the work that @mangini is doing is completed
-  #     - run: |
-  #         function Update-EnvironmentVariables {
-  #           foreach ($level in "Machine", "User") {
-  #             [Environment]::GetEnvironmentVariables($level).GetEnumerator() | % {
-  #               # For Path variables, append the new values, if they're not already in there
-  #               if ($_.Name -Match 'Path$') {
-  #                 $_.Value = ($((Get-Content "Env:$($_.Name)") + ";$($_.Value)") -Split ';' | Select -Unique) -Join ';'
-  #               }
-  #               $_
-  #             } | Set-Content -Path { "Env:$($_.Name)" }
-  #           }
-  #         }
-
-  #         try {
-  #           Write-Host "Starting Install installer.exe..."
-  #           $Process = Start-Process -FilePath ${{ github.workspace }}/tmp/installer.exe -ArgumentList ("-q") -Wait -PassThru
-  #           $ExitCode = $Process.ExitCode
-  #           if ($ExitCode -eq 0 -or $ExitCode -eq 3010) {
-  #             Write-Host "Installation successful"
-  #           } else {
-  #             Write-Host "non-zero exit code returned by the installation process: $ExitCode"
-  #             exit $ExitCode
-  #           }
-  #         } catch {
-  #           Write-Host "Failed to install: $($_.Exception.Message)"
-  #           exit 1
-  #         }
-  #         Update-EnvironmentVariables
-
-  #         # Reset Path and environment
-  #         echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-  #         Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
-
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         repository: apple/swift-format
-  #         ref: ${{ needs.context.outputs.swift_format_revision }}
-  #         path: ${{ github.workspace }}/SourceCache/swift-format
-
-  #     - run: swift test
-  #       working-directory: ${{ github.workspace }}/SourceCache/swift-format
-
-  #     - run: swift build -debug-info-format none -c release
-  #       working-directory: ${{ github.workspace }}/SourceCache/swift-format
-
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         repository: apple/swift-installer-scripts
-  #         ref: ${{ needs.context.outputs.swift_installer_scripts_revision }}
-  #         path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
-
-  #     - uses: microsoft/setup-msbuild@v1.3.1
-
-  #     - run: msbuild ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/swift-format.wixproj -nologo -restore -p:Configuration=Release -p:SWIFT_FORMAT_BUILD=${{ github.workspace }}\SourceCache\swift-format\.build\release -p:OutputPath=${{ github.workspace }}\artifacts -p:RunWixToolsOutOfProc=true
-
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: swift-format-msi
-  #         path: ${{ github.workspace }}/artifacts/swift-format.msi
-
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: swift-format.exe
-  #         path: ${{ github.workspace }}/SourceCache/swift-format/.build/${{ matrix.triple }}/release/swift-format.exe
-
-  # swift_inspect:
-  #   runs-on: windows-latest
-  #   needs: [context, installer]
-
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - arch: 'amd64'
-  #           cpu: 'x86_64'
-  #           triple: 'x86_64-unknown-windows-msvc'
-
-  #   steps:
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         name: installer-${{ matrix.arch }}
-  #         path: ${{ github.workspace }}/tmp
-
-  #     # TODO(compnerd) can this be done via a re-usage workflow for swift-format?
-
-  #     # TODO(compnerd): migrate this to compnerd/gha-setup-swift after the work that @mangini is doing is completed
-  #     - run: |
-  #         function Update-EnvironmentVariables {
-  #           foreach ($level in "Machine", "User") {
-  #             [Environment]::GetEnvironmentVariables($level).GetEnumerator() | % {
-  #               # For Path variables, append the new values, if they're not already in there
-  #               if ($_.Name -Match 'Path$') {
-  #                 $_.Value = ($((Get-Content "Env:$($_.Name)") + ";$($_.Value)") -Split ';' | Select -Unique) -Join ';'
-  #               }
-  #               $_
-  #             } | Set-Content -Path { "Env:$($_.Name)" }
-  #           }
-  #         }
-  #         try {
-  #           Write-Host "Starting Install installer.exe..."
-  #           $Process = Start-Process -FilePath ${{ github.workspace }}/tmp/installer.exe -ArgumentList ("-q") -Wait -PassThru
-  #           $ExitCode = $Process.ExitCode
-  #           if ($ExitCode -eq 0 -or $ExitCode -eq 3010) {
-  #             Write-Host "Installation successful"
-  #           } else {
-  #             Write-Host "non-zero exit code returned by the installation process: $ExitCode"
-  #             exit $ExitCode
-  #           }
-  #         } catch {
-  #           Write-Host "Failed to install: $($_.Exception.Message)"
-  #           exit 1
-  #         }
-  #         Update-EnvironmentVariables
-  #         # Reset Path and environment
-  #         echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-  #         Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
-
-  #     - uses: microsoft/setup-msbuild@v1.3.1
-
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         repository: apple/swift
-  #         ref: ${{ needs.context.outputs.swift_revision }}
-  #         path: ${{ github.workspace }}/SourceCache/swift
-
-  #     - run: |
-  #         swift build -debug-info-format none -c release -Xcc -I"${env:SDKROOT}"\usr\include\swift\SwiftRemoteMirror -Xlinker ${env:SDKROOT}\usr\lib\swift\windows\${{ matrix.cpu }}\swiftRemoteMirror.lib
-  #       working-directory: ${{ github.workspace }}\SourceCache\swift\tools\swift-inspect
-
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         ref: ${{ needs.context.outputs.swift_installer_scripts_revision }}
-  #         repository: apple/swift-installer-scripts
-  #         path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
-
-  #     - name: Package
-  #       run: |
-  #         msbuild -nologo -restore -p:Configuration=Release -p:RunWixToolsOutOfProc=true -p:OutputPath=${{ github.workspace }}\artifacts -p:ProductVersion=${{ needs.context.outputs.swift_version }} -p:SWIFT_INSPECT_BUILD=${{ github.workspace }}\SourceCache\swift\tools\swift-inspect\.build\release ${{ github.workspace }}\SourceCache\swift-installer-scripts\platforms\Windows\swift-inspect.wixproj
-
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: swift-inspect-msi
-  #         path: ${{ github.workspace }}/artifacts/swift-inspect.msi
-
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: swift-inspect.exe
-  #         path: ${{ github.workspace }}/SourceCache/swift/tools/swift-inspect/.build/${{ matrix.triple }}/release/swift-inspect.exe
-
   snapshot:
     runs-on: ubuntu-latest
-    needs: [context, smoke_test] # , swift_format, swift_inspect]
+    needs: [context, smoke_test]
 
     steps:
       - uses: actions/checkout@v3
@@ -2159,23 +1987,13 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [context, smoke_test] #, swift_format, swift_inspect]
+    needs: [context, smoke_test]
 
     steps:
       - uses: actions/download-artifact@v3
         with:
           name: installer-amd64
           path: ${{ github.workspace }}/tmp
-
-      # - uses: actions/download-artifact@v3
-      #   with:
-      #     name: swift-format-msi
-      #     path: ${{ github.workspace }}/tmp
-
-      # - uses: actions/download-artifact@v3
-      #   with:
-      #     name: swift-inspect-msi
-      #     path: ${{ github.workspace }}/tmp
 
       - uses: actions/create-release@v1
         env:
@@ -2195,19 +2013,3 @@ jobs:
           asset_name: installer-amd64.exe
           asset_path: ${{ github.workspace }}/tmp/installer.exe
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-      # - uses: actions/upload-release-asset@v1.0.2
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     asset_content_type: application/octet-stream
-      #     asset_name: swift-format.msi
-      #     asset_path: ${{ github.workspace }}/tmp/swift-format.msi
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      # - uses: actions/upload-release-asset@v1.0.2
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     asset_content_type: application/octet-stream
-      #     asset_name: swift-inspect.msi
-      #     asset_path: ${{ github.workspace }}/tmp/swift-inspect.msi
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }}


### PR DESCRIPTION
With the update to the installer definitions, we'll need to reshuffle the CI to build `swift-format` and `swift-inspect` using the compiler in artifacts rather than running the installer. Until then, comment them out to get the builds green again.