### PR TITLE
GHA: publish ARM64 installers

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2066,7 +2066,12 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: installer-amd64
-          path: ${{ github.workspace }}/tmp
+          path: ${{ github.workspace }}/tmp/amd64
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: installer-arm64
+          path: ${{ github.workspace }}/tmp/arm64
 
       - uses: actions/create-release@v1
         env:
@@ -2084,5 +2089,14 @@ jobs:
         with:
           asset_content_type: application/octet-stream
           asset_name: installer-amd64.exe
-          asset_path: ${{ github.workspace }}/tmp/installer.exe
+          asset_path: ${{ github.workspace }}/tmp/amd64/installer.exe
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+
+      - uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_content_type: application/octet-stream
+          asset_name: installer-arm64.exe
+          asset_path: ${{ github.workspace }}/tmp/arm64/installer.exe
           upload_url: ${{ steps.create_release.outputs.upload_url }}


### PR DESCRIPTION
Wire up the arm64 installer release path to allow us to easily download the ARM64 toolchain installers.