### PR TITLE
AzDO: begin integrating DocC into the toolchain

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -57,6 +57,11 @@ resources:
       name: apple/swift-cmark
       ref: refs/heads/gfm
       type: github
+    - repository: apple/swift-docc
+      endpoint: GitHub
+      name: apple/swift-docc
+      ref: refs/heads/main
+      type: github
     - repository: apple/swift-format
       endpoint: GitHub
       name: apple/swift-format
@@ -1578,6 +1583,8 @@ stages:
             fetchDepth: 1
           - checkout: apple/swift-format
             fetchDepth: 1
+          - checkout: apple/swift-docc
+            fetchDepth: 1
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -1669,6 +1676,10 @@ stages:
               swift build -c release -debug-info-format none --package-path $(Build.SourcesDirectory)/swift/tools/swift-inspect --scratch-path $(Agent.BuildDirectory)/swift-inspect -Xcc -I%SDKROOT%\usr\include\swift\SwiftRemoteMirror -Xlinker %SDKROOT%\usr\lib\swift\windows\$(platform)\swiftRemoteMirror.lib
           - publish: $(Agent.BuildDirectory)/swift-inspect/release/swift-inspect.exe
             artifact: swift-inspect-$(arch)
+          - script: |
+              swift build -c release -debug-info-format none --package-path $(Build.SourcesDirectory)/swift-docc --scratch-path $(Agent.BuildDirectory)/swift-docc
+          - publish: $(Agent.BuildDirectory)/swift-docc/release/docc.exe
+            artifact: swift-docc-$(arch)
 
   - stage: package_tools
     displayName: Tools MSIs


### PR DESCRIPTION
Begin integrating the build of DocC into the toolchain as we prepare to distribute it with the toolchain.