### PR TITLE
AzDO: truncate intermediate output files to save space

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -430,8 +430,15 @@ stages:
               targetType: 'inline'
               script: |
                 # Free some space for install step
-                Remove-Item $(Build.SourcesDirectory)/swift/.git -Recurse -Force
-                Remove-Item $(Build.SourcesDirectory)/llvm-project/.git -Recurse -Force
+                Get-ChildItem $(Agent.BuildDirectory)\1\*.obj -File -Recurse | ForEach-Object {
+                  $CreationTime = $_.CreationTime
+                  $LastAccessTime = $_.LastAccessTime
+                  $LastWriteTime = $_.LastWriteTime
+                  Set-Content -Path $_.FullName -Force -Value "!"
+                  $_.CreationTime = $CreationTime
+                  $_.LastAccessTime = $LastAccessTime
+                  $_.LastWriteTime = $LastWriteTime
+                }
             condition: or(contains(variables['Agent.Name'], 'Azure'), eq(variables['Agent.Name'], 'Hosted Agent'))
           - task: CMake@1
             inputs:


### PR DESCRIPTION
"Desperate Times Call for Desperate Measures"

Truncating obj files and resetting timestamps to trick Ninja thinking they are not changed, so install step runs as usual.

Here is my success run: https://dev.azure.com/lxbndr/swift-windows/_build/results?buildId=372&view=logs&j=af9f4b2c-adba-5fb9-b92b-bad76b92442e&t=cb4b7c89-a562-5e9e-e8f2-2817ec23f4b4
The environment is synthetic and all input is prebuilt, but the goal was to pass install step without rebuilding whole toolchain.