### PR TITLE
Set the intermediate path for wixprojs

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -580,6 +580,7 @@ function Build-WiXProject() {
 
   $Properties = $Properties.Clone()
   TryAdd-KeyValue $Properties Configuration Release
+  TryAdd-KeyValue $Properties BaseIntermediateOutputPath "$($Arch.BinaryCache)\installer-scripts\"
   TryAdd-KeyValue $Properties BaseOutputPath "$($Arch.BinaryCache)\msi\"
   TryAdd-KeyValue $Properties ProductArchitecture $ArchName
   TryAdd-KeyValue $Properties ProductVersion $ProductVersionArg


### PR DESCRIPTION
It previously defaulted to a location in the source tree.