### PR TITLE
build: specify bundle flavor

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1407,6 +1407,7 @@ function Build-DocC() {
 
 function Build-Installer() {
   $Properties = @{
+    BundleFlavor = "offline";
     DEVTOOLS_ROOT = "$($HostArch.ToolchainInstallRoot)\";
     TOOLCHAIN_ROOT = "$($HostArch.ToolchainInstallRoot)\";
     INCLUDE_SWIFT_FORMAT = "true";


### PR DESCRIPTION
The default value is online bundle, which will break the current testing that we have available on swift.org CI.  Default to the offline bundle for now.