### PR TITLE
build: use static linking for swift-syntax temporarily

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1467,7 +1467,7 @@ function Build-Syntax($Arch) {
     -SwiftSDK $SDKInstallRoot `
     -BuildTargets default `
     -Defines @{
-      BUILD_SHARED_LIBS = "YES";
+      BUILD_SHARED_LIBS = "NO";
     }
 }
 


### PR DESCRIPTION
This will increase the size of the toolchain but is required to work with the ABI name mismatches on the swift-syntax binaries used across the toolchain and SourceKit-LSP.