### PR TITLE
build: stage the MSMs

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1425,7 +1425,7 @@ function Build-Installer() {
   Build-WiXProject bundle\installer.wixproj -Arch $HostArch -Properties $Properties
 
   if ($Stage -and (-not $ToBatch)) {
-    Copy-File "$($HostArch.BinaryCache)\installer\Release\$($HostArch.VSName)\*.msi" "$Stage\"
+    Copy-File "$($HostArch.BinaryCache)\installer\Release\$($HostArch.VSName)\*.msm" "$Stage\"
     Copy-File "$($HostArch.BinaryCache)\installer\Release\$($HostArch.VSName)\installer.exe" "$Stage\"
   }
 }


### PR DESCRIPTION
Now that we have the MSMs, we do not need the MSIs as the two intents for the MSI was to provide the runtime (which should prefer the MSM) and the installation of the components, which is now possible with the installer once the remaining changes are merged.