### PR TITLE
build: indicate that the SDK should be included

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1416,6 +1416,7 @@ function Build-Installer() {
   }
 
   foreach ($Arch in $SDKArchs) {
+    $Properties["INCLUDE_$($Arch.VSName.ToUpperInvariant())"] = "true"
     $Properties["PLATFORM_ROOT_$($Arch.VSName.ToUpperInvariant())"] = "$($Arch.PlatformInstallRoot)\"
     $Properties["SDK_ROOT_$($Arch.VSName.ToUpperInvariant())"] = "$($Arch.SDKInstallRoot)\"
   }


### PR DESCRIPTION
We have additional indicators to the build process to indicate which SDKs and Runtimes are built and should be packaged.  This updates the packaging to account for that.