### PR TITLE
build: ensure that the temporary directory exists

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1595,6 +1595,7 @@ function Build-Installer() {
     Copy-File "$($HostArch.BinaryCache)\installer\Release\$($HostArch.VSName)\*.msm" "$Stage\"
     Copy-File "$($HostArch.BinaryCache)\installer\Release\$($HostArch.VSName)\installer.exe" "$Stage\"
     # Extract installer engine to ease code-signing on swift.org CI
+    New-Item -Type Directory -Path "$($HostArch.BinaryCache)\installer\$($HostArch.VSName)\" -ErrorAction Ignore | Out-Null
     Invoke-Program "$BinaryCache\wix-4.0.1\tools\net6.0\any\wix.exe" -- burn detach "$($HostArch.BinaryCache)\installer\Release\$($HostArch.VSName)\installer.exe" -engine "$Stage\installer-engine.exe" -intermediateFolder "$($HostArch.BinaryCache)\installer\$($HostArch.VSName)\"
   }
 }


### PR DESCRIPTION
Create the temporary directory before extracting the burn engine which would otherwise fail.