### PR TITLE
Upload runtime MSM to Release artifacts

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1985,6 +1985,11 @@ jobs:
           name: installer-amd64
           path: ${{ github.workspace }}/tmp
 
+      - uses: actions/download-artifact@v3
+        with:
+          name: runtime.amd64.msm
+          path: ${{ github.workspace }}/tmp
+
       - uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -2002,4 +2007,13 @@ jobs:
           asset_content_type: application/octet-stream
           asset_name: installer-amd64.exe
           asset_path: ${{ github.workspace }}/tmp/installer.exe
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+
+      - uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_content_type: application/octet-stream
+          asset_name: runtime.amd64.msm
+          asset_path: ${{ github.workspace }}/tmp/runtime.amd64.msm
           upload_url: ${{ steps.create_release.outputs.upload_url }}


### PR DESCRIPTION
Follows up #603 by downloading the MSM from the swift-toolchain.yml action run and uploading it to the GitHub release's artifacts.
Test run: https://github.com/thebrowsercompany/swift-build/actions/runs/5812190767
Result: https://github.com/thebrowsercompany/swift-build/releases/tag/20230809.001-ami contains runtime.amd64.msm
![image](https://github.com/compnerd/swift-build/assets/94327711/022624e9-483b-480f-be23-b673a3586085)
