### PR TITLE
CI: Update rules to pass the `VCRedistDir` appropriately

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -1991,6 +1991,7 @@ stages:
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
                 -p:PLATFORM_ROOT=$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform
                 -p:SDK_ROOT=$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk
+                -p:VCRedistDir="${env:VCToolsRedistDir}\${env:VSCMD_ARG_TGT_ARCH}\Microsoft.VC143.CRT\"
                 -bl:$(Agent.BuildDirectory)\installer\$(arch)-rtl.binlog
           - publish: $(Agent.BuildDirectory)\installer\$(arch)-rtl.binlog
             artifact: $(arch)-rtl.binlog
@@ -2172,7 +2173,6 @@ stages:
                 -p:ProductVersion=${{ parameters.ProductVersion }}${{ parameters.BuildTag }}
                 -p:CERTIFICATE=$(certificate.secureFilePath)
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
-                -p:VCRedistDir="${env:VCToolsRedistDir}\${env:VSCMD_ARG_TGT_ARCH}\Microsoft.VC143.CRT\"
                 -p:INCLUDE_AMD64_SDK=true
                 -p:INCLUDE_X86_SDK=true
                 -p:INCLUDE_ARM64_SDK=true

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2075,6 +2075,7 @@ jobs:
               -p:SDK_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk `
               -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
+              -p:VCRedistDir="${env:VCToolsRedistDir}\${env:VSCMD_ARG_TGT_ARCH}\Microsoft.VC143.CRT\" `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/rtl/msi/rtlmsi.wixproj
 
       - uses: actions/upload-artifact@v3
@@ -2197,7 +2198,6 @@ jobs:
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:BundleFlavor=offline `
-              -p:VCRedistDir="${env:VCToolsRedistDir}\${env:VSCMD_ARG_TGT_ARCH}\Microsoft.VC143.CRT\" `
               -p:INCLUDE_AMD64_SDK=true `
               -p:INCLUDE_X86_SDK=true `
               -p:INCLUDE_ARM64_SDK=true `


### PR DESCRIPTION
This is used by the runtime MSI, not the installer bundle.  This works on the Apple CI as it does a single unified build, whereas we do the piecemeal build to get better control.  Adjust the invocation to match the requirements.