### PR TITLE
AzDO: use pinned toolchain for early swift-syntax build

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -40,17 +40,17 @@ resources:
     - repository: apple/swift-asn1
       endpoint: GitHub
       name: apple/swift-asn1
-      ref: refs/tags/0.8.0
+      ref: refs/tags/1.0.0
       type: github
     - repository: apple/swift-certificates
       endpoint: GitHub
       name: apple/swift-certificates
-      ref: refs/tags/0.6.0
+      ref: refs/tags/1.0.1
       type: github
     - repository: apple/swift-collections
       endpoint: GitHub
       name: apple/swift-collections
-      ref: refs/tags/1.0.1
+      ref: refs/tags/1.0.4
       type: github
     - repository: apple/swift-cmark
       endpoint: GitHub
@@ -80,7 +80,7 @@ resources:
     - repository: apple/swift-crypto
       endpoint: GitHub
       name: apple/swift-crypto
-      ref: refs/tags/2.5.0
+      ref: refs/tags/3.0.0
       type: github
     - repository: apple/swift-driver
       endpoint: GitHub
@@ -120,7 +120,7 @@ resources:
     - repository: curl/curl
       endpoint: GitHub
       name: curl/curl
-      ref: refs/tags/curl-7_77_0
+      ref: refs/tags/curl-8_4_0
       type: github
     - repository: gnome/libxml2
       endpoint: GitHub
@@ -160,6 +160,14 @@ parameters:
   - name: PythonVersion
     type: string
     default: '3.9.10'
+
+  - name: PinnedSwiftBranch
+    type: string
+    default: 'swift-5.9-release'
+  
+  - name: PinnedToolchain
+    type: string
+    default: 'swift-5.9-RELEASE'
 
 stages:
   - stage: tools
@@ -287,11 +295,11 @@ stages:
             'x64':
               arch: amd64
               platform: x86_64
-              EXTRA_CMAKE_ARGS:
+              EXTRA_CMAKE_ARGS: -D SWIFT_BUILD_SWIFT_SYNTAX=YES -D CMAKE_Swift_COMPILER=$(workspace.binaries)/toolchains/${{ parameters.PinnedToolchain }}/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe -D CMAKE_Swift_FLAGS="-sdk $(workspace.binaries)/toolchains/${{ parameters.PinnedToolchain }}/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk" -D SWIFT_PATH_TO_SWIFT_SDK=$(workspace.binaries)/toolchains/${{ parameters.PinnedToolchain }}/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk
             'arm64':
               arch: arm64
               platform: aarch64
-              EXTRA_CMAKE_ARGS: -D CMAKE_SYSTEM_NAME=Windows -D CMAKE_SYSTEM_PROCESSOR=ARM64 -D "SWIFT_CLANG_LOCATION=C:/Program Files/LLVM/bin"
+              EXTRA_CMAKE_ARGS: -D CMAKE_SYSTEM_NAME=Windows -D CMAKE_SYSTEM_PROCESSOR=ARM64
         steps:
           - download: current
             artifact: build-tools
@@ -327,7 +335,7 @@ stages:
               modifyEnvironment: true
           - task: UsePythonVersion@0
             inputs:
-              versionSpec: ${{ parameters.PythonVersion }}
+              versionSpec: "${{ parameters.PythonVersion }}"
               addToPath: true
               architecture: 'x64'
           - task: PowerShell@2
@@ -350,13 +358,18 @@ stages:
                 SET PYTHON_EXECUTABLE=%%i
               )
               ECHO PYTHON_EXECUTABLE=%PYTHON_EXECUTABLE%
+              @echo ##vso[task.setvariable variable=PYTHON_EXECUTABLE;]%PYTHON_EXECUTABLE%
+
+              IF DEFINED PYTHON_ROOT (
+                echo PYTHON_ROOT is already set to %PYTHON_ROOT%
+                goto :eof
+              )
 
               CALL :getpath "%PYTHON_EXECUTABLE%" PYTHON_ROOT
               FOR /F "tokens=* USEBACKQ" %%i IN (`cygpath -m "%PYTHON_ROOT%\"`) DO (
                 SET PYTHON_ROOT=%%i
               )
               ECHO PYTHON_ROOT=%PYTHON_ROOT%
-
               @echo ##vso[task.setvariable variable=PYTHON_ROOT;]%PYTHON_ROOT%
               GOTO :eof
 
@@ -368,7 +381,54 @@ stages:
               SET %2=%~dp1
               EXIT /b
             displayName: Find Python
-            condition: eq(variables['platform'], 'x86_64')
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                $ToolchainsPath = "$(Build.BinariesDirectory)\toolchains"
+                $PinnedToolchainPath = "$ToolchainsPath\${{ parameters.PinnedToolchain }}"
+                Write-Host "##vso[task.setvariable variable=PATH;]$PinnedToolchainPath\PFiles64\Swift\runtime-development\usr\bin;${env:Path}"
+                if (Test-Path "$PinnedToolchainPath\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe") {
+                  Write-Output "Found Swift at $PinnedToolchainPath"
+                  return
+                }
+                Write-Output "Swift toolchain not found"
+                $WiXVersion = "4.0.1"
+                $WiXPath = "$(Build.BinariesDirectory)\wix-$WiXVersion"
+                if (-not (Test-Path "$WiXPath\tools\net6.0\any\wix.exe")) {
+                  Write-Output "WiX $WiXVersion not found"
+                  $WiXDownloadURL = "https://www.nuget.org/api/v2/package/wix/$WiXVersion"
+                  if (-not (Test-Path "$WiXPath.zip")) {
+                    Write-Output "Downloading $WiXDownloadURL"
+                    (New-Object Net.WebClient).DownloadFile("$WiXDownloadURL", "$WiXPath.zip")
+                  }
+                  Write-Output "Extracting wix-$WiXVersion.zip"
+                  New-Item -ItemType Directory -ErrorAction Ignore $WiXPath | Out-Null
+                  Expand-Archive -Path "$WiXPath.zip" -Destination $WiXPath -Force
+                }
+                New-Item -ItemType Directory -ErrorAction Ignore "$ToolchainsPath" | Out-Null
+                if (-not (Test-Path "$PinnedToolchainPath.exe")) {
+                  $SwiftDownloadURL = "https://swift.org/builds/${{ parameters.PinnedSwiftBranch }}/windows10/${{ parameters.PinnedToolchain }}/${{ parameters.PinnedToolchain }}-windows10.exe"
+                  Write-Output "Downloading $SwiftDownloadURL"
+                  (New-Object Net.WebClient).DownloadFile("$SwiftDownloadURL", "$PinnedToolchainPath.exe")
+                }
+                Write-Output "Installing Swift toolchain..."
+                & $WixPath\tools\net6.0\any\wix.exe burn extract "$PinnedToolchainPath.exe" -out "$ToolchainsPath\"
+                Start-Process msiexec.exe -NoNewWindow -ArgumentList "/qn /a ""$ToolchainsPath\a0"" TARGETDIR=""$PinnedToolchainPath""" -Wait
+                Start-Process msiexec.exe -NoNewWindow -ArgumentList "/qn /a ""$ToolchainsPath\a1"" TARGETDIR=""$PinnedToolchainPath""" -Wait
+                Start-Process msiexec.exe -NoNewWindow -ArgumentList "/qn /a ""$ToolchainsPath\a2"" TARGETDIR=""$PinnedToolchainPath""" -Wait
+                Start-Process msiexec.exe -NoNewWindow -ArgumentList "/qn /a ""$ToolchainsPath\a3"" TARGETDIR=""$PinnedToolchainPath""" -Wait
+                Write-Output "Cleaning up..."
+                Remove-Item "$WiXPath" -Force -Recurse -ErrorAction Ignore
+                Remove-Item "$WiXPath.zip"
+                Remove-Item "$ToolchainsPath\a0"
+                Remove-Item "$ToolchainsPath\a1"
+                Remove-Item "$ToolchainsPath\a2"
+                Remove-Item "$ToolchainsPath\a3"
+                Remove-Item "$PinnedToolchainPath.exe"
+          - bash: |
+              echo "##vso[task.setvariable variable=binaries;isOutput=true]$(cygpath -m '$(Build.BinariesDirectory)')"
+            name: workspace
           - task: CMake@1
             inputs:
               cmakeArgs:
@@ -392,6 +452,7 @@ stages:
                 -D LLVM_EXTERNAL_SWIFT_SOURCE_DIR=$(Build.SourcesDirectory)/swift
                 -D LLVM_NATIVE_TOOL_DIR=$(Pipeline.Workspace)/build-tools/bin
                 -D LLVM_TABLEGEN=$(Pipeline.Workspace)/build-tools/bin/llvm-tblgen.exe
+                -D SWIFT_CLANG_LOCATION=$(workspace.binaries)/toolchains/${{ parameters.PinnedToolchain }}/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin
                 -D LLVM_USE_HOST_TOOLS=NO
                 -D SWIFT_BUILD_DYNAMIC_SDK_OVERLAY=NO
                 -D SWIFT_BUILD_DYNAMIC_STDLIB=NO
@@ -418,6 +479,7 @@ stages:
                 -D LLDB_PYTHON_EXT_SUFFIX=.pyd
                 -D LLDB_PYTHON_RELATIVE_PATH=lib/site-packages
                 -D Python3_ROOT_DIR=$(PYTHON_ROOT)
+                -D Python3_EXECUTABLE=$(PYTHON_EXECUTABLE)
                 -D Python3_INCLUDE_DIR=$(PYTHON_ROOT)/include
                 -D Python3_LIBRARY=$(PYTHON_ROOT)/libs/python39.lib
                 $(EXTRA_CMAKE_ARGS)
@@ -446,6 +508,9 @@ stages:
                 --build $(Agent.BuildDirectory)/1 --target install-distribution-stripped
           - publish: $(Build.StagingDirectory)
             artifact: toolchain-$(arch)
+          - publish: $(Build.BinariesDirectory)/toolchains/${{ parameters.PinnedToolchain }}/PFiles64/Swift/runtime-development/usr/bin
+            artifact: ${{ parameters.PinnedToolchain }}-runtime-bin
+            condition: eq(variables['platform'], 'x86_64')
 
   - stage: icu
     dependsOn: []
@@ -864,6 +929,8 @@ stages:
             artifact: zlib-$(arch)-1.2.11
           - download: current
             artifact: toolchain-amd64
+          - download: current
+            artifact: ${{ parameters.PinnedToolchain }}-runtime-bin
           - checkout: apple/llvm-project
             fetchDepth: 1
           - checkout: apple/swift
@@ -896,6 +963,11 @@ stages:
           - bash: |
               echo "##vso[task.setvariable variable=root;isOutput=true]$(cygpath -m '$(Pipeline.Workspace)')"
             name: workspace
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                Write-Host "##vso[task.setvariable variable=PATH;]$(Agent.BuildDirectory)\${{ parameters.PinnedToolchain }}-runtime-bin;${env:Path}"
           - task: CMake@1
             inputs:
               cmakeArgs:
@@ -952,6 +1024,11 @@ stages:
             inputs:
               cmakeArgs:
                 --build $(Agent.BuildDirectory)/swift --target install
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                Write-Host "##vso[task.setvariable variable=PATH;]$(Agent.BuildDirectory)\swift\bin;${env:Path}"
           - task: CMake@1
             inputs:
               cmakeArgs:
@@ -980,6 +1057,11 @@ stages:
             inputs:
               cmakeArgs:
                 --build $(Agent.BuildDirectory)/libdispatch
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                Write-Host "##vso[task.setvariable variable=PATH;]$(Agent.BuildDirectory)\libdispatch;${env:Path}"
           - task: CMake@1
             inputs:
               cmakeArgs:
@@ -1020,6 +1102,11 @@ stages:
             inputs:
               cmakeArgs:
                 --build $(Agent.BuildDirectory)/foundation
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                Write-Host "##vso[task.setvariable variable=PATH;]$(Agent.BuildDirectory)\foundation\bin;${env:Path}"
           - task: CMake@1
             inputs:
               cmakeArgs:
@@ -1109,6 +1196,9 @@ stages:
             artifact: toolchain-amd64
           - download: current
             artifact: windows-sdk-$(arch)
+          - download: current
+            artifact: windows-sdk-amd64
+            condition: ne(variables['arch'], 'amd64')
           - checkout: apple/indexstore-db
             fetchDepth: 1
           - checkout: apple/sourcekit-lsp
@@ -1157,6 +1247,11 @@ stages:
           - bash: |
               echo "##vso[task.setvariable variable=root;isOutput=true]$(cygpath -m '$(Pipeline.Workspace)')"
             name: workspace
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                Write-Host "##vso[task.setvariable variable=PATH;]$(Agent.BuildDirectory)\windows-sdk-amd64\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk\usr\bin;${env:Path}"
           - task: CMake@1
             inputs:
               cmakeArgs:
@@ -1518,6 +1613,7 @@ stages:
                 -D SwiftCollections_DIR=$(Agent.BuildDirectory)/swift-collections/cmake/modules
                 -D SwiftPM_DIR=$(Agent.BuildDirectory)/swift-package-manager/cmake/modules
                 -D SwiftSystem_DIR=$(Agent.BuildDirectory)/swift-system/cmake/modules
+                -D SwiftCrypto_DIR=$(Agent.BuildDirectory)/swift-crypto/cmake/modules
                 -D TSC_DIR=$(Agent.BuildDirectory)/swift-tools-support-core/cmake/modules
                 -D SwiftSyntax_DIR=$(Agent.BuildDirectory)/swift-syntax/cmake/modules
           - task: CMake@1
@@ -2050,6 +2146,11 @@ stages:
                 -p:CERTIFICATE=$(certificate.secureFilePath)
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
                 -bl:$(Agent.BuildDirectory)\installer\$(arch)-shared.binlog
+          - bash: |
+              echo "##vso[task.setvariable variable=VCToolsRedistDir;isOutput=true]$VCToolsRedistDir"
+              echo "##vso[task.setvariable variable=VSCMD_ARG_TGT_ARCH;isOutput=true]$VSCMD_ARG_TGT_ARCH"
+              echo "##vso[task.setvariable variable=VSCMD_VER;isOutput=true]$VSCMD_VER"
+            name: env
           - task: MSBuild@1
             inputs:
               solution: $(Build.SourcesDirectory)/platforms/Windows/bundle/installer.wixproj
@@ -2067,8 +2168,8 @@ stages:
                 -p:ProductVersion=${{ parameters.ProductVersion }}${{ parameters.BuildTag }}
                 -p:CERTIFICATE=$(certificate.secureFilePath)
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
-                -p:VCRedistInstaller="${env:VCToolsRedistDir}\vc_redist.${env:VSCMD_ARG_TGT_ARCH}.exe"
-                -p:VSVersion=${env:VSCMD_VER}
+                -p:VCRedistInstaller="$(env.VCToolsRedistDir)\vc_redist.$(env.VSCMD_ARG_TGT_ARCH).exe"
+                -p:VSVersion=$(env.VSCMD_VER)
                 -p:INCLUDE_AMD64_SDK=true
                 -p:INCLUDE_X86_SDK=true
                 -p:INCLUDE_ARM64_SDK=true


### PR DESCRIPTION
Also:
- bump dependencies (curl 8.4.0, swift-asn1, swift-certificates, swift-collections, swift-crypto)
- specify `SWIFT_CLANG_LOCATION` unconditionally (not only for arm64 builds)
- adjust VS redist packaging