### PR TITLE
GHA: adjust key for caches

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -238,7 +238,7 @@ jobs:
         uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
-          key: sccache-windows-${{ matrix.arch }}-sqlite
+          key: windows-${{ matrix.arch }}-sqlite
           variant: sccache
           append-timestamp: false
 
@@ -299,7 +299,7 @@ jobs:
         uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
-          key: sccache-windows-amd64-icu_tools
+          key: windows-amd64-icu_tools
           variant: sccache
           append-timestamp: false
 
@@ -385,7 +385,7 @@ jobs:
         uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
-          key: sccache-windows-${{ matrix.arch }}-icu
+          key: windows-${{ matrix.arch }}-icu
           variant: sccache
           append-timestamp: false
 
@@ -444,7 +444,7 @@ jobs:
         uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 1M
-          key: sccache-windows-${{ matrix.arch }}-cmark-gfm
+          key: windows-${{ matrix.arch }}-cmark-gfm
           variant: sccache
           append-timestamp: false
 
@@ -503,7 +503,7 @@ jobs:
         uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
-          key: sccache-windows-amd64-build_tools
+          key: windows-amd64-build_tools
           variant: sccache
           append-timestamp: false
 
@@ -691,7 +691,7 @@ jobs:
         uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 500M
-          key: sccache-windows-${{ matrix.arch }}-compilers
+          key: windows-${{ matrix.arch }}-compilers
           variant: sccache
           append-timestamp: false
 
@@ -845,7 +845,7 @@ jobs:
         uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
-          key: sccache-windows-${{ matrix.arch }}-zlib
+          key: windows-${{ matrix.arch }}-zlib
           variant: sccache
           append-timestamp: false
 
@@ -907,7 +907,7 @@ jobs:
         uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
-          key: sccache-windows-${{ matrix.arch }}-curl
+          key: windows-${{ matrix.arch }}-curl
           variant: sccache
           append-timestamp: false
 
@@ -1041,7 +1041,7 @@ jobs:
         uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
-          key: sccache-windows-${{ matrix.arch }}-libxml2
+          key: windows-${{ matrix.arch }}-libxml2
           variant: sccache
           append-timestamp: false
 


### PR DESCRIPTION
Remove the `sccache-` prefix as that is already implicitly added.