### PR TITLE
AzDO: drop t-s-c sqlite parameters, bump llvm to 20230725

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -20,7 +20,7 @@ resources:
     - repository: apple/llvm-project
       endpoint: GitHub
       name: apple/llvm-project
-      ref: refs/heads/stable/20221013
+      ref: refs/heads/stable/20230725
       type: github
     - repository: apple/sourcekit-lsp
       endpoint: GitHub
@@ -328,10 +328,16 @@ stages:
               )
               @echo ##vso[task.setvariable variable=vs;]%vs%
               @echo ##vso[task.setvariable variable=vsdevcmd;]%VsDevCmd%
+          - script: |
+              start "" /wait "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\setup.exe" modify --add Microsoft.VisualStudio.Component.VC.14.37.17.7.x86.x64 --installPath $(vs) -q
+            condition: and(succeeded(), eq(variables['platform'], 'x86_64'))
+          - script: |
+              start "" /wait "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\setup.exe" modify --add Microsoft.VisualStudio.Component.VC.14.37.17.7.ARM64 --installPath $(vs) -q
+            condition: and(succeeded(), eq(variables['platform'], 'aarch64'))
           - task: BatchScript@1
             inputs:
               filename: $(VsDevCmd)
-              arguments: -no_logo -arch=$(arch) -host_arch=amd64
+              arguments: -no_logo -arch=$(arch) -host_arch=amd64 -vcvars_ver=14.37
               modifyEnvironment: true
           - task: UsePythonVersion@0
             inputs:
@@ -1427,8 +1433,6 @@ stages:
                 -G Ninja
                 -S $(Build.SourcesDirectory)/swift-tools-support-core
                 -D SwiftSystem_DIR=$(Agent.BuildDirectory)/swift-system/cmake/modules
-                -D SQLite3_LIBRARY=$(Pipeline.Workspace)/sqlite-$(arch)-3.36.0/Library/sqlite-3.36.0/usr/lib/SQLite3.lib
-                -D SQLite3_INCLUDE_DIR=$(Pipeline.Workspace)/sqlite-$(arch)-3.36.0/Library/sqlite-3.36.0/usr/include
           - task: CMake@1
             inputs:
               cmakeArgs:


### PR DESCRIPTION
Adopted latest build process changes:
- llvm branch set to `stable/20230725`
- VS toolset updated to latest version to workaround build issues
- dropped unnecessary t-s-c sqlite configuration parameters