### PR TITLE
Update build.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -848,6 +848,7 @@ function Build-Compilers($Arch, [switch]$Test = $false) {
         LLVM_TABLEGEN = "$BinaryCache\0\bin\llvm-tblgen.exe";
         LLVM_USE_HOST_TOOLS = "NO";
         SWIFT_BUILD_SWIFT_SYNTAX = "YES";
+        SWIFT_CLANG_LOCATION = "$BinaryCache\toolchains\$PinnedToolchain\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin";
         SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY = "YES";
         SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP = "YES";
         SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING = "YES";


### PR DESCRIPTION
Use the pinned toolchain's clang to build libdispatch and SourceKit rather than trying to use the just built clang to build the components.  This should allow us to simplify the build and simplify cross-compilation, while making the build system more robust.