### PR TITLE
Revert "Fix reference to the runtime msi"

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1425,7 +1425,7 @@ function Build-Installer() {
     }
   }
 
-  foreach ($MSI in ("bld", "cli", "dbg", "ide", "sdk", "rtl")) {
+  foreach ($MSI in ("bld", "cli", "dbg", "ide", "sdk", "runtime")) {
     if ($ToBatch) {
       Write-Output "Move-Item $($HostArch.BinaryCache)\msi\Release\$($HostArch.VSName)\$MSI.msi $($HostArch.BinaryCache)\msi\";
     } else {


### PR DESCRIPTION
Reverts compnerd/swift-build#625

The renaming is not yet merged.