### PR TITLE
build: adjust the msbuild invocation for spaces

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -595,7 +595,11 @@ function Build-WiXProject() {
   $MSBuildArgs += "-noLogo"
   $MSBuildArgs += "-restore"
   foreach ($Property in $Properties.GetEnumerator()) {
-    $MSBuildArgs += "-p:$($Property.Key)=$($Property.Value)"
+    if ($Property.Value.Contains(" ")) {
+      $MSBuildArgs += "-p:$($Property.Key)=$($Property.Value.Replace('\', '\\'))"
+    } else {
+      $MSBuildArgs += "-p:$($Property.Key)=$($Property.Value)"
+    }
   }
   $MSBuildArgs += "-bl:$($Arch.BinaryRoot)\msi\$ArchName-$([System.IO.Path]::GetFileNameWithoutExtension($FileName)).binlog"
   $MSBuildArgs += "-ds:False"


### PR DESCRIPTION
When properties contain spaces and backslashes, the backslashes are treated as escape characters and must be escaped.  Escape the paths prior to passing them to allow building again.