### PR TITLE
Backport caching changes to 5.10

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -236,6 +236,7 @@ jobs:
           max-size: 100M
           key: sccache-windows-${{ matrix.arch }}-sqlite
           variant: sccache
+          append-timestamp: false
 
       - name: Configure SQLite
         run: |
@@ -296,6 +297,7 @@ jobs:
           max-size: 100M
           key: sccache-windows-amd64-icu_tools
           variant: sccache
+          append-timestamp: false
 
       - name: Configure ICU Build Tools
         run:
@@ -381,6 +383,7 @@ jobs:
           max-size: 100M
           key: sccache-windows-${{ matrix.arch }}-icu
           variant: sccache
+          append-timestamp: false
 
       - name: Configure ICU
         run: |
@@ -454,6 +457,7 @@ jobs:
           max-size: 100M
           key: sccache-windows-amd64-build_tools
           variant: sccache
+          append-timestamp: false
 
       - name: Configure Tools
         run: |
@@ -641,6 +645,7 @@ jobs:
           max-size: 500M
           key: sccache-windows-${{ matrix.arch }}-compilers
           variant: sccache
+          append-timestamp: false
 
       - name: Configure Compilers
         run: |
@@ -793,6 +798,7 @@ jobs:
           max-size: 100M
           key: sccache-windows-${{ matrix.arch }}-zlib
           variant: sccache
+          append-timestamp: false
 
       - name: Configure zlib
         run: |
@@ -854,6 +860,7 @@ jobs:
           max-size: 100M
           key: sccache-windows-${{ matrix.arch }}-curl
           variant: sccache
+          append-timestamp: false
 
       - name: Configure curl
         run: |
@@ -987,6 +994,7 @@ jobs:
           max-size: 100M
           key: sccache-windows-${{ matrix.arch }}-libxml2
           variant: sccache
+          append-timestamp: false
 
       - name: Configure libxml2
         run: |

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -234,7 +234,7 @@ jobs:
         uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
-          key: sccache-windows-${{ matrix.arch }}-sqlite
+          key: windows-${{ matrix.arch }}-sqlite
           variant: sccache
           append-timestamp: false
 
@@ -295,7 +295,7 @@ jobs:
         uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
-          key: sccache-windows-amd64-icu_tools
+          key: windows-amd64-icu_tools
           variant: sccache
           append-timestamp: false
 
@@ -381,7 +381,7 @@ jobs:
         uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
-          key: sccache-windows-${{ matrix.arch }}-icu
+          key: windows-${{ matrix.arch }}-icu
           variant: sccache
           append-timestamp: false
 
@@ -455,7 +455,7 @@ jobs:
         uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
-          key: sccache-windows-amd64-build_tools
+          key: windows-amd64-build_tools
           variant: sccache
           append-timestamp: false
 
@@ -643,7 +643,7 @@ jobs:
         uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 500M
-          key: sccache-windows-${{ matrix.arch }}-compilers
+          key: windows-${{ matrix.arch }}-compilers
           variant: sccache
           append-timestamp: false
 
@@ -796,7 +796,7 @@ jobs:
         uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
-          key: sccache-windows-${{ matrix.arch }}-zlib
+          key: windows-${{ matrix.arch }}-zlib
           variant: sccache
           append-timestamp: false
 
@@ -858,7 +858,7 @@ jobs:
         uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
-          key: sccache-windows-${{ matrix.arch }}-curl
+          key: windows-${{ matrix.arch }}-curl
           variant: sccache
           append-timestamp: false
 
@@ -992,7 +992,7 @@ jobs:
         uses: compnerd/ccache-action@sccache-0.7.4
         with:
           max-size: 100M
-          key: sccache-windows-${{ matrix.arch }}-libxml2
+          key: windows-${{ matrix.arch }}-libxml2
           variant: sccache
           append-timestamp: false
 


### PR DESCRIPTION
This backports:
- 363b317c637c02ded0496ffb844030d62aeba94f
- 8c568ff632e4d7d6785f8d95d6ac1fb0529c2240

To 5.10 from main. The motivation is to help clean up the cache storage and prepares for bifurcating the caches per branch.