### PR TITLE
Fix quoting in CMake args defines

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -320,9 +320,9 @@ function TryAdd-KeyValue([hashtable]$Hashtable, [string]$Key, [string]$Value) {
   }
 }
 
-function Append-FlagsDefine([hashtable]$Defines, [string]$Name, [string]$Value) {
+function Append-FlagsDefine([hashtable]$Defines, [string]$Name, [string[]]$Value) {
   if ($Defines.Contains($Name)) {
-    $Defines[$name] += " $Value" 
+    $Defines[$name] = @($Defines[$name]) + $Value
   } else {
     $Defines.Add($Name, $Value)
   }
@@ -354,7 +354,7 @@ function Build-CMakeProject {
     [string[]] $UseMSVCCompilers = @(), # C,CXX
     [string[]] $UseBuiltCompilers = @(), # ASM,C,CXX,Swift
     [string] $SwiftSDK = "",
-    [hashtable] $Defines = @{},
+    [hashtable] $Defines = @{}, # Values are either single strings or arrays of flags
     [string[]] $BuildTargets = @()
   )
 
@@ -374,14 +374,16 @@ function Build-CMakeProject {
 
     # Add additional defines (unless already present)
     $Defines = $Defines.Clone()
+  
     TryAdd-KeyValue $Defines CMAKE_BUILD_TYPE $BuildType
     TryAdd-KeyValue $Defines CMAKE_MT "mt"
 
     $GenerateDebugInfo = $Defines["CMAKE_BUILD_TYPE"] -ne "Release"
-    $Zi = if ($GenerateDebugInfo) { "/Zi" } else { "" }
 
-    $CFlags = "/GS- /Gw /Gy /Oi /Oy $Zi /Zc:inline"
-    $CXXFlags = "/GS- /Gw /Gy /Oi /Oy $Zi /Zc:inline /Zc:__cplusplus"
+    $CFlags = @("/GS-", "/Gw", "/Gy", "/Oi", "/Oy", "/Zc:inline")
+    if ($GenerateDebugInfo) { $CFlags += "/Zi" }
+    $CXXFlags = $CFlags.Clone() + "/Zc:__cplusplus"
+
     if ($UseMSVCCompilers.Contains("C")) {
       TryAdd-KeyValue $Defines CMAKE_C_COMPILER cl
       Append-FlagsDefine $Defines CMAKE_C_FLAGS $CFlags
@@ -430,34 +432,32 @@ function Build-CMakeProject {
       $RuntimeBinaryCache = Get-ProjectBinaryCache $Arch 1
       $SwiftResourceDir = "${RuntimeBinaryCache}\lib\swift"
 
-      $SwiftArgs = [System.Collections.ArrayList]@()
+      $SwiftArgs = @()
 
       if ($SwiftSDK -ne "") {
-        $SwiftArgs.Add("-sdk ""$SwiftSDK""") | Out-Null
+        $SwiftArgs += @("-sdk", $SwiftSDK)
       } else {
-        $SwiftArgs.Add("-resource-dir ""$SwiftResourceDir""") | Out-Null
-        $SwiftArgs.Add("-L ""$SwiftResourceDir\windows""") | Out-Null
-        $SwiftArgs.Add("-vfsoverlay ""$RuntimeBinaryCache\stdlib\windows-vfs-overlay.yaml""") | Out-Null
+        $SwiftArgs += @("-resource-dir", "$SwiftResourceDir")
+        $SwiftArgs += @("-L", "$SwiftResourceDir\windows")
+        $SwiftArgs += @("-vfsoverlay", "$RuntimeBinaryCache\stdlib\windows-vfs-overlay.yaml")
       }
 
       # Debug Information
       if ($GenerateDebugInfo) {
         if ($SwiftDebugFormat -eq "dwarf") {
-          $SwiftArgs.Add("-g -Xlinker /DEBUG:DWARF -use-ld=lld-link") | Out-Null
+          $SwiftArgs += @("-g", "-Xlinker", "/DEBUG:DWARF", "-use-ld=lld-link")
         } else {
-          $SwiftArgs.Add("-g -debug-info-format=codeview -Xlinker -debug") | Out-Null
+          $SwiftArgs += @("-g", "-debug-info-format=codeview", "-Xlinker", "-debug")
         }
       } else {
-        $SwiftArgs.Add("-gnone") | Out-Null
+        $SwiftArgs += "-gnone"
       }
-      $SwiftArgs.Add("-Xlinker /INCREMENTAL:NO") | Out-Null
+      $SwiftArgs += @("-Xlinker", "/INCREMENTAL:NO")
 
       # Swift Requries COMDAT folding and de-duplication
-      $SwiftArgs.Add("-Xlinker /OPT:REF") | Out-Null
-      $SwiftArgs.Add("-Xlinker /OPT:ICF") | Out-Null
-
-      $SwiftcFlags = $SwiftArgs.ToArray() -Join " "
-      Append-FlagsDefine $Defines CMAKE_Swift_FLAGS $SwiftcFlags
+      $SwiftArgs += @("-Xlinker", "/OPT:REF")
+      $SwiftArgs += @("-Xlinker", "/OPT:ICF")
+      Append-FlagsDefine $Defines CMAKE_Swift_FLAGS $SwiftArgs
 
       # Workaround CMake 3.26+ enabling `-wmo` by default on release builds
       Append-FlagsDefine $Defines CMAKE_Swift_FLAGS_RELEASE "-O"
@@ -473,11 +473,34 @@ function Build-CMakeProject {
       $cmakeGenerateArgs += @("-C", $CacheScript)
     }
     foreach ($Define in ($Defines.GetEnumerator() | Sort-Object Name)) {
-      # Avoid backslashes in defines since they are going into CMakeCache.txt,
-      # where they are interpreted as escapes. Assume all backslashes
-      # are path separators and can be turned into forward slashes.
-      $ValueWithForwardSlashes = $Define.Value.Replace("\", "/")
-      $cmakeGenerateArgs += @("-D", "$($Define.Key)=$ValueWithForwardSlashes")
+      # The quoting gets tricky to support defines containing compiler flags args,
+      # some of which can contain spaces, for example `-D` `Flags=-flag "C:/Program Files"`
+      # Avoid backslashes since they are going into CMakeCache.txt,
+      # where they are interpreted as escapes.
+      if ($Define.Value -is [string]) {
+        # Single token value, no need to quote spaces, the splat operator does the right thing.
+        $Value = $Define.Value.Replace("\", "/")
+      }
+      else {
+        # Flags array, multiple tokens, quoting needed for tokens containing spaces
+        $Value = ""
+        foreach ($Arg in $Define.Value) {
+          if ($Value.Length -gt 0) {
+            $Value += " "
+          }
+
+          $ArgWithForwardSlashes = $Arg.Replace("\", "/")
+          if ($ArgWithForwardSlashes.Contains(" ")) {
+            # Quote and escape the quote so it makes it through
+            $Value += "\""$ArgWithForwardSlashes\"""
+          }
+          else {
+            $Value += $ArgWithForwardSlashes
+          }
+        }
+      }
+
+      $cmakeGenerateArgs += @("-D", "$($Define.Key)=$Value")
     }
 
     Invoke-Program cmake.exe @cmakeGenerateArgs
@@ -583,7 +606,7 @@ function Build-WiXProject() {
   $MSBuildArgs = @("$SourceCache\swift-installer-scripts\platforms\Windows\$FileName")
   $MSBuildArgs += "-noLogo"
   $MSBuildArgs += "-restore"
-    foreach ($Property in $Properties.GetEnumerator()) {
+  foreach ($Property in $Properties.GetEnumerator()) {
     if ($Property.Value.Contains(" ")) {
       $MSBuildArgs += "-p:$($Property.Key)=$($Property.Value.Replace('\', '\\'))"
     } else {
@@ -835,7 +858,7 @@ function Build-Runtime($Arch) {
       SWIFT_PATH_TO_LIBDISPATCH_SOURCE = "$SourceCache\swift-corelibs-libdispatch";
       SWIFT_PATH_TO_STRING_PROCESSING_SOURCE = "$SourceCache\swift-experimental-string-processing";
       SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE = "$SourceCache\swift-syntax";
-      CMAKE_SHARED_LINKER_FLAGS = "/INCREMENTAL:NO /OPT:REF /OPT:ICF";
+      CMAKE_SHARED_LINKER_FLAGS = @("/INCREMENTAL:NO", "/OPT:REF", "/OPT:ICF");
     }
 
   Invoke-Program $python -c "import plistlib; print(str(plistlib.dumps({ 'DefaultProperties': { 'DEFAULT_USE_RUNTIME': 'MD' } }), encoding='utf-8'))" `
@@ -893,7 +916,7 @@ function Build-Foundation($Arch, [switch]$Test = $false) {
         # Turn off safeseh for lld as it has safeseh enabled by default
         # and fails with an ICU data object file icudt69l_dat.obj. This
         # matters to X86 only.
-        CMAKE_Swift_FLAGS = if ($Arch -eq $ArchX86) { "-Xlinker /SAFESEH:NO" } else { "" };
+        CMAKE_Swift_FLAGS = if ($Arch -eq $ArchX86) { @("-Xlinker", "/SAFESEH:NO") } else { "" };
         CURL_DIR = "$LibraryRoot\curl-7.77.0\usr\lib\$ShortArch\cmake\CURL";
         ICU_DATA_LIBRARY_RELEASE = "$LibraryRoot\icu-69.1\usr\lib\$ShortArch\sicudt69.lib";
         ICU_I18N_LIBRARY_RELEASE = "$LibraryRoot\icu-69.1\usr\lib\$ShortArch\sicuin69.lib";
@@ -1263,7 +1286,7 @@ function Build-PackageManager($Arch) {
     -BuildTargets default `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
-      CMAKE_Swift_FLAGS = "-DCRYPTO_v2";
+      CMAKE_Swift_FLAGS = @("-DCRYPTO_v2");
       SwiftSystem_DIR = "$BinaryCache\2\cmake\modules";
       TSC_DIR = "$BinaryCache\3\cmake\modules";
       LLBuild_DIR = "$BinaryCache\4\cmake\modules";
@@ -1288,8 +1311,8 @@ function Build-IndexStoreDB($Arch) {
     -BuildTargets default `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
-      CMAKE_C_FLAGS = "-Xclang -fno-split-cold-code -I$SDKInstallRoot\usr\include -I$SDKInstallRoot\usr\include\Block";
-      CMAKE_CXX_FLAGS = "-Xclang -fno-split-cold-code -I$SDKInstallRoot\usr\include -I$SDKInstallRoot\usr\include\Block";
+      CMAKE_C_FLAGS = @("-Xclang", "-fno-split-cold-code", "-I$SDKInstallRoot\usr\include", "-I$SDKInstallRoot\usr\include\Block");
+      CMAKE_CXX_FLAGS = @("-Xclang", "-fno-split-cold-code", "-I$SDKInstallRoot\usr\include", "-I$SDKInstallRoot\usr\include\Block");
     }
 }
 
@@ -1385,9 +1408,9 @@ function Build-DocC() {
 
 function Build-Installer() {
   Build-WiXProject bld\bld.wixproj -Arch $HostArch -Properties @{
-        DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
+    DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
     TOOLCHAIN_ROOT = "$($HostArch.ToolchainInstallRoot)\";
-      }
+  }
 
   Build-WiXProject cli\cli.wixproj -Arch $HostArch -Properties @{
     DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
@@ -1436,14 +1459,10 @@ function Build-Installer() {
 
 #-------------------------------------------------------------------
 
-Build-Compilers $HostArch -Test
-exit
-
 if (-not $SkipBuild) {
   Build-BuildTools $HostArch
   Build-Compilers $HostArch
 }
-
 
 foreach ($Arch in $SDKArchs) {
   if (-not $SkipBuild) {

--- a/build.ps1
+++ b/build.ps1
@@ -433,11 +433,11 @@ function Build-CMakeProject {
       $SwiftArgs = [System.Collections.ArrayList]@()
 
       if ($SwiftSDK -ne "") {
-        $SwiftArgs.Add("-sdk $SwiftSDK") | Out-Null
+        $SwiftArgs.Add("-sdk ""$SwiftSDK""") | Out-Null
       } else {
-        $SwiftArgs.Add("-resource-dir $SwiftResourceDir") | Out-Null
-        $SwiftArgs.Add("-L $SwiftResourceDir\windows") | Out-Null
-        $SwiftArgs.Add("-vfsoverlay $RuntimeBinaryCache\stdlib\windows-vfs-overlay.yaml") | Out-Null
+        $SwiftArgs.Add("-resource-dir ""$SwiftResourceDir""") | Out-Null
+        $SwiftArgs.Add("-L ""$SwiftResourceDir\windows""") | Out-Null
+        $SwiftArgs.Add("-vfsoverlay ""$RuntimeBinaryCache\stdlib\windows-vfs-overlay.yaml""") | Out-Null
       }
 
       # Debug Information
@@ -476,11 +476,7 @@ function Build-CMakeProject {
       # Avoid backslashes in defines since they are going into CMakeCache.txt,
       # where they are interpreted as escapes. Assume all backslashes
       # are path separators and can be turned into forward slashes.
-      $ValueWithPlaceholder = if ($SwiftSDK -ne "") { $Define.Value.Replace("$SwiftSDK", "<SDK>") } else { $Define.Value }
-      $ValueWithForwardSlashes = $ValueWithPlaceholder.Replace("\", "/")
-      if ($SwiftSDK -ne "") {
-        $ValueWithForwardSlashes = $ValueWithForwardSlashes.Replace("<SDK>", "\`"$SwiftSDK\`"")
-      }
+      $ValueWithForwardSlashes = $Define.Value.Replace("\", "/")
       $cmakeGenerateArgs += @("-D", "$($Define.Key)=$ValueWithForwardSlashes")
     }
 
@@ -587,7 +583,7 @@ function Build-WiXProject() {
   $MSBuildArgs = @("$SourceCache\swift-installer-scripts\platforms\Windows\$FileName")
   $MSBuildArgs += "-noLogo"
   $MSBuildArgs += "-restore"
-  foreach ($Property in $Properties.GetEnumerator()) {
+    foreach ($Property in $Properties.GetEnumerator()) {
     if ($Property.Value.Contains(" ")) {
       $MSBuildArgs += "-p:$($Property.Key)=$($Property.Value.Replace('\', '\\'))"
     } else {
@@ -1389,9 +1385,9 @@ function Build-DocC() {
 
 function Build-Installer() {
   Build-WiXProject bld\bld.wixproj -Arch $HostArch -Properties @{
-    DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
+        DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
     TOOLCHAIN_ROOT = "$($HostArch.ToolchainInstallRoot)\";
-  }
+      }
 
   Build-WiXProject cli\cli.wixproj -Arch $HostArch -Properties @{
     DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
@@ -1439,6 +1435,9 @@ function Build-Installer() {
 }
 
 #-------------------------------------------------------------------
+
+Build-Compilers $HostArch -Test
+exit
 
 if (-not $SkipBuild) {
   Build-BuildTools $HostArch
@@ -1498,7 +1497,7 @@ if (-not $SkipBuild) {
   Build-Inspect $HostArch
   Build-Format $HostArch
   Build-DocC $HostArch
-}
+  }
 
 if (-not $SkipPackaging) {
   Build-Installer

--- a/build.ps1
+++ b/build.ps1
@@ -1464,6 +1464,7 @@ if (-not $SkipBuild) {
   Build-Compilers $HostArch
 }
 
+
 foreach ($Arch in $SDKArchs) {
   if (-not $SkipBuild) {
     Build-ZLib $Arch
@@ -1516,7 +1517,7 @@ if (-not $SkipBuild) {
   Build-Inspect $HostArch
   Build-Format $HostArch
   Build-DocC $HostArch
-  }
+}
 
 if (-not $SkipPackaging) {
   Build-Installer

--- a/build.ps1
+++ b/build.ps1
@@ -480,8 +480,7 @@ function Build-CMakeProject {
       if ($Define.Value -is [string]) {
         # Single token value, no need to quote spaces, the splat operator does the right thing.
         $Value = $Define.Value.Replace("\", "/")
-      }
-      else {
+      } else {
         # Flags array, multiple tokens, quoting needed for tokens containing spaces
         $Value = ""
         foreach ($Arg in $Define.Value) {
@@ -493,8 +492,7 @@ function Build-CMakeProject {
           if ($ArgWithForwardSlashes.Contains(" ")) {
             # Quote and escape the quote so it makes it through
             $Value += "\""$ArgWithForwardSlashes\"""
-          }
-          else {
+          } else {
             $Value += $ArgWithForwardSlashes
           }
         }


### PR DESCRIPTION
If a cmake define is an argument string, we need to distinguish tokens containing spaces from multiple tokens. For example, we must be able to pass the below as two command line arguments to cmake:
`-D` `CMAKE_Swift_FLAGS=-sdk "S:/Program Files/Swift/Platforms/Windows.platform/Developer/SDKs/Windows.sdk" -g -Xlinker /DEBUG:DWARF -use-ld=lld-link -Xlinker /INCREMENTAL:NO -Xlinker /OPT:REF -Xlinker /OPT:ICF`

Quoting becomes tricky in this case. We need to quote compiler flags arguments when they contain spaces to keep them a single token, and because of Windows cmd or cmake rules, the quotes need to be escaped with backslashes. Which means that we can't replace all backslashes into forward slashes wholesale.

The solution is to support two kinds of entries in the `$Defines` hashtable: single strings and arrays of strings. For defines whose value is an array of strings, we'll run logic to do the proper quoting into a final string that will preserve the tokenization when calling the compiler. This fixes issues with `"-sdk $SDKPath"`, which would be interpreted as more than two tokens if `$SDKPath` contains spaces.