### PR TITLE
Azure: publish cab files alongside with msi's

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -1806,16 +1806,32 @@ stages:
                 -p:DEVTOOLS_ROOT=$(Pipeline.Workspace)/devtools-$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
                 -p:TOOLCHAIN_ROOT=$(Pipeline.Workspace)/toolchain-$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
                 -bl:$(Agent.BuildDirectory)\installer\$(arch)-ide.binlog
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                New-Item -ItemType Directory -ErrorAction Ignore $(Build.StagingDirectory)/bld-$(arch)-msi | Out-Null
+                New-Item -ItemType Directory -ErrorAction Ignore $(Build.StagingDirectory)/cli-$(arch)-msi | Out-Null
+                New-Item -ItemType Directory -ErrorAction Ignore $(Build.StagingDirectory)/dbg-$(arch)-msi | Out-Null
+                New-Item -ItemType Directory -ErrorAction Ignore $(Build.StagingDirectory)/ide-$(arch)-msi | Out-Null
+                Move-Item $(Agent.BuildDirectory)/installer/Release/$(arch)/bld.msi $(Build.StagingDirectory)/bld-$(arch)-msi/
+                Move-Item $(Agent.BuildDirectory)/installer/Release/$(arch)/bld.cab $(Build.StagingDirectory)/bld-$(arch)-msi/
+                Move-Item $(Agent.BuildDirectory)/installer/Release/$(arch)/cli.msi $(Build.StagingDirectory)/cli-$(arch)-msi/
+                Move-Item $(Agent.BuildDirectory)/installer/Release/$(arch)/cli.cab $(Build.StagingDirectory)/cli-$(arch)-msi/
+                Move-Item $(Agent.BuildDirectory)/installer/Release/$(arch)/dbg.msi $(Build.StagingDirectory)/dbg-$(arch)-msi/
+                Move-Item $(Agent.BuildDirectory)/installer/Release/$(arch)/dbg.cab $(Build.StagingDirectory)/dbg-$(arch)-msi/
+                Move-Item $(Agent.BuildDirectory)/installer/Release/$(arch)/ide.msi $(Build.StagingDirectory)/ide-$(arch)-msi/
+                Move-Item $(Agent.BuildDirectory)/installer/Release/$(arch)/ide.cab $(Build.StagingDirectory)/ide-$(arch)-msi/
           - publish: $(Agent.BuildDirectory)\installer\$(arch)-ide.binlog
             artifact: $(arch)-ide.binlog
             condition: failed()
-          - publish: $(Agent.BuildDirectory)/installer/Release/$(arch)/bld.msi
+          - publish: $(Build.StagingDirectory)/bld-$(arch)-msi
             artifact: bld-$(arch)-msi
-          - publish: $(Agent.BuildDirectory)/installer/Release/$(arch)/cli.msi
+          - publish: $(Build.StagingDirectory)/cli-$(arch)-msi
             artifact: cli-$(arch)-msi
-          - publish: $(Agent.BuildDirectory)/installer/Release/$(arch)/dbg.msi
+          - publish: $(Build.StagingDirectory)/dbg-$(arch)-msi
             artifact: dbg-$(arch)-msi
-          - publish: $(Agent.BuildDirectory)/installer/Release/$(arch)/ide.msi
+          - publish: $(Build.StagingDirectory)/ide-$(arch)-msi
             artifact: ide-$(arch)-msi
 
   - stage: package_sdk_runtime
@@ -1898,12 +1914,22 @@ stages:
                 -p:PLATFORM_ROOT=$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform
                 -p:SDK_ROOT=$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk
                 -bl:$(Agent.BuildDirectory)\installer\$(arch)-sdk.binlog
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                New-Item -ItemType Directory -ErrorAction Ignore $(Build.StagingDirectory)/sdk-windows-$(arch)-msi | Out-Null
+                New-Item -ItemType Directory -ErrorAction Ignore $(Build.StagingDirectory)/rtl-windows-$(arch)-msi | Out-Null
+                Move-Item $(Agent.BuildDirectory)/installer/Release/$(arch)/sdk.$(arch).msi $(Build.StagingDirectory)/sdk-windows-$(arch)-msi/
+                Move-Item $(Agent.BuildDirectory)/installer/Release/$(arch)/sdk.$(arch).cab $(Build.StagingDirectory)/sdk-windows-$(arch)-msi/
+                Move-Item $(Agent.BuildDirectory)/installer/Release/$(arch)/rtl.msi $(Build.StagingDirectory)/rtl-windows-$(arch)-msi/
+                Move-Item $(Agent.BuildDirectory)/installer/Release/$(arch)/rtl.cab $(Build.StagingDirectory)/rtl-windows-$(arch)-msi/
           - publish: $(Agent.BuildDirectory)\installer\$(arch)-sdk.binlog
             artifact: $(arch)-sdk.binlog
             condition: failed()
-          - publish: $(Agent.BuildDirectory)/installer/Release/$(arch)/sdk.$(arch).msi
+          - publish: $(Build.StagingDirectory)/sdk-windows-$(arch)-msi
             artifact: sdk-windows-$(arch)-msi
-          - publish: $(Agent.BuildDirectory)/installer/Release/$(arch)/rtl.msi
+          - publish: $(Build.StagingDirectory)/rtl-windows-$(arch)-msi
             artifact: rtl-windows-$(arch)-msi
           - publish: $(Agent.BuildDirectory)/installer/Release/$(arch)/rtl.$(arch).msm
             artifact: rtl-windows-$(arch)-msm
@@ -1951,10 +1977,15 @@ stages:
               SourceFolder: $(Pipeline.Workspace)
               Contents: |
                 bld-$(arch)-msi/bld.msi
+                bld-$(arch)-msi/bld.cab
                 cli-$(arch)-msi/cli.msi
+                cli-$(arch)-msi/cli.cab
                 dbg-$(arch)-msi/dbg.msi
+                dbg-$(arch)-msi/dbg.cab
                 ide-$(arch)-msi/ide.msi
+                ide-$(arch)-msi/ide.cab
                 rtl-windows-$(arch)-msi/rtl.msi
+                rtl-windows-$(arch)-msi/rtl.cab
               TargetFolder: $(Agent.BuildDirectory)/installer/Release/$(arch)/
               flattenFolders: true
           - task: CopyFiles@2
@@ -1963,6 +1994,7 @@ stages:
               Contents: |
                 rtl-windows-x86-msm/rtl.x86.msm
                 sdk-windows-x86-msi/sdk.x86.msi
+                sdk-windows-x86-msi/sdk.x86.cab
               TargetFolder: $(Agent.BuildDirectory)/installer/Release/x86/
               flattenFolders: true
           - task: CopyFiles@2
@@ -1971,6 +2003,7 @@ stages:
               Contents: |
                 rtl-windows-amd64-msm/rtl.amd64.msm
                 sdk-windows-amd64-msi/sdk.amd64.msi
+                sdk-windows-amd64-msi/sdk.amd64.cab
               TargetFolder: $(Agent.BuildDirectory)/installer/Release/amd64/
               flattenFolders: true
           - task: CopyFiles@2
@@ -1979,6 +2012,7 @@ stages:
               Contents: |
                 rtl-windows-arm64-msm/rtl.arm64.msm
                 sdk-windows-arm64-msi/sdk.arm64.msi
+                sdk-windows-arm64-msi/sdk.arm64.cab
               TargetFolder: $(Agent.BuildDirectory)/installer/Release/arm64/
               flattenFolders: true
           - script: |


### PR DESCRIPTION
Had to move msi and cab files to dedicated dirs before publishing, as Azure only can publish whole directories or single files.