### PR TITLE
GHA: install a Swift toolchain to workaround race condition

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -502,27 +502,19 @@ jobs:
           echo "PYTHON_LOCATION_amd64=$env:pythonLocation" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "PYTHON_LOCATION_arm64=${{ github.workspace }}\pythonarm64.${{ env.PYTHON_VERSION }}\tools" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Install LLVM
-        if: matrix.arch == 'arm64'
-        run: |
-          curl.exe -sL "https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.5/LLVM-15.0.5-win64.exe" -o ${env:TEMP}\llvm-installer.exe
+      - uses: compnerd/gha-setup-vsdevenv@main
+        with:
+          host_arch: amd64
+          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+          arch: ${{ matrix.arch }}
 
-          Write-Host "Starting ${env:TEMP}\llvm-installer.exe"
-          $Process = Start-Process -FilePath ${env:TEMP}\llvm-installer.exe -ArgumentList ("/S", "/D=${env:ProgramFiles}\LLVM") -Wait -PassThru
-          $ExitCode = $Process.ExitCode
-          if ($ExitCode -eq 0) {
-            Write-Host "Installation successful"
-          } else {
-            Write-Host "non-zero exit code returned by the installation process: $ExitCode"
-            exit $ExitCode
-          }
-
-          Remove-Item ${env:TEMP}\llvm-installer.exe
-
-          $stdatomic = "${env:ProgramFiles}\LLVM\lib\clang\15.0.5\include\stdatomic.h"
-          if (Test-Path -Path $stdatomic) {
-            (Get-Content $stdatomic).replace('__has_include_next(<stdatomic.h>) && !(defined(_MSC_VER) && !defined(__cplusplus))', '0') | Set-Content $stdatomic
-          }
+      - name: Install Swift Toolchain
+        uses: compnerd/gha-setup-swift@main
+        with:
+          github-repo: thebrowsercompany/swift-build
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          release-asset-name: installer-amd64.exe
+          release-tag-name: '20231016.0'
 
       - name: Workaround MSVC#10444970
         if: matrix.arch == 'arm64'
@@ -541,26 +533,22 @@ jobs:
             COMPILE_FLAGS "/Od /Gw /Oi /Oy /Gw /Ob2 /Ot /GF")
           "@
 
-      - uses: compnerd/gha-setup-vsdevenv@main
-        with:
-          host_arch: amd64
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }}
-
       - name: Configure Compilers
         run: |
           if ( "${{ matrix.arch }}" -eq "arm64" ) {
             $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
             $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=ARM64"
             $CACHE="Windows-aarch64.cmake"
-            $CLANG_LOCATION = cygpath -m ${env:ProgramFiles}\llvm\bin
-            $SWIFT_CLANG_LOCATION="-D SWIFT_CLANG_LOCATION=${CLANG_LOCATION}"
 
             # FIXME(compnerd) re-enable runtimes after we sort out compiler-rt
             (Get-Content ${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-aarch64.cmake).replace(' runtimes', '') | Set-Content ${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-aarch64.cmake
           } else {
             $CACHE="Windows-x86_64.cmake"
           }
+          $SWIFTC = cygpath -m (Get-Command swiftc).Source
+          $SDKROOT = cygpath -m ${env:SDKROOT}
+          $CLANG_LOCATION = cygpath -m (Split-Path (Get-Command clang-cl).Source)
+          Remove-Item env:\SDKROOT
           cmake -B ${{ github.workspace }}/BinaryCache/1 `
                 -C ${{ github.workspace }}/SourceCache/swift/cmake/caches/${CACHE} `
                 -D CMAKE_BUILD_TYPE=Release `
@@ -587,6 +575,7 @@ jobs:
                 -D SWIFT_BUILD_DYNAMIC_SDK_OVERLAY=NO `
                 -D SWIFT_BUILD_DYNAMIC_STDLIB=NO `
                 -D SWIFT_BUILD_REMOTE_MIRROR=NO `
+                -D SWIFT_CLANG_LOCATION=${CLANG_LOCATION} `
                 -D SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=YES `
                 -D SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP=YES `
                 -D SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED=YES `
@@ -611,8 +600,7 @@ jobs:
                 -D Python3_EXECUTABLE=${{ steps.python.outputs.python-path }} `
                 -D Python3_INCLUDE_DIR=$env:PYTHON_LOCATION_${{ matrix.arch }}\include `
                 -D Python3_LIBRARY=$env:PYTHON_LOCATION_${{ matrix.arch }}\libs\python39.lib `
-                -D Python3_ROOT_DIR=$env:pythonLocation `
-                ${SWIFT_CLANG_LOCATION}
+                -D Python3_ROOT_DIR=$env:pythonLocation
 
       - name: Build Compiler Distribution
         run: cmake --build ${{ github.workspace }}/BinaryCache/1 --target distribution


### PR DESCRIPTION
We will soon need the Swift toolchain for building swift-syntax to support macros. Do this now to allow us access to `clang-cl` to avoid a dependency race condition where dispatch is built before `clang-cl` is built, which seems to have arisen with the rebranch.