### PR TITLE
GHA: bump sccache to 0.7.4

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -204,7 +204,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
           key: sccache-windows-${{ matrix.arch }}-sqlite
@@ -264,7 +264,7 @@ jobs:
           arch: amd64
 
       - name: Setup sccache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
           key: sccache-windows-amd64-icu_tools
@@ -349,7 +349,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
           key: sccache-windows-${{ matrix.arch }}-icu
@@ -404,7 +404,7 @@ jobs:
       - uses: compnerd/gha-setup-vsdevenv@main
 
       - name: Setup sccache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
           key: sccache-windows-amd64-build_tools
@@ -592,7 +592,7 @@ jobs:
           "@
 
       - name: Setup sccache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 500M
           key: sccache-windows-${{ matrix.arch }}-compilers
@@ -744,7 +744,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
           key: sccache-windows-${{ matrix.arch }}-zlib
@@ -805,7 +805,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
           key: sccache-windows-${{ matrix.arch }}-curl
@@ -938,7 +938,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
           key: sccache-windows-${{ matrix.arch }}-libxml2


### PR DESCRIPTION
Use the forked ccache-action to use the latest sccache release. This should allow us to use the direct mode and hopefully get slightly faster builds.