### PR TITLE
GHA: attempt to use sccache's direct mode

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -22,6 +22,9 @@ on:
         default: false
         type: boolean
 
+env:
+  SCCACHE_DIRECT: yes
+
 jobs:
   context:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The direct mode can give a nice boost to sccache if the preprocessor is not used.  This might be helpful for us, so lets try enabling it.