### PR TITLE
build.ps1: `-sdk` and `-resource-dir` are mutually exclusive

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -567,14 +567,14 @@ function Build-CMakeProject {
       if ($UseBuiltCompilers.Contains("Swift")) {
         if ($SwiftSDK -ne "") {
           $SwiftArgs += @("-sdk", $SwiftSDK)
+        } else {
+          $RuntimeBinaryCache = Get-ProjectBinaryCache $Arch 1
+          $SwiftResourceDir = "${RuntimeBinaryCache}\lib\swift"
+
+          $SwiftArgs += @("-resource-dir", "$SwiftResourceDir")
+          $SwiftArgs += @("-L", "$SwiftResourceDir\windows")
+          $SwiftArgs += @("-vfsoverlay", "$RuntimeBinaryCache\stdlib\windows-vfs-overlay.yaml")
         }
-
-        $RuntimeBinaryCache = Get-ProjectBinaryCache $Arch 1
-        $SwiftResourceDir = "${RuntimeBinaryCache}\lib\swift"
-
-        $SwiftArgs += @("-resource-dir", "$SwiftResourceDir")
-        $SwiftArgs += @("-L", "$SwiftResourceDir\windows")
-        $SwiftArgs += @("-vfsoverlay", "$RuntimeBinaryCache\stdlib\windows-vfs-overlay.yaml")
       } else {
         $SwiftArgs += @("-sdk", "$BinaryCache\toolchains\$PinnedToolchain\PFiles64\Swift\Platforms\Windows.platform\Developer\SDKs\Windows.sdk")
       }


### PR DESCRIPTION
These flags should not be combined as they cause the modules to be built incorrectly and remove some of the required library search paths. Repair the standard build for now.