### PR TITLE
build: repair the inclusion specifier

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1416,6 +1416,7 @@ function Build-Installer() {
   }
 
   foreach ($Arch in $SDKArchs) {
+    $Properties["INCLUDE_$($Arch.VSName.ToUpperInvariant())_SDK"] = "true"
     $Properties["PLATFORM_ROOT_$($Arch.VSName.ToUpperInvariant())"] = "$($Arch.PlatformInstallRoot)\"
     $Properties["SDK_ROOT_$($Arch.VSName.ToUpperInvariant())"] = "$($Arch.SDKInstallRoot)\"
   }


### PR DESCRIPTION
The SDKs are included by the `INCLUDE_[ARCH]_SDK` indicator which was missing the `_SDK` suffix preventing the inclusion.  Correct this to repair the packaging.