### PR TITLE
build: stage additional artifacts

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1590,8 +1590,12 @@ function Build-Installer() {
   Build-WiXProject bundle\installer.wixproj -Arch $HostArch -Properties $Properties
 
   if ($Stage -and (-not $ToBatch)) {
+    Copy-File "$($HostArch.BinaryCache)\installer\Release\$($HostArch.VSName)\*.cab" "$Stage\"
+    Copy-File "$($HostArch.BinaryCache)\installer\Release\$($HostArch.VSName)\*.msi" "$Stage\"
     Copy-File "$($HostArch.BinaryCache)\installer\Release\$($HostArch.VSName)\*.msm" "$Stage\"
     Copy-File "$($HostArch.BinaryCache)\installer\Release\$($HostArch.VSName)\installer.exe" "$Stage\"
+    # Extract installer engine to ease code-signing on swift.org CI
+    Invoke-Program "$BinaryCache\wix-4.0.1\tools\net6.0\any\wix.exe" -- burn detach "$($HostArch.BinaryCache)\installer\Release\$($HostArch.VSName)\installer.exe" -engine "$Stage\installer-engine.exe" -intermediateFolder "$($HostArch.BinaryCache)\installer\$($HostArch.VSName)\"
   }
 }
 


### PR DESCRIPTION
We need to stage the MSIs and the Burn engine to simplify the code signing process for the swift.org hosted builds. Simply add the additional copying and the burn detachment to the staging process.