### PR TITLE
GHA: disable runtime bundling

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2139,8 +2139,6 @@ jobs:
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:BundleFlavor=offline `
-              -p:VCRedistInstaller="${env:VCToolsRedistDir}\vc_redist.${env:VSCMD_ARG_TGT_ARCH}.exe" `
-              -p:VSVersion=${env:VSCMD_VER} `
               -p:INCLUDE_AMD64_SDK=true `
               -p:INCLUDE_X86_SDK=true `
               -p:INCLUDE_ARM64_SDK=true `


### PR DESCRIPTION
The addition of the VCRuntime this way requires that we have administrative rights.  Restore the ability to install the toolchain without the administrative rights by disabling the runtime packaging.