### PR TITLE
GHA: attempt to unescape a level of quoting for SDK

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -717,7 +717,7 @@ jobs:
                 -D CMAKE_MT=mt `
                 -D CMAKE_Swift_COMPILER="${SWIFTC}" `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk \`"${SDKROOT}\`"" `
+                -D CMAKE_Swift_FLAGS="-sdk `"${SDKROOT}`"" `
                 -D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.CMAKE_EXE_LINKER_FLAGS }}" `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.CMAKE_SHARED_LINKER_FLAGS }}" `


### PR DESCRIPTION
The recent GHA build image update seemed to have caused build errors. Unescape the path in the hopes that it fixes it.