### PR TITLE
github swift-toolchain workflow: use a release-specific release tag n…

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -73,7 +73,19 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qq update -yq
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qq -o Dpkg::Use-Pty=0 install -yq repo libxml2-utils
 
-          repo init --quiet --groups default --depth 1 -u https://github.com/compnerd/swift-build -b main
+          # Which branch is this workflow based on
+          branch_version_string=${{ github.event.inputs.swift_version || '0.0.0' }}
+          if echo "$branch_version_string" | grep '\.'; then
+            branch_version="$(echo "$branch_version_string" | cut -d '.' -f 1).$(echo "$branch_version_string" | cut -d '.' -f 2)"
+          else
+            branch_version="$branch_version_string"
+          fi
+          if [[ "$branch_version" == "0.0" ]] ; then
+            branch_name="main"
+          else
+            branch_name="release/${branch_version}"
+          fi
+          repo init --quiet --groups default --depth 1 -u https://github.com/compnerd/swift-build -b $branch_name
           repo sync --quiet --no-clone-bundle --no-tags --jobs $(nproc --all)
 
           if [[ "${{ github.event.inputs.snapshot }}" == "true" ]] ; then
@@ -137,7 +149,11 @@ jobs:
           if [[ -n "${{ github.event.inputs.swift_tag }}" ]] ; then
             echo swift_tag=${{ github.event.inputs.swift_tag }} | tee -a ${GITHUB_OUTPUT}
           else
-            echo swift_tag=$(date +%Y%m%d.$(date +%-H/6 | bc)) | tee -a ${GITHUB_OUTPUT}
+            if [[ "$branch_name" == "main" ]] ; then
+              echo swift_tag=$(date +%Y%m%d.$(date +%-H/6 | bc)) | tee -a ${GITHUB_OUTPUT}
+            else
+              echo swift_tag=swift-"$branch_version"-$(date +%Y%m%d.$(date +%-H/6 | bc)) | tee -a ${GITHUB_OUTPUT}
+            fi
           fi
 
           echo windows_build_runner=${{ vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -75,16 +75,12 @@ jobs:
 
           # Which branch is this workflow based on
           branch_version_string=${{ github.event.inputs.swift_version || '0.0.0' }}
-          if echo "$branch_version_string" | grep '\.'; then
-            branch_version="$(echo "$branch_version_string" | cut -d '.' -f 1).$(echo "$branch_version_string" | cut -d '.' -f 2)"
+          if [[ $branch_version_string == *.* ]]; then
+            branch_name=$(echo ${branch_version_string} | awk -F. '{ ver=$1"."$2; print (ver == "0.0") ? "main" : "release/"ver }')
           else
-            branch_version="$branch_version_string"
+            branch_name="release/$branch_version_string"
           fi
-          if [[ "$branch_version" == "0.0" ]] ; then
-            branch_name="main"
-          else
-            branch_name="release/${branch_version}"
-          fi
+
           repo init --quiet --groups default --depth 1 -u https://github.com/compnerd/swift-build -b $branch_name
           repo sync --quiet --no-clone-bundle --no-tags --jobs $(nproc --all)
 
@@ -152,7 +148,7 @@ jobs:
             if [[ "$branch_name" == "main" ]] ; then
               echo swift_tag=$(date +%Y%m%d.$(date +%-H/6 | bc)) | tee -a ${GITHUB_OUTPUT}
             else
-              echo swift_tag=swift-"$branch_version"-$(date +%Y%m%d.$(date +%-H/6 | bc)) | tee -a ${GITHUB_OUTPUT}
+              echo swift_tag=swift-"$branch_version_string"-$(date +%Y%m%d.$(date +%-H/6 | bc)) | tee -a ${GITHUB_OUTPUT}
             fi
           fi
 

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -11,18 +11,29 @@ the `swift-build` release branch is created.
 
 The swift-toolchain workflow needs to be updated once a new branch is created.
 
-Firstly, the branch that the `repo` tool uses should be updated. The repo tool checks
-out the Swift repos from the manifest provided in the XML file. This line
-in the workflow YAML file sets it up:
+Firstly, the branch that the `repo` tool uses is inferred from the Swift version given to the 
+github action. The repo tool checks
+out the Swift repos from the manifest provided in the XML file. These lines
+specify the Swift version passed to the Github action:
 
 ```cmd
-repo init --quiet --groups default --depth 1 -u https://github.com/compnerd/swift-build -b main
+      swift_version:
+        description: 'Swift Version'
+        default: '0.0.0'
+        required: false
+        type: string
 ```
 
-The new branch should instead point to itself instead of `main`, e.g. for `release/5.10`:
+Instead of the the '0.0.0', the default should be changed to the version that's
+used by the release branch. For instance, for the 5.10 Swift release the default
+should be set to '5.10.0':
 
 ```cmd
-repo init --quiet --groups default --depth 1 -u https://github.com/compnerd/swift-build -b release/5.10
+      swift_version:
+        description: 'Swift Version'
+        default: '5.10.0'
+        required: false
+        type: string
 ```
 
 Then, the `repo` tool manifest should be updated. It's specified in the `default.xml` file.
@@ -37,7 +48,6 @@ This should be changed to appropriate release default, e.g. `release/5.10`.
 Certain other repos need a different default. For example, llvm-project uses
 the `swift/release/5.10` convention instead, and thus it has to be specified
 manually in the repo reference item, so for the 5.10 release it should look like:
-
 ```xml
 <project remote="github" name="apple/llvm-project" path="llvm-project" revision="swift/release/5.10" />
 ```


### PR DESCRIPTION
…ame when a non-main branch is built