### PR TITLE
Pass flags to bundle the vcredist installer

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -2033,6 +2033,8 @@ stages:
                 -p:ProductVersion=${{ parameters.ProductVersion }}${{ parameters.BuildTag }}
                 -p:CERTIFICATE=$(certificate.secureFilePath)
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
+                -p:VCREDIST_INSTALLER="${env:VCToolsRedistDir}\vc_redist.${env:VSCMD_ARG_TGT_ARCH}.exe"
+                -p:VCREDIST_VERSION=$env:VCToolsVersion
                 -p:INCLUDE_AMD64_SDK=true
                 -p:INCLUDE_X86_SDK=true
                 -p:INCLUDE_ARM64_SDK=true

--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -2033,8 +2033,8 @@ stages:
                 -p:ProductVersion=${{ parameters.ProductVersion }}${{ parameters.BuildTag }}
                 -p:CERTIFICATE=$(certificate.secureFilePath)
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
-                -p:VCREDIST_INSTALLER="${env:VCToolsRedistDir}\vc_redist.${env:VSCMD_ARG_TGT_ARCH}.exe"
-                -p:VCREDIST_VERSION=$env:VCToolsVersion
+                -p:VCRedistInstaller="${env:VCToolsRedistDir}\vc_redist.${env:VSCMD_ARG_TGT_ARCH}.exe"
+                -p:VSVersion=${env:VSCMD_VER}
                 -p:INCLUDE_AMD64_SDK=true
                 -p:INCLUDE_X86_SDK=true
                 -p:INCLUDE_ARM64_SDK=true

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1977,8 +1977,8 @@ jobs:
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:BundleFlavor=offline `
-              -p:VCREDIST_INSTALLER="${env:VCToolsRedistDir}\vc_redist.${env:VSCMD_ARG_TGT_ARCH}.exe" `
-              -p:VCREDIST_VERSION=${env:VCToolsVersion} `
+              -p:VCRedistInstaller="${env:VCToolsRedistDir}\vc_redist.${env:VSCMD_ARG_TGT_ARCH}.exe" `
+              -p:VSVersion=${env:VSCMD_VER} `
               -p:INCLUDE_AMD64_SDK=true `
               -p:INCLUDE_X86_SDK=true `
               -p:INCLUDE_ARM64_SDK=true `

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1977,6 +1977,8 @@ jobs:
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:BundleFlavor=offline `
+              -p:VCREDIST_INSTALLER="${env:VCToolsRedistDir}\vc_redist.${env:VSCMD_ARG_TGT_ARCH}.exe" `
+              -p:VCREDIST_VERSION=${env:VCToolsVersion} `
               -p:INCLUDE_AMD64_SDK=true `
               -p:INCLUDE_X86_SDK=true `
               -p:INCLUDE_ARM64_SDK=true `

--- a/build.ps1
+++ b/build.ps1
@@ -1558,6 +1558,16 @@ function Build-Installer() {
     INCLUDE_SWIFT_DOCC = "true";
     SWIFT_DOCC_BUILD = "$($HostArch.BinaryCache)\swift-docc\release";
     SWIFT_DOCC_RENDER_ARTIFACT_ROOT = "${SourceCache}\swift-docc-render-artifact";
+    VCREDIST_INSTALLER = "$($env:VCToolsRedistDir)"
+  }
+
+  Isolate-EnvVars {
+    Invoke-VsDevShell $HostArch
+    $VCRedistInstallerPath = "${env:VCToolsRedistDir}\vc_redist.$($HostArch.ShortName).exe"
+    if (Test-Path $VCRedistInstallerPath) {
+      $Properties["VCREDIST_INSTALLER"] = $VCRedistInstallerPath
+      $Properties["VCREDIST_VERSION"] = $env:VCToolsVersion
+    }
   }
 
   foreach ($Arch in $SDKArchs) {

--- a/build.ps1
+++ b/build.ps1
@@ -1564,8 +1564,8 @@ function Build-Installer() {
     Invoke-VsDevShell $HostArch
     $VCRedistInstallerPath = "${env:VCToolsRedistDir}\vc_redist.$($HostArch.ShortName).exe"
     if (Test-Path $VCRedistInstallerPath) {
-      $Properties["VCREDIST_INSTALLER"] = $VCRedistInstallerPath
-      $Properties["VCREDIST_VERSION"] = $env:VCToolsVersion
+      $Properties["VCRedistInstaller"] = $VCRedistInstallerPath
+      $Properties["VSVersion"] = $env:VSCMD_VER
     }
   }
 

--- a/build.ps1
+++ b/build.ps1
@@ -1558,7 +1558,6 @@ function Build-Installer() {
     INCLUDE_SWIFT_DOCC = "true";
     SWIFT_DOCC_BUILD = "$($HostArch.BinaryCache)\swift-docc\release";
     SWIFT_DOCC_RENDER_ARTIFACT_ROOT = "${SourceCache}\swift-docc-render-artifact";
-    VCREDIST_INSTALLER = "$($env:VCToolsRedistDir)"
   }
 
   Isolate-EnvVars {


### PR DESCRIPTION
Leverages the new Swift toolchain installer support for integrating the vcredist installer: https://github.com/apple/swift-installer-scripts/pull/250