### PR TITLE
build: collect binlogs on the build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -566,7 +566,6 @@ function Build-WiXProject() {
     [hashtable]$Properties = @{}
   )
 
-  $Name = $FileName.Split('.')[0]
   $ArchName = $Arch.VSName
 
   $ProductVersionArg = $ProductVersion
@@ -589,6 +588,8 @@ function Build-WiXProject() {
   foreach ($Property in $Properties.GetEnumerator()) {
     $MSBuildArgs += "-p:$($Property.Key)=$($Property.Value)"
   }
+  $MSBuildArgs += "-bl:$($Arch.BinaryRoot)\msi\$ArchName-$([System.IO.Path]::GetFileNameWithoutExtension($FileName)).binlog"
+  $MSBuildArgs += "-ds:False"
 
   Invoke-Program $msbuild @MSBuildArgs
 }


### PR DESCRIPTION
This can be helpful to diagnose build failures.  Always collect a binlog so that we can analyse the build process later.  Take the opportunity to clean out an unreferenced variable.  One side effect is that the summary view is enabled with the binarylogger, so disable that explicitly.