### PR TITLE
Azure: cleanup previous build data for self-hosted agents

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -310,6 +310,23 @@ stages:
             fetchDepth: 1
           - checkout: apple/swift-corelibs-libdispatch
             fetchDepth: 1
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                # Use a special file to mark last built arch
+                $CookieFilePath = "$(Agent.BuildDirectory)/arch.txt"
+                if (Test-Path -Path $CookieFilePath) {
+                  $LastBuiltArch = (Get-Content -Path $CookieFilePath | Out-String).Trim()
+                }
+                if ($LastBuiltArch -eq "$(arch)") {
+                  # Same arch or a fresh build
+                  return
+                }
+                "$(arch)" | Out-File -FilePath $CookieFilePath
+                Remove-Item $(Agent.BuildDirectory)/1 -Force  -Recurse -ErrorAction Ignore
+            displayName: Cleanup
+            condition: not(or(contains(variables['Agent.Name'], 'Azure'), eq(variables['Agent.Name'], 'Hosted Agent')))
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
@@ -871,6 +888,32 @@ stages:
             fetchDepth: 1
           - checkout: apple/swift-syntax
             fetchDepth: 1
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                # Use a special file to mark last built arch
+                $CookieFilePath = "$(Agent.BuildDirectory)/arch.txt"
+                if (Test-Path -Path $CookieFilePath) {
+                  $LastBuiltArch = (Get-Content -Path $CookieFilePath | Out-String).Trim()
+                }
+                if ($LastBuiltArch -eq "$(arch)") {
+                  # Same arch or a fresh build
+                  return
+                }
+                "$(arch)" | Out-File -FilePath $CookieFilePath
+                foreach ($BuildFolder in ( `
+                  "llvm", `
+                  "swift", `
+                  "libdispatch", `
+                  "foundation", `
+                  "xctest", `
+                  "$(Build.StagingDirectory)/Library"))
+                {
+                  Remove-Item $(Agent.BuildDirectory)/$BuildFolder -Force -Recurse -ErrorAction Ignore
+                }
+            displayName: Cleanup
+            condition: not(or(contains(variables['Agent.Name'], 'Azure'), eq(variables['Agent.Name'], 'Hosted Agent')))
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
@@ -1132,6 +1175,41 @@ stages:
             fetchDepth: 1
           - checkout: apple/swift-syntax
             fetchDepth: 1
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                # Use a special file to mark last built arch
+                $CookieFilePath = "$(Agent.BuildDirectory)/arch.txt"
+                if (Test-Path -Path $CookieFilePath) {
+                  $LastBuiltArch = (Get-Content -Path $CookieFilePath | Out-String).Trim()
+                }
+                if ($LastBuiltArch -eq "$(arch)") {
+                  # Same arch or a fresh build
+                  return
+                }
+                "$(arch)" | Out-File -FilePath $CookieFilePath
+                foreach ($BuildFolder in ( `
+                  "swift-argument-parser", `
+                  "swift-collections", `
+                  "swift-crypto", `
+                  "Yams", `
+                  "swift-llbuild", `
+                  "swift-system", `
+                  "swift-tools-support-core", `
+                  "swift-driver", `
+                  "swift-asn1", `
+                  "swift-certificates", `
+                  "swift-package-manager", `
+                  "indexstore-db", `
+                  "sourcekit-lsp", `
+                  "swift-syntax", `
+                  "$(Build.StagingDirectory)/Library"))
+                {
+                  Remove-Item $(Agent.BuildDirectory)/$BuildFolder -Force  -Recurse -ErrorAction Ignore
+                }
+            displayName: Cleanup
+            condition: not(or(contains(variables['Agent.Name'], 'Azure'), eq(variables['Agent.Name'], 'Hosted Agent')))
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (


### PR DESCRIPTION
I am trying to reduce the amount of work I have to repeat every time I run the pipeline locally. E.g. I have to disable archs except of only one, because build folders are reused for different matrix branches (x64, arm64, x86) when running on a self-hosted agent, and LLVM/Swift are not happy on such "incremental" reconfigured builds.

This is approach I tested for some time, and it works pretty well. I am using a marker file to store the actual arch we're building. In case it is already present and contains a different arch, I am doing a cleanup of build output folders (still reusing source cache).

Can't say I am thrilled with such bookmarking, but I don't see any simple way to detect arch. Thought about reading CMake caches, but that seems requiring even more code.

Also, there is a condition on cleanup steps, guarding azure-hosted agents from unnecessary work.