### PR TITLE
Azure: patch llvm config as temporary workaround for slow arm64 builds

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -338,6 +338,7 @@ stages:
                 echo "##vso[task.setvariable variable=PYTHON_ROOT;]${PWD}\pythonarm64.${{ parameters.PythonVersion }}\tools"
                 (Get-Content $(Build.SourcesDirectory)/swift/cmake/caches/Windows-aarch64.cmake).replace(' runtimes', '') | Set-Content $(Build.SourcesDirectory)/swift/cmake/caches/Windows-aarch64.cmake
                 "set_source_files_properties(StandardLibrary.cpp PROPERTIES COMPILE_FLAGS ""/Od /Gw /Oi /Oy /Gy /Ob2 /Ot /GF"")" + "`n" + (Get-Content $(Build.SourcesDirectory)/llvm-project/clang/lib/Tooling/Inclusions/Stdlib/CMakeLists.txt -Raw) | Set-Content $(Build.SourcesDirectory)/llvm-project/clang/lib/Tooling/Inclusions/Stdlib/CMakeLists.txt
+                "set_source_files_properties(CGBuiltin.cpp PROPERTIES COMPILE_FLAGS ""/Od /Gw /Oi /Oy /Gy /Ob2 /Ot /GF"")" + "`n" + (Get-Content $(Build.SourcesDirectory)/llvm-project/clang/lib/CodeGen/CMakeLists.txt -Raw) | Set-Content $(Build.SourcesDirectory)/llvm-project/clang/lib/CodeGen/CMakeLists.txt
                 $stdatomic = 'C:\Program Files\LLVM\lib\clang\15.0.7\include\stdatomic.h'
                 if (Test-Path -Path $stdatomic) {
                   (Get-Content $stdatomic).replace('!(defined(_MSC_VER) && !defined(__cplusplus))', '0') | Set-Content $stdatomic

--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -337,6 +337,7 @@ stages:
                 nuget install pythonarm64 -Version ${{ parameters.PythonVersion }}
                 echo "##vso[task.setvariable variable=PYTHON_ROOT;]${PWD}\pythonarm64.${{ parameters.PythonVersion }}\tools"
                 (Get-Content $(Build.SourcesDirectory)/swift/cmake/caches/Windows-aarch64.cmake).replace(' runtimes', '') | Set-Content $(Build.SourcesDirectory)/swift/cmake/caches/Windows-aarch64.cmake
+                "set_source_files_properties(StandardLibrary.cpp PROPERTIES COMPILE_FLAGS ""/Od /Gw /Oi /Oy /Gy /Ob2 /Ot /GF"")" + "`n" + (Get-Content $(Build.SourcesDirectory)/llvm-project/clang/lib/Tooling/Inclusions/Stdlib/CMakeLists.txt -Raw) | Set-Content $(Build.SourcesDirectory)/llvm-project/clang/lib/Tooling/Inclusions/Stdlib/CMakeLists.txt
                 $stdatomic = 'C:\Program Files\LLVM\lib\clang\15.0.7\include\stdatomic.h'
                 if (Test-Path -Path $stdatomic) {
                   (Get-Content $stdatomic).replace('!(defined(_MSC_VER) && !defined(__cplusplus))', '0') | Set-Content $stdatomic


### PR DESCRIPTION
Here we're disabling all optimizations with `/Od`, and then enabling `/Gw /Oi /Oy /Gy /Ob2 /Ot /GF`, which is the same flag set as `/O2` enables, but without "Global Optimizations" (`/Og`).