### PR TITLE
build: correct typo in debug info format

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -537,7 +537,7 @@ function Build-SPMProject {
         "-Xlinker", "-L$($HostArch.SDKInstallRoot)\usr\lib\swift\windows"
     )
     if ($BuildType -eq "Release") {
-      $Arguments += @("-debug-info-format", "-none")
+      $Arguments += @("-debug-info-format", "none")
     } else {
       if ($SwiftDebugFormat -eq "dwarf") {
         $Arguments += @("-debug-info-format", "dwarf")


### PR DESCRIPTION
Remove the accidental leading `-` in the debug info format that prevented the Release mode builds.