### PR TITLE
Use ImageRoot-based paths when building SPM projects

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -526,15 +526,15 @@ function Build-SPMProject {
   $Stopwatch = [Diagnostics.Stopwatch]::StartNew()
 
   Isolate-EnvVars {
-    $env:Path = "${RuntimeInstallRoot}\usr\bin;${ToolchainInstallRoot}\usr\bin;${env:Path}"
-    $env:SDKROOT = $Arch.SDKInstallRoot
+    $env:Path = "$RuntimeInstallRoot\usr\bin;$ToolchainInstallRoot\usr\bin;${env:Path}"
+    $env:SDKROOT = $SDKInstallRoot
 
     $Arguments = @(
         "--scratch-path", $Bin,
         "--package-path", $Src,
         "-c", "release",
-        "-Xbuild-tools-swiftc", "-I$($HostArch.SDKInstallRoot)\usr\lib\swift",
-        "-Xbuild-tools-swiftc", "-L$($HostArch.SDKInstallRoot)\usr\lib\swift\windows",
+        "-Xbuild-tools-swiftc", "-I$SDKInstallRoot\usr\lib\swift",
+        "-Xbuild-tools-swiftc", "-L$SDKInstallRoot\usr\lib\swift\windows",
         "-Xcc", "-I$($HostArch.SDKInstallRoot)\usr\lib\swift",
         "-Xlinker", "-L$($HostArch.SDKInstallRoot)\usr\lib\swift\windows"
     )
@@ -548,7 +548,7 @@ function Build-SPMProject {
       }
     }
 
-    Invoke-Program "$($Arch.ToolchainInstallRoot)\usr\bin\swift.exe" "build" @Arguments @AdditionalArguments
+    Invoke-Program "$ToolchainInstallRoot\usr\bin\swift.exe" "build" @Arguments @AdditionalArguments
   }
 
   if (-not $ToBatch) {
@@ -1366,7 +1366,7 @@ function Build-Inspect() {
     -Src $SourceCache\swift\tools\swift-inspect `
     -Bin $OutDir `
     -Arch $HostArch `
-    -Xcc "-I$($HostArch.SDKInstallRoot)\usr\include\swift\SwiftRemoteMirror" -Xlinker "$($HostArch.SDKInstallRoot)\usr\lib\swift\windows\$($HostArch.LLVMName)\swiftRemoteMirror.lib" `
+    -Xcc "-I$SDKInstallRoot\usr\include\swift\SwiftRemoteMirror" -Xlinker "$SDKInstallRoot\usr\lib\swift\windows\$($HostArch.LLVMName)\swiftRemoteMirror.lib" `
     -Xcc -Xclang -Xcc -fno-split-cold-code # Workaround https://github.com/llvm/llvm-project/issues/40056
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -535,8 +535,8 @@ function Build-SPMProject {
         "-c", "release",
         "-Xbuild-tools-swiftc", "-I$SDKInstallRoot\usr\lib\swift",
         "-Xbuild-tools-swiftc", "-L$SDKInstallRoot\usr\lib\swift\windows",
-        "-Xcc", "-I$($HostArch.SDKInstallRoot)\usr\lib\swift",
-        "-Xlinker", "-L$($HostArch.SDKInstallRoot)\usr\lib\swift\windows"
+        "-Xcc", "-I$SDKInstallRoot\usr\lib\swift",
+        "-Xlinker", "-L$SDKInstallRoot\usr\lib\swift\windows"
     )
     if ($BuildType -eq "Release") {
       $Arguments += @("-debug-info-format", "none")


### PR DESCRIPTION
The $ImageRoot-based paths (especially SDK) have had reshuffling applied to match a freshly installed toolchain's layout.

main version of #620