### PR TITLE
build: include DocC into the packaging

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1414,6 +1414,9 @@ function Build-Installer() {
     SWIFT_FORMAT_BUILD = "$($HostArch.BinaryCache)\swift-format\release";
     INCLUDE_SWIFT_INSPECT = "true";
     SWIFT_INSPECT_BUILD = "$($HostArch.BinaryCache)\swift-inspect\release";
+    INCLUDE_SWIFT_DOCC = "true";
+    SWIFT_DOCC_BUILD = "$($HostArch.BinaryCache)\swift-docc\release";
+    SWIFT_DOCC_RENDER_ARTIFACT_ROOT = "${SourceCache}\swift-docc-render-artifact";
   }
 
   foreach ($Arch in $SDKArchs) {


### PR DESCRIPTION
This introduces the packaging options to integrate DocC into the distribution.