### PR TITLE
AzDO: ensure succeeded condition is evaluated

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -357,7 +357,7 @@ stages:
                 if (Test-Path -Path $stdatomic) {
                   (Get-Content $stdatomic).replace('!(defined(_MSC_VER) && !defined(__cplusplus))', '0') | Set-Content $stdatomic
                 }
-            condition: eq(variables['platform'], 'aarch64')
+            condition: and(succeeded(), eq(variables['platform'], 'aarch64'))
           - script: |
               CALL :where python.exe PYTHON_EXECUTABLE
               FOR /F "tokens=* USEBACKQ" %%i IN (`cygpath -m "%PYTHON_EXECUTABLE%"`) DO (
@@ -507,7 +507,7 @@ stages:
                   $_.LastAccessTime = $LastAccessTime
                   $_.LastWriteTime = $LastWriteTime
                 }
-            condition: or(contains(variables['Agent.Name'], 'Azure'), eq(variables['Agent.Name'], 'Hosted Agent'))
+            condition: and(succeeded(), or(contains(variables['Agent.Name'], 'Azure'), eq(variables['Agent.Name'], 'Hosted Agent')))
           - task: CMake@1
             inputs:
               cmakeArgs:
@@ -516,7 +516,7 @@ stages:
             artifact: toolchain-$(arch)
           - publish: $(Build.BinariesDirectory)/toolchains/${{ parameters.PinnedToolchain }}/PFiles64/Swift/runtime-development/usr/bin
             artifact: ${{ parameters.PinnedToolchain }}-runtime-bin
-            condition: eq(variables['platform'], 'x86_64')
+            condition: and(succeeded(), eq(variables['platform'], 'x86_64'))
 
   - stage: icu
     dependsOn: []
@@ -558,7 +558,7 @@ stages:
               filename: $(VsDevCmd)
               arguments: -no_logo -arch=amd64 -host_arch=amd64
               modifyEnvironment: true
-            condition: eq(variables['BUILD_TOOLS'], 'NO')
+            condition: and(succeeded(), eq(variables['BUILD_TOOLS'], 'NO'))
           - task: CMake@1
             inputs:
               cmakeArgs:
@@ -574,12 +574,12 @@ stages:
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/icu-69.1/usr
                 -G Ninja
                 -S $(Build.SourcesDirectory)/icu/icu4c
-            condition: eq(variables['BUILD_TOOLS'], 'NO')
+            condition: and(succeeded(), eq(variables['BUILD_TOOLS'], 'NO'))
           - task: CMake@1
             inputs:
               cmakeArgs:
                 --build $(Agent.BuildDirectory)/icu-69.1-build
-            condition: eq(variables['BUILD_TOOLS'], 'NO')
+            condition: and(succeeded(), eq(variables['BUILD_TOOLS'], 'NO'))
           - task: BatchScript@1
             inputs:
               filename: $(VsDevCmd)
@@ -600,7 +600,7 @@ stages:
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/icu-69.1/usr
                 -G Ninja
                 -S $(Build.SourcesDirectory)/icu/icu4c
-            condition: eq(variables['BUILD_TOOLS'], 'NO')
+            condition: and(succeeded(), eq(variables['BUILD_TOOLS'], 'NO'))
           - task: CMake@1
             inputs:
               cmakeArgs:
@@ -616,7 +616,7 @@ stages:
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/icu-69.1/usr
                 -G Ninja
                 -S $(Build.SourcesDirectory)/icu/icu4c
-            condition: eq(variables['BUILD_TOOLS'], 'YES')
+            condition: and(succeeded(), eq(variables['BUILD_TOOLS'], 'YES'))
           - task: CMake@1
             inputs:
               cmakeArgs:
@@ -1204,7 +1204,7 @@ stages:
             artifact: windows-sdk-$(arch)
           - download: current
             artifact: windows-sdk-amd64
-            condition: ne(variables['arch'], 'amd64')
+            condition: and(succeeded(), ne(variables['arch'], 'amd64'))
           - checkout: apple/indexstore-db
             fetchDepth: 1
           - checkout: apple/sourcekit-lsp


### PR DESCRIPTION
We have a plenty of steps with conditions, and most of them don't check the job status. This not only looks weird when the job is cancelled or failed, but could lead to (minor) undesirable/unexpected side effects.