### PR TITLE
GHA: adjust to CMake built swift-format on Windows

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -77,8 +77,10 @@ jobs:
       swift_crypto_revision: ${{ steps.context.outputs.swift_crypto_revision }}
       swift_driver_revision: ${{ steps.context.outputs.swift_driver_revision }}
       swift_experimental_string_processing_revision: ${{ steps.context.outputs.swift_experimental_string_processing_revision }}
+      swift_format_revision: ${{ steps.context.outputs.swift_format_revision }}
       swift_installer_scripts_revision: ${{ steps.context.outputs.swift_installer_scripts_revision }}
       swift_llbuild_revision: ${{ steps.context.outputs.swift_llbuild_revision }}
+      swift_markdown_revision: ${{ steps.context.outputs.swift_markdown_revision }}
       swift_package_manager_revision: ${{ steps.context.outputs.swift_package_manager_revision }}
       swift_revision: ${{ steps.context.outputs.swift_revision }}
       swift_syntax_revision: ${{ steps.context.outputs.swift_syntax_revision }}
@@ -133,8 +135,10 @@ jobs:
           swift_crypto_revision=refs/tags/2.4.0
           swift_driver_revision=refs/tags/${{ inputs.swift_tag }}
           swift_experimental_string_processing_revision=refs/tags/${{ inputs.swift_tag }}
+          swift_format_revision=refs/heads/main
           swift_installer_scripts_revision=refs/heads/main
           swift_llbuild_revision=refs/tags/${{ inputs.swift_tag }}
+          swift_markdown_revision=refs/tags/${{ inputs.swift_tag }}
           swift_package_manager_revision=refs/tags/${{ inputs.swift_tag }}
           swift_syntax_revision=refs/tags/${{ inputs.swift_tag }}
           swift_system_revision=refs/tags/1.1.1
@@ -443,7 +447,7 @@ jobs:
       - name: Configure cmark-gfm
         run: >
           cmake -B ${{ github.workspace }}/BinaryCache/cmark-gfm-0.29.0.gfm.13 `
-                -D BUILD_SHARED_LIBS=NO `
+                -D BUILD_SHARED_LIBS=YES `
                 -D BUILD_TESTING=NO `
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
@@ -461,9 +465,6 @@ jobs:
         run: cmake --build ${{ github.workspace }}/BinaryCache/cmark-gfm-0.29.0.gfm.13
       - name: Install cmark-gfm
         run: cmake --build ${{ github.workspace }}/BinaryCache/cmark-gfm-0.29.0.gfm.13 --target install
-      - name: Adjust Layout
-        run: |
-          Copy-Item -Path "${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr/lib/cmake/cmark-gfm.cmake" -Destination "${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr/lib/cmake/cmark-gfm-config.cmake"
       - uses: actions/upload-artifact@v4
         with:
           name: cmark-gfm-${{ matrix.arch }}-0.29.0.gfm.13
@@ -1069,7 +1070,7 @@ jobs:
 
   sdk:
     continue-on-error: ${{ matrix.arch != 'amd64' }}
-    needs: [context, icu, libxml2, curl, zlib, compilers]
+    needs: [context, icu, libxml2, curl, zlib, compilers, cmark_gfm]
     runs-on: ${{ needs.context.outputs.windows_build_runner }}
 
     strategy:
@@ -1110,6 +1111,13 @@ jobs:
         with:
           name: compilers-amd64
           path: ${{ github.workspace }}/BuildRoot/Library
+      - uses: actions/download-artifact@v4
+        with:
+          name: cmark-gfm-amd64-0.29.0.gfm.13
+          path: ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr
+
+      - name: cmark-gfm Setup
+        run: Copy-Item ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr/bin/*.dll ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/
 
       - uses: actions/checkout@v4
         with:
@@ -1431,6 +1439,19 @@ jobs:
         with:
           name: swift-syntax-${{ matrix.arch }}
           path: ${{ github.workspace }}/BinaryCache/swift-syntax
+      - uses: actions/download-artifact@v4
+        with:
+          name: cmark-gfm-amd64-0.29.0.gfm.13
+          path: ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr
+
+      - name: cmark-gfm Setup
+        run: Copy-Item ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr/bin/*.dll ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/
+
+      - uses: actions/download-artifact@v4
+        if: matrix.arch == 'arm64'
+        with:
+          name: cmark-gfm-arm64-0.29.0.gfm.13
+          path: ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr
 
       - uses: actions/checkout@v4
         with:
@@ -1482,9 +1503,21 @@ jobs:
           show-progress: false
       - uses: actions/checkout@v4
         with:
+          repository: apple/swift-format
+          ref: ${{ needs.context.outputs.swift_format_revision }}
+          path: ${{ github.workspace }}/SourceCache/swift-format
+          show-progress: false
+      - uses: actions/checkout@v4
+        with:
           repository: apple/swift-llbuild
           ref: ${{ needs.context.outputs.swift_llbuild_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-llbuild
+          show-progress: false
+      - uses: actions/checkout@v4
+        with:
+          repository: apple/swift-markdown
+          ref: ${{ needs.context.outputs.swift_markdown_revision }}
+          path: ${{ github.workspace }}/SourceCache/swift-markdown
           show-progress: false
       - uses: actions/checkout@v4
         with:
@@ -1875,6 +1908,68 @@ jobs:
       - name: Build swift-package-manager
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-package-manager
 
+      - name: Configure Markdown
+        run: |
+          # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+
+          cmake -B ${{ github.workspace }}/BinaryCache/swift-markdown `
+                -D BUILD_SHARED_LIBS=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
+                -D CMAKE_C_COMPILER=${CLANG_CL} `
+                -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.CMAKE_C_FLAGS }}" `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
+                -D CMAKE_Swift_COMPILER_WORKS=YES `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                -D CMAKE_SYSTEM_NAME=Windows `
+                -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-markdown `
+                -D ArgumentParser_DIR=${{ github.workspace }}/BinaryCache/swift-argument-parser/cmake/modules `
+                -D cmark-gfm_DIR=${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr/lib/cmake
+      - name: Build Markdown
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-markdown
+
+      - name: extract swift-syntax
+        run: |
+          $module = "${{ github.workspace }}/BinaryCache/swift-syntax/cmake/modules/SwiftSyntaxConfig.cmake"
+          $bindir = cygpath -m ${{ github.workspace }}/BinaryCache/swift-syntax
+          (Get-Content $module).Replace('<BINARY_DIR>', "${bindir}") | Set-Content $module
+
+      - name: Configure Format
+        run: |
+          # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+
+          cmake -B ${{ github.workspace }}/BinaryCache/swift-format `
+                -D BUILD_SHARED_LIBS=YES `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
+                -D CMAKE_C_COMPILER=${CLANG_CL} `
+                -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.CMAKE_C_FLAGS }}" `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
+                -D CMAKE_Swift_COMPILER_WORKS=YES `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                -D CMAKE_SYSTEM_NAME=Windows `
+                -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-format `
+                -D ArgumentParser_DIR=${{ github.workspace }}/BinaryCache/swift-argument-parser/cmake/modules `
+                -D cmark-gfm_DIR=${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr/lib/cmake `
+                -D SwiftMarkdown_DIR=${{ github.workspace }}/BinaryCache/swift-markdown/cmake/modules `
+                -D SwiftSyntax_DIR=${{ github.workspace }}/BinaryCache/swift-syntax/cmake/modules
+      - name: Build swift-format
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-format
+
       - name: Configure IndexStoreDB
         run: |
           # Workaround CMake 3.20 issue
@@ -1904,12 +1999,6 @@ jobs:
                 -S ${{ github.workspace }}/SourceCache/indexstore-db
       - name: Build indexstore-db
         run: cmake --build ${{ github.workspace }}/BinaryCache/indexstore-db
-
-      - name: extract swift-syntax
-        run: |
-          $module = "${{ github.workspace }}/BinaryCache/swift-syntax/cmake/modules/SwiftSyntaxConfig.cmake"
-          $bindir = cygpath -m ${{ github.workspace }}/BinaryCache/swift-syntax
-          (Get-Content $module).Replace('<BINARY_DIR>', "${bindir}") | Set-Content $module
 
       - name: Configure SourceKit-LSP
         run: |
@@ -1966,6 +2055,8 @@ jobs:
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-package-manager --target install
       - name: Install SourceKit-LSP
         run: cmake --build ${{ github.workspace }}/BinaryCache/sourcekit-lsp --target install
+      - name: Install swift-format
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-format --target install
 
       - uses: actions/upload-artifact@v4
         with:
@@ -1999,6 +2090,13 @@ jobs:
         with:
           name: devtools-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library
+      - uses: actions/download-artifact@v4
+        with:
+          name: cmark-gfm-${{ matrix.arch }}-0.29.0.gfm.13
+          path: ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr
+
+      - name: cmark-gfm Setup
+        run: Copy-Item ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr/bin/*.dll ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/
 
       - uses: actions/checkout@v4
         with:
@@ -2045,7 +2143,6 @@ jobs:
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:DEVTOOLS_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
               -p:TOOLCHAIN_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
-              -p:SWIFT_FORMAT_BUILD=false `
               -p:ProductArchitecture=${{ matrix.arch }} `
               -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/cli/cli.wixproj


### PR DESCRIPTION
Build swift-markdown, swift-format with CMake. swift-format is no longer optional, so we must build it and package it.