### PR TITLE
Add sourcekit-lsp initialization smoke test

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2306,6 +2306,16 @@ jobs:
       - run: swift test -Xswiftc -DENABLE_TESTING
         working-directory: ${{ github.workspace }}/SourceCache/swift-win32
 
+      - name: Test that sourcekit-lsp initializes
+        working-directory: ${{ github.workspace }}/SourceCache/swift-win32
+        run: |
+          $diagnosticOutput = $( $output = & ${{ github.workspace }}/tests/sourcekit-lsp-initialization-message | sourcekit-lsp.exe ) 2>&1
+          if (-not ($diagnosticOutput -Match "Succeeded") -or -not ($diagnosticOutput -Match "InitializeResult")) {
+            Write-Host "sourcekit-lsp failed to initialize"
+            Write-Host $diagnosticOutput
+            exit 1
+          }
+
   snapshot:
     runs-on: ubuntu-latest
     needs: [context, smoke_test]

--- a/tests/sourcekit-lsp-initialization-message
+++ b/tests/sourcekit-lsp-initialization-message
@@ -1,0 +1,11 @@
+Content-Length: 152
+
+{
+    "jsonrpc": "2.0",
+    "id": 0,
+    "method": "initialize",
+    "params": {
+        "capabilities": {},
+        "trace": "verbose",
+    }
+}


### PR DESCRIPTION
Not sure of the best place to add the initialization request message. Because of the specific format of the message (must be CLRF; must be precise byte-length) it seemed difficult to inline into the GHA. I added a new `tests` dir with the file there, but I am reluctant to clutter the repo root. Is there a better place to put this?