### PR TITLE
GHA: update the {download,upload}-artifact action

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -143,7 +143,7 @@ jobs:
           echo windows_build_runner=${{ vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
           echo compilers_build_runner=${{ vars.COMPILERS_BUILD_RUNNER || vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: stable.xml
           path: stable.xml
@@ -206,7 +206,7 @@ jobs:
       - name: Install SQLite
         run: cmake --build ${{ github.workspace }}/BinaryCache/sqlite-3.43.2 --target install
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: sqlite-${{ matrix.arch }}-3.43.2
           path: ${{ github.workspace }}/BuildRoot/Library/sqlite-3.43.2/usr
@@ -266,7 +266,7 @@ jobs:
       - name: Build ICU Tools
         run: cmake --build ${{ github.workspace }}/BinaryCache/icu-tools-69.1
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: icu-tools-69.1
           path: |
@@ -296,7 +296,7 @@ jobs:
             BUILD_TOOLS: YES
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: icu-tools-69.1
           path: ${{ github.workspace }}/BinaryCache/icu-tools-69.1/usr/bin
@@ -354,7 +354,7 @@ jobs:
       - name: Install ICU
         run: cmake --build ${{ github.workspace }}/BinaryCache/icu-69.1 --target install
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: icu-${{ matrix.arch }}-69.1
           path: ${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr
@@ -458,7 +458,7 @@ jobs:
       - name: Build swift-compatibility-symbols
         run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target swift-compatibility-symbols
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-tools
           path: |
@@ -493,7 +493,7 @@ jobs:
             triple: 'aarch64-unknown-windows-msvc'
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-tools
           path: ${{ github.workspace }}/BinaryCache/0/bin
@@ -675,7 +675,7 @@ jobs:
         run: cmake --build ${{ github.workspace }}/BinaryCache/1 --target install-distribution-stripped
 
       - name: Upload Compilers
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: compilers-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library
@@ -693,13 +693,13 @@ jobs:
           Copy-Item -Path $module -Destination "${{ github.workspace }}/BinaryCache/swift-syntax/cmake/modules"
 
       - name: Upload swift-syntax
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: swift-syntax-${{ matrix.arch }}
           path: ${{ github.workspace }}/BinaryCache/swift-syntax
 
       # TODO(compnerd) this takes ~1h due to the size, see if we can compress first
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: false # ${{ needs.context.outputs.debug_info }}
         with:
           name: compilers-${{ matrix.arch }}-debug-info
@@ -764,7 +764,7 @@ jobs:
       - name: Install zlib
         run: cmake --build ${{ github.workspace }}/BinaryCache/zlib-1.3 --target install
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: zlib-${{ matrix.arch }}-1.3
           path: ${{ github.workspace }}/BuildRoot/Library/zlib-1.3/usr
@@ -786,7 +786,7 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/curl
           show-progress: false
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: zlib-${{ matrix.arch }}-1.3
           path: ${{ github.workspace }}/BuildRoot/Library/zlib-1.3/usr
@@ -902,7 +902,7 @@ jobs:
       - name: Install curl
         run: cmake --build ${{ github.workspace }}/BinaryCache/curl-7.77.0 --target install
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: curl-${{ matrix.arch }}-7.77.0
           path: ${{ github.workspace }}/BuildRoot/Library/curl-7.77.0/usr
@@ -964,7 +964,7 @@ jobs:
       - name: Install libxml2
         run: cmake --build ${{ github.workspace }}/BinaryCache/libxml2-2.11.5 --target install
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: libxml2-${{ matrix.arch }}-2.11.5
           path: ${{ github.workspace }}/BuildRoot/Library/libxml2-2.11.5/usr
@@ -991,24 +991,24 @@ jobs:
             triple: 'i686-unknown-windows-msvc'
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: icu-${{ matrix.arch }}-69.1
           path: ${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: libxml2-${{ matrix.arch }}-2.11.5
           path: ${{ github.workspace }}/BuildRoot/Library/libxml2-2.11.5/usr
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: curl-${{ matrix.arch }}-7.77.0
           path: ${{ github.workspace }}/BuildRoot/Library/curl-7.77.0/usr
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: zlib-${{ matrix.arch }}-1.3
           path: ${{ github.workspace }}/BuildRoot/Library/zlib-1.3/usr
       - name: Download Compilers
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: compilers-amd64
           path: ${{ github.workspace }}/BuildRoot/Library
@@ -1280,7 +1280,7 @@ jobs:
               # runtime.
               plistlib.dump({ 'DefaultProperties': { 'DEFAULT_USE_RUNTIME': 'MD' } }, plist)
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: windows-sdk-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform
@@ -1309,26 +1309,26 @@ jobs:
             triple: 'aarch64-unknown-windows-msvc'
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: sqlite-${{ matrix.arch }}-3.43.2
           path: ${{ github.workspace }}/BuildRoot/Library/sqlite-3.43.2/usr
       - name: Download Compilers
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: compilers-amd64
           path: ${{ github.workspace }}/BuildRoot/Library
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: windows-sdk-amd64
           path: ${{ github.workspace }}/BinaryCache
       - name: Download SDK
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: windows-sdk-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform
       - name: Downlaod swift-syntax
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: swift-syntax-${{ matrix.arch }}
           path: ${{ github.workspace }}/BinaryCache/swift-syntax
@@ -1868,7 +1868,7 @@ jobs:
       - name: Install SourceKit-LSP
         run: cmake --build ${{ github.workspace }}/BinaryCache/sourcekit-lsp --target install
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: devtools-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot-DevTools/Library
@@ -1892,11 +1892,11 @@ jobs:
 
     steps:
       - name: Download Compilers
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: compilers-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: devtools-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library
@@ -1979,28 +1979,28 @@ jobs:
               -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/ide/ide.wixproj
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: bld-${{ matrix.arch }}-msi
           path: |
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.cab
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cli-${{ matrix.arch }}-msi
           path: |
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.cab
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dbg-${{ matrix.arch }}-msi
           path: |
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.cab
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ide-${{ matrix.arch }}-msi
           path: |
@@ -2024,7 +2024,7 @@ jobs:
             platform: x86
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: windows-sdk-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform
@@ -2078,19 +2078,19 @@ jobs:
               -p:VCRedistDir="${env:VCToolsRedistDir}\${env:VSCMD_ARG_TGT_ARCH}\Microsoft.VC143.CRT\" `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/rtl/msi/rtlmsi.wixproj
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: sdk-windows-${{ matrix.arch }}-msi
           path: |
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/sdk.${{ matrix.arch }}.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/sdk.${{ matrix.arch }}.cab
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: rtl-windows-${{ matrix.arch }}-msi
           path: |
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/rtl.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/rtl.cab
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: rtl-windows-${{ matrix.arch }}-msm
           path: |
@@ -2107,49 +2107,49 @@ jobs:
         arch: ['amd64' , 'arm64']
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: bld-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cli-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dbg-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ide-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rtl-windows-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rtl-windows-amd64-msm
           path: ${{ github.workspace }}/BinaryCache/installer/Release/amd64
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rtl-windows-x86-msm
           path: ${{ github.workspace }}/BinaryCache/installer/Release/x86
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rtl-windows-arm64-msm
           path: ${{ github.workspace }}/BinaryCache/installer/Release/arm64
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: sdk-windows-amd64-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/amd64
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: sdk-windows-x86-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/x86
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: sdk-windows-arm64-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/arm64
@@ -2205,7 +2205,7 @@ jobs:
               -p:ProductVersion=${{ needs.context.outputs.swift_version }}-${{ needs.context.outputs.swift_tag }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bundle/installer.wixproj
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: installer-${{ matrix.arch }}
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/installer.exe
@@ -2215,7 +2215,7 @@ jobs:
     runs-on: ${{ needs.context.outputs.windows_build_runner }}
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: installer-amd64
           path: ${{ github.workspace }}/tmp
@@ -2277,7 +2277,7 @@ jobs:
           ref: refs/heads/main
           show-progress: false
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: stable.xml
 
@@ -2295,12 +2295,12 @@ jobs:
     needs: [context, smoke_test]
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: installer-amd64
           path: ${{ github.workspace }}/tmp/amd64
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: installer-arm64
           path: ${{ github.workspace }}/tmp/arm64


### PR DESCRIPTION
Use the new V4 release of the artifact which should have performance improvements though it will change some of the behaviour.