### PR TITLE
build: deploy CxxShim module on Windows

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1015,6 +1015,11 @@ function Install-Platform($Arch) {
     }
   }
 
+  # Copy the CxxShim module
+  foreach ($Source in ("libcxxshim.h", "libcxxshim.modulemap", "libcxxstdlibshim.h")) {
+    Copy-File "$WindowsLibSrc\$Source" "$WindowsLibDst"
+  }
+
   # Copy plist files (same across architectures)
   Copy-File "$($Arch.PlatformInstallRoot)\Info.plist" $PlatformInstallRoot\
   Copy-File "$($Arch.SDKInstallRoot)\SDKSettings.plist" $SDKInstallRoot\


### PR DESCRIPTION
The installer will copy this module as well, but we failed to deploy it from the staging to the local installation which prevents the local deployment from being used for testing C++ interop.