### PR TITLE
build: adjust the library search path

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -619,7 +619,7 @@ function Build-CMakeProject {
     }
 
     if ($UseBuiltCompilers.Contains("Swift")) {
-      $env:Path = "$RuntimeInstallRoot\usr\bin;$ToolchainInstallRoot\usr\bin;${env:Path}"
+      $env:Path = "$($HostArch.SDKInstallRoot)\usr\bin;$ToolchainInstallRoot\usr\bin;${env:Path}"
     }
     Invoke-Program cmake.exe @cmakeGenerateArgs
 


### PR DESCRIPTION
The just installed SDK is placed into the SDKInstallRoot not the RuntimeInstallRoot.  Account for this when constructing the new path.