### PR TITLE
build.ps1: Remove the msbuild intermediate directory override

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -580,7 +580,6 @@ function Build-WiXProject() {
 
   $Properties = $Properties.Clone()
   TryAdd-KeyValue $Properties Configuration Release
-  TryAdd-KeyValue $Properties BaseIntermediateOutputPath "$($Arch.BinaryCache)\installer-scripts\"
   TryAdd-KeyValue $Properties BaseOutputPath "$($Arch.BinaryCache)\msi\"
   TryAdd-KeyValue $Properties ProductArchitecture $ArchName
   TryAdd-KeyValue $Properties ProductVersion $ProductVersionArg


### PR DESCRIPTION
This was causing nuget restore failures because projects were overwriting the same `project.assets.json` file. I thought we were writing to the source tree without this, but it must have been stale files from previous versions of the build, because the installer should now send intermediates to `$(BaseOutputPath)obj\$(MSBuildProjectName)\`, and we override `BaseOutputPath`.