### PR TITLE
GHA: do not include timestamp in cache key

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -240,6 +240,7 @@ jobs:
           max-size: 100M
           key: sccache-windows-${{ matrix.arch }}-sqlite
           variant: sccache
+          append-timestamp: false
 
       - name: Configure SQLite
         run: |
@@ -300,6 +301,7 @@ jobs:
           max-size: 100M
           key: sccache-windows-amd64-icu_tools
           variant: sccache
+          append-timestamp: false
 
       - name: Configure ICU Build Tools
         run:
@@ -385,6 +387,7 @@ jobs:
           max-size: 100M
           key: sccache-windows-${{ matrix.arch }}-icu
           variant: sccache
+          append-timestamp: false
 
       - name: Configure ICU
         run: |
@@ -443,6 +446,7 @@ jobs:
           max-size: 1M
           key: sccache-windows-${{ matrix.arch }}-cmark-gfm
           variant: sccache
+          append-timestamp: false
 
       - name: Configure cmark-gfm
         run: >
@@ -501,6 +505,7 @@ jobs:
           max-size: 100M
           key: sccache-windows-amd64-build_tools
           variant: sccache
+          append-timestamp: false
 
       - name: Configure Tools
         run: |
@@ -688,6 +693,7 @@ jobs:
           max-size: 500M
           key: sccache-windows-${{ matrix.arch }}-compilers
           variant: sccache
+          append-timestamp: false
 
       - name: Configure Compilers
         run: |
@@ -841,6 +847,7 @@ jobs:
           max-size: 100M
           key: sccache-windows-${{ matrix.arch }}-zlib
           variant: sccache
+          append-timestamp: false
 
       - name: Configure zlib
         run: |
@@ -902,6 +909,7 @@ jobs:
           max-size: 100M
           key: sccache-windows-${{ matrix.arch }}-curl
           variant: sccache
+          append-timestamp: false
 
       - name: Configure curl
         run: |
@@ -1035,6 +1043,7 @@ jobs:
           max-size: 100M
           key: sccache-windows-${{ matrix.arch }}-libxml2
           variant: sccache
+          append-timestamp: false
 
       - name: Configure libxml2
         run: |


### PR DESCRIPTION
This ensures that we do not misrepresent the latest cache entry. Without this, the caches used is subtly incorrect.