### PR TITLE
build.ps1: Support non-installed Windows SDKs

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -376,8 +376,7 @@ function Ensure-WindowsSDK {
   try {
     Isolate-EnvVars { Invoke-VsDevShell $HostArch }
     return
-  }
-  catch {}
+  } catch {}
 
   Write-Output "Windows SDK $WinSDKVersion not found. Downloading from nuget..."
 


### PR DESCRIPTION
The Apple CI build machines only have an older, problematic version of the Windows SDK installed. This will allow us to override it with a more recent downloaded one without having to install it to program files.

I diffed `vsdevcmd` invocations with and without `-winver=none` to figure out which environment variables to set.