### PR TITLE
Upload MSM to release artifacts during swift-toolchain build

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1821,6 +1821,10 @@ jobs:
         with:
           name: runtime-windows-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BinaryCache/runtime/Release/${{ matrix.arch }}/runtime.msi
+      - uses: actions/upload-artifact@v3
+        with:
+          name: runtime.${{ matrix.arch }}.msm
+          path: ${{ github.workspace }}/BinaryCache/sdk/Release/${{ matrix.arch }}/runtime.${{ matrix.arch }}.msm
 
   installer:
     runs-on: windows-latest


### PR DESCRIPTION
Example invocation: https://github.com/thebrowsercompany/swift-build/actions/runs/5798835944
Artifacts: TODO