### PR TITLE
Azure: free space for toolchain install

### DIFF
--- a/.azure/vs2022-swift-5.9.yml
+++ b/.azure/vs2022-swift-5.9.yml
@@ -417,6 +417,14 @@ stages:
             inputs:
               cmakeArgs:
                 --build $(Agent.BuildDirectory)/1 --target distribution
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                # Free some space for install step
+                Remove-Item $(Build.SourcesDirectory)/swift/.git -Recurse -Force
+                Remove-Item $(Build.SourcesDirectory)/llvm-project/.git -Recurse -Force
+            condition: or(contains(variables['Agent.Name'], 'Azure'), eq(variables['Agent.Name'], 'Hosted Agent'))
           - task: CMake@1
             inputs:
               cmakeArgs:

--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -425,6 +425,14 @@ stages:
             inputs:
               cmakeArgs:
                 --build $(Agent.BuildDirectory)/1 --target distribution
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                # Free some space for install step
+                Remove-Item $(Build.SourcesDirectory)/swift/.git -Recurse -Force
+                Remove-Item $(Build.SourcesDirectory)/llvm-project/.git -Recurse -Force
+            condition: or(contains(variables['Agent.Name'], 'Azure'), eq(variables['Agent.Name'], 'Hosted Agent'))
           - task: CMake@1
             inputs:
               cmakeArgs:


### PR DESCRIPTION
This is adventurous a little, but should save us about 1Gb+ of space.
Hope I didn't mess the condition. I want this be enabled only for Azure hosted runners, and there seems no other way to detect them.