### PR TITLE
build: SQLite3 dependency in t-s-c was dropped a year ago

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1260,8 +1260,6 @@ function Build-ToolsSupportCore($Arch) {
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
       SwiftSystem_DIR = "$BinaryCache\2\cmake\modules";
-      SQLite3_INCLUDE_DIR = "$LibraryRoot\sqlite-3.36.0\usr\include";
-      SQLite3_LIBRARY = "$LibraryRoot\sqlite-3.36.0\usr\lib\SQLite3.lib";
     }
 }
 


### PR DESCRIPTION
Update to the current state of the world.
a56cfe7b9acdcff4220c4350f24798bf28b9410a removed the dependency on SQLite from tools-support-core, remove the unnecessary arguments.