### PR TITLE
AzDO: Adopt swift-format and cmark-gfm changes from GHA

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -62,6 +62,11 @@ resources:
       name: apple/swift-format
       ref: refs/heads/main
       type: github
+    - repository: apple/swift-markdown
+      endpoint: GitHub
+      name: apple/swift-markdown
+      ref: refs/heads/main
+      type: github
     - repository: apple/swift-corelibs-libdispatch
       endpoint: GitHub
       name: apple/swift-corelibs-libdispatch
@@ -162,8 +167,75 @@ parameters:
     default: '3.9.10'
 
 stages:
-  - stage: tools
+  - stage: cmark_gfm
     dependsOn: []
+    jobs:
+      - job: build
+        strategy:
+          matrix:
+            'x64':
+              arch: amd64
+              platform: x86_64
+            'arm64':
+              arch: arm64
+              platform: aarch64
+        steps:
+          - script: |
+              git config --global --add core.autocrlf false
+              git config --global --add core.symlinks true
+            displayName: Configure git
+          - checkout: apple/swift-cmark
+            fetchDepth: 1
+          - script: |
+              SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+              FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
+                SET vs="%%i"
+                IF EXIST "%%i\Common7\Tools\VsDevCmd.bat" (
+                  SET VsDevCmd="%%i\Common7\Tools\VsDevCmd.bat"
+                )
+              )
+              @echo ##vso[task.setvariable variable=vs;]%vs%
+              @echo ##vso[task.setvariable variable=vsdevcmd;]%VsDevCmd%
+            displayName: Find VS
+          - task: BatchScript@1
+            displayName: Setup VS Environment
+            inputs:
+              filename: $(VsDevCmd)
+              arguments: -no_logo -arch=$(arch) -host_arch=amd64
+              modifyEnvironment: true
+          - task: CMake@1
+            displayName: Configure cmark-gfm
+            inputs:
+              cmakeArgs:
+                -B $(Build.BinariesDirectory)/$(arch)/cmark-gfm-0.29.0.gfm.13
+                -D BUILD_SHARED_LIBS=YES
+                -D BUILD_TESTING=NO
+                -D CMAKE_BUILD_TYPE=Release
+                -D CMAKE_C_COMPILER=cl
+                -D CMAKE_C_COMPILER_FLAGS="/GS- /Oy /Gw /Gy"
+                -D CMAKE_CXX_COMPILER=cl
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
+                -D CMAKE_MT=mt
+                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/cmark-gfm-0.29.0.gfm.13/usr
+                -D CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=YES
+                -S $(Build.SourcesDirectory)
+                -G Ninja
+          - task: CMake@1
+            displayName: Build cmark-gfm
+            inputs:
+              cmakeArgs:
+                --build $(Build.BinariesDirectory)/$(arch)/cmark-gfm-0.29.0.gfm.13
+          - task: CMake@1
+            displayName: Install cmark-gfm
+            inputs:
+              cmakeArgs:
+                --build $(Build.BinariesDirectory)/$(arch)/cmark-gfm-0.29.0.gfm.13 --target install
+          - publish: $(Build.StagingDirectory)/Library/cmark-gfm-0.29.0.gfm.13
+            artifact: cmark-gfm-$(arch)-0.29.0.gfm.13
+            displayName: Upload cmark-gfm
+
+  - stage: tools
+    dependsOn: [cmark_gfm]
     jobs:
       - job: x64
         steps:

--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -2089,18 +2089,19 @@ stages:
           matrix:
             'x64':
               arch: amd64
-              platform: x64
-            # TODO(compnerd) enable AArch64 toolchain
-            # 'arm64':
-            #  arch: arm64
-            #  platform: aarch64
+            'arm64':
+              arch: arm64
         steps:
-          - download: current
-            artifact: toolchain-$(arch)
-          - download: current
-            artifact: devtools-$(arch)
-          - download: current
-            artifact: swift-format-$(arch)
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              buildType: 'current'
+              artifactName: toolchain-$(arch)
+              targetPath: '$(Pipeline.Workspace)/$(arch)'
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              buildType: 'current'
+              artifactName: devtools-$(arch)
+              targetPath: '$(Pipeline.Workspace)/$(arch)'
           - download: current
             artifact: swift-inspect-$(arch)
           - download: current
@@ -2111,7 +2112,7 @@ stages:
             inputs:
               targetType: 'inline'
               script: |
-                Copy-Item $(Pipeline.Workspace)/cmark-gfm-$(arch)-0.29.0.gfm.13/usr/bin/*.dll $(Pipeline.Workspace)/$(arch)/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/
+                Copy-Item $(Pipeline.Workspace)/cmark-gfm-$(arch)-0.29.0.gfm.13/usr/bin/*.dll $(Pipeline.Workspace)/$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/
           - checkout: apple/swift-installer-scripts
             fetchDepth: 1
           - script: |
@@ -2133,11 +2134,10 @@ stages:
             inputs:
               secureFile: dt.compnerd.org.p12
             name: certificate
+
           - task: MSBuild@1
             inputs:
               solution: $(Build.SourcesDirectory)/platforms/Windows/bld/bld.wixproj
-              msbuildArchitecture: $(arch)
-              platform: $(platform)
               configuration: Release
               maximumCpuCount: true
               createLogFile: true
@@ -2145,20 +2145,20 @@ stages:
                 -restore
                 -maxCpuCount
                 -p:BaseOutputPath=$(Agent.BuildDirectory)\installer\
+                -p:ProductArchitecture=$(arch)
                 -p:ProductVersion=${{ parameters.ProductVersion }}
                 -p:CERTIFICATE=$(certificate.secureFilePath)
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
-                -p:DEVTOOLS_ROOT=$(Pipeline.Workspace)/devtools-$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
-                -p:TOOLCHAIN_ROOT=$(Pipeline.Workspace)/toolchain-$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
+                -p:DEVTOOLS_ROOT=$(Pipeline.Workspace)/$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
+                -p:TOOLCHAIN_ROOT=$(Pipeline.Workspace)/$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
                 -bl:$(Agent.BuildDirectory)\installer\$(arch)-bld.binlog
           - publish: $(Agent.BuildDirectory)\installer\$(arch)-bld.binlog
             artifact: $(arch)-bld.binlog
             condition: failed()
+
           - task: MSBuild@1
             inputs:
               solution: $(Build.SourcesDirectory)/platforms/Windows/cli/cli.wixproj
-              msbuildArchitecture: $(arch)
-              platform: $(platform)
               configuration: Release
               maximumCpuCount: true
               createLogFile: true
@@ -2166,22 +2166,20 @@ stages:
                 -restore
                 -maxCpuCount
                 -p:BaseOutputPath=$(Agent.BuildDirectory)\installer\
+                -p:ProductArchitecture=$(arch)
                 -p:ProductVersion=${{ parameters.ProductVersion }}
                 -p:CERTIFICATE=$(certificate.secureFilePath)
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
-                -p:DEVTOOLS_ROOT=$(Pipeline.Workspace)/devtools-$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
-                -p:TOOLCHAIN_ROOT=$(Pipeline.Workspace)/toolchain-$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
-                -p:INCLUDE_SWIFT_FORMAT=true
-                -p:SWIFT_FORMAT_BUILD=$(Pipeline.Workspace)/swift-format-$(arch)/
+                -p:DEVTOOLS_ROOT=$(Pipeline.Workspace)/$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
+                -p:TOOLCHAIN_ROOT=$(Pipeline.Workspace)/$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
                 -bl:$(Agent.BuildDirectory)\installer\$(arch)-cli.binlog
           - publish: $(Agent.BuildDirectory)\installer\$(arch)-cli.binlog
             artifact: $(arch)-cli.binlog
             condition: failed()
+
           - task: MSBuild@1
             inputs:
               solution: $(Build.SourcesDirectory)/platforms/Windows/dbg/dbg.wixproj
-              msbuildArchitecture: $(arch)
-              platform: $(platform)
               configuration: Release
               maximumCpuCount: true
               createLogFile: true
@@ -2189,22 +2187,22 @@ stages:
                 -restore
                 -maxCpuCount
                 -p:BaseOutputPath=$(Agent.BuildDirectory)\installer\
+                -p:ProductArchitecture=$(arch)
                 -p:ProductVersion=${{ parameters.ProductVersion }}
                 -p:CERTIFICATE=$(certificate.secureFilePath)
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
-                -p:DEVTOOLS_ROOT=$(Pipeline.Workspace)/devtools-$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
-                -p:TOOLCHAIN_ROOT=$(Pipeline.Workspace)/toolchain-$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
+                -p:DEVTOOLS_ROOT=$(Pipeline.Workspace)/$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
+                -p:TOOLCHAIN_ROOT=$(Pipeline.Workspace)/$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
                 -p:INCLUDE_SWIFT_INSPECT=true
                 -p:SWIFT_INSPECT_BUILD=$(Pipeline.Workspace)/swift-inspect-$(arch)/
                 -bl:$(Agent.BuildDirectory)\installer\$(arch)-dbg.binlog
           - publish: $(Agent.BuildDirectory)\installer\$(arch)-dbg.binlog
             artifact: $(arch)-dbg.binlog
             condition: failed()
+
           - task: MSBuild@1
             inputs:
               solution: $(Build.SourcesDirectory)/platforms/Windows/ide/ide.wixproj
-              msbuildArchitecture: $(arch)
-              platform: $(platform)
               configuration: Release
               maximumCpuCount: true
               createLogFile: true
@@ -2212,12 +2210,18 @@ stages:
                 -restore
                 -maxCpuCount
                 -p:BaseOutputPath=$(Agent.BuildDirectory)\installer\
+                -p:ProductArchitecture=$(arch)
                 -p:ProductVersion=${{ parameters.ProductVersion }}
                 -p:CERTIFICATE=$(certificate.secureFilePath)
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
-                -p:DEVTOOLS_ROOT=$(Pipeline.Workspace)/devtools-$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
-                -p:TOOLCHAIN_ROOT=$(Pipeline.Workspace)/toolchain-$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
+                -p:DEVTOOLS_ROOT=$(Pipeline.Workspace)/$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
+                -p:TOOLCHAIN_ROOT=$(Pipeline.Workspace)/$(arch)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
                 -bl:$(Agent.BuildDirectory)\installer\$(arch)-ide.binlog
+          - publish: $(Agent.BuildDirectory)\installer\$(arch)-ide.binlog
+            displayName: Upload logs
+            artifact: $(arch)-ide.binlog
+            condition: failed()
+
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -2234,9 +2238,7 @@ stages:
                 Move-Item $(Agent.BuildDirectory)/installer/Release/$(arch)/dbg.cab $(Build.StagingDirectory)/dbg-$(arch)-msi/
                 Move-Item $(Agent.BuildDirectory)/installer/Release/$(arch)/ide.msi $(Build.StagingDirectory)/ide-$(arch)-msi/
                 Move-Item $(Agent.BuildDirectory)/installer/Release/$(arch)/ide.cab $(Build.StagingDirectory)/ide-$(arch)-msi/
-          - publish: $(Agent.BuildDirectory)\installer\$(arch)-ide.binlog
-            artifact: $(arch)-ide.binlog
-            condition: failed()
+          
           - publish: $(Build.StagingDirectory)/bld-$(arch)-msi
             artifact: bld-$(arch)-msi
           - publish: $(Build.StagingDirectory)/cli-$(arch)-msi

--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -592,6 +592,22 @@ stages:
           - publish: $(Build.BinariesDirectory)/toolchains/20231016.0/rtl
             artifact: pinned-toolchain-runtime
             condition: and(succeeded(), eq(variables['platform'], 'x86_64'))
+          - task: PowerShell@2
+            displayName: Extract swift-syntax
+            inputs:
+              targetType: 'inline'
+              script: |
+                $module = "$(Agent.BuildDirectory)/1/cmake/modules/SwiftSyntaxConfig.cmake"
+                $bindir = cygpath -m $(Agent.BuildDirectory)/1
+                (Get-Content $module).Replace("${bindir}", '<BINARY_DIR>') | Set-Content $module
+                New-Item -Path $(Build.StagingDirectory)/swift-syntax/lib/swift/host -ItemType Directory | Out-Null
+                Copy-Item -Path "$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/lib/*.lib" -Destination "$(Build.StagingDirectory)/swift-syntax/lib"
+                Copy-Item -Path "$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/lib/*.lib" -Destination "$(Build.StagingDirectory)/swift-syntax/lib/swift/host"
+                Copy-Item -Path "$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/lib/swift/host/*.swiftmodule" -Destination "$(Build.StagingDirectory)/swift-syntax/lib/swift/host" -Recurse
+                New-Item -Path $(Build.StagingDirectory)/swift-syntax/cmake/modules -ItemType Directory | Out-Null
+                Copy-Item -Path $module -Destination "$(Build.StagingDirectory)/swift-syntax/cmake/modules"
+          - publish: $(Build.StagingDirectory)/swift-syntax
+            artifact: swift-syntax-$(arch)
 
   - stage: icu
     dependsOn: []

--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -887,8 +887,8 @@ stages:
                 -D USE_WIN32_IDN=YES
                 -D USE_WIN32_LARGE_FILES=YES
                 -D USE_WIN32_LDAP=NO
-                -D ZLIB_ROOT=$(Pipeline.Workspace)/zlib-x64-1.3/Library/zlib-1.3/usr
-                -D ZLIB_LIBRARY=$(Pipeline.Workspace)/zlib-x64-1.3/Library/zlib-1.3/usr/lib/zlibstatic.lib
+                -D ZLIB_ROOT=$(Pipeline.Workspace)/zlib-$(arch)-1.3/Library/zlib-1.3/usr
+                -D ZLIB_LIBRARY=$(Pipeline.Workspace)/zlib-$(arch)-1.3/Library/zlib-1.3/usr/lib/zlibstatic.lib
           - task: CMake@1
             inputs:
               cmakeArgs:

--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -2362,10 +2362,9 @@ stages:
             'x64':
               arch: amd64
               platform: x64
-            # TODO(compnerd) enable AArch64 toolchain
-            # 'arm64':
-            #  arch: arm64
-            #  platform: aarch64
+            'arm64':
+              arch: arm64
+              platform: arm64
         steps:
           - download: current
             artifact: bld-$(arch)-msi
@@ -2456,15 +2455,13 @@ stages:
           - task: MSBuild@1
             inputs:
               solution: $(Build.SourcesDirectory)/platforms/Windows/shared/shared.wixproj
-              msbuildArchitecture: $(arch)
-              platform: $(platform)
               configuration: Release
               maximumCpuCount: true
               createLogFile: true
               msbuildArguments:
                 -restore
-                -maxCpuCount
                 -p:BaseOutputPath=$(Agent.BuildDirectory)\installer\
+                -p:ProductArchitecture=$(arch)
                 -p:ProductVersion=${{ parameters.ProductVersion }}${{ parameters.BuildTag }}
                 -p:CERTIFICATE=$(certificate.secureFilePath)
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)
@@ -2472,17 +2469,15 @@ stages:
           - task: MSBuild@1
             inputs:
               solution: $(Build.SourcesDirectory)/platforms/Windows/bundle/installer.wixproj
-              msbuildArchitecture: $(arch)
-              platform: $(platform)
               configuration: Release
               maximumCpuCount: true
               createLogFile: true
               msbuildArguments:
                 -restore
-                -maxCpuCount
                 -p:BaseOutputPath=$(Agent.BuildDirectory)\installer\
                 -p:BuildProjectReferences=false
                 -p:BundleFlavor=offline
+                -p:ProductArchitecture=$(arch)
                 -p:ProductVersion=${{ parameters.ProductVersion }}${{ parameters.BuildTag }}
                 -p:CERTIFICATE=$(certificate.secureFilePath)
                 -p:PASSPHRASE=$(CERTIFICATE_PASSWORD)

--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -418,8 +418,6 @@ stages:
                 nuget install pythonarm64 -Version ${{ parameters.PythonVersion }}
                 echo "##vso[task.setvariable variable=PYTHON_ROOT;]${PWD}\pythonarm64.${{ parameters.PythonVersion }}\tools"
                 (Get-Content $(Build.SourcesDirectory)/swift/cmake/caches/Windows-aarch64.cmake).replace(' runtimes', '') | Set-Content $(Build.SourcesDirectory)/swift/cmake/caches/Windows-aarch64.cmake
-                "set_source_files_properties(StandardLibrary.cpp PROPERTIES COMPILE_FLAGS ""/Od /Gw /Oi /Oy /Gy /Ob2 /Ot /GF"")" + "`n" + (Get-Content $(Build.SourcesDirectory)/llvm-project/clang/lib/Tooling/Inclusions/Stdlib/CMakeLists.txt -Raw) | Set-Content $(Build.SourcesDirectory)/llvm-project/clang/lib/Tooling/Inclusions/Stdlib/CMakeLists.txt
-                "set_source_files_properties(CGBuiltin.cpp PROPERTIES COMPILE_FLAGS ""/Od /Gw /Oi /Oy /Gy /Ob2 /Ot /GF"")" + "`n" + (Get-Content $(Build.SourcesDirectory)/llvm-project/clang/lib/CodeGen/CMakeLists.txt -Raw) | Set-Content $(Build.SourcesDirectory)/llvm-project/clang/lib/CodeGen/CMakeLists.txt
             condition: and(succeeded(), eq(variables['platform'], 'aarch64'))
           - script: |
               CALL :where python.exe PYTHON_EXECUTABLE

--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -1362,6 +1362,10 @@ stages:
             artifact: windows-sdk-$(arch)
           - download: current
             artifact: windows-sdk-amd64
+            condition: and(succeeded(), ne(variables['arch'], 'amd64'))
+          - download: current
+            artifact: swift-syntax-$(arch)
+            displayName: Download swift-syntax
           - download: current
             artifact: cmark-gfm-$(arch)-0.29.0.gfm.13
             displayName: Download cmark-gfm ($(arch))
@@ -1397,7 +1401,9 @@ stages:
             fetchDepth: 1
           - checkout: jpsim/Yams
             fetchDepth: 1
-          - checkout: apple/swift-syntax
+          - checkout: apple/swift-format
+            fetchDepth: 1
+          - checkout: apple/swift-markdown
             fetchDepth: 1
           - task: PowerShell@2
             displayName: cmark-gfm Setup 
@@ -1420,18 +1426,31 @@ stages:
               filename: $(VsDevCmd)
               arguments: -no_logo -arch=$(arch) -host_arch=amd64
               modifyEnvironment: true
-          - bash: |
-              echo "##vso[task.setvariable variable=root;isOutput=true]$(cygpath -m '$(Pipeline.Workspace)')"
-            name: workspace
           - task: PowerShell@2
+            displayName: Restructure SDK
             inputs:
               targetType: 'inline'
               script: |
-                Write-Host "##vso[task.setvariable variable=PATH;]$(Agent.BuildDirectory)\windows-sdk-amd64\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk\usr\bin;${env:Path}"
+                $env:SDKROOT="$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
+                mv ${env:SDKROOT}/usr/lib/swift/dispatch ${env:SDKROOT}/usr/include/
+                mv ${env:SDKROOT}/usr/lib/swift/os ${env:SDKROOT}/usr/include/
+                mv ${env:SDKROOT}/usr/lib/swift/Block ${env:SDKROOT}/usr/include/
+                mv ${env:SDKROOT}/usr/lib/swift/windows/BlocksRuntime.lib ${env:SDKROOT}/usr/lib/swift/windows/$(platform)/
+                mv ${env:SDKROOT}/usr/lib/swift/windows/dispatch.lib ${env:SDKROOT}/usr/lib/swift/windows/$(platform)/
+                mv ${env:SDKROOT}/usr/lib/swift/windows/swiftDispatch.lib ${env:SDKROOT}/usr/lib/swift/windows/$(platform)/
+                mv ${env:SDKROOT}/usr/lib/swift/windows/Foundation.lib ${env:SDKROOT}/usr/lib/swift/windows/$(platform)/
+                mv ${env:SDKROOT}/usr/lib/swift/windows/FoundationXML.lib ${env:SDKROOT}/usr/lib/swift/windows/$(platform)/
+                mv ${env:SDKROOT}/usr/lib/swift/windows/FoundationNetworking.lib ${env:SDKROOT}/usr/lib/swift/windows/$(platform)/
+                Write-Host "##vso[task.prependpath]$(Agent.BuildDirectory)\windows-sdk-amd64\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk\usr\bin"
+                Write-Host "##vso[task.setvariable variable=SDKROOT;]${env:SDKROOT}"
+          - bash: |
+              echo "##vso[task.setvariable variable=root;isOutput=true]$(cygpath -m '$(Pipeline.Workspace)')"
+            name: workspace
+
           - task: CMake@1
             inputs:
               cmakeArgs:
-                -B $(Agent.BuildDirectory)/swift-argument-parser
+                -B $(Build.BinariesDirectory)/$(arch)/swift-argument-parser
                 -D BUILD_SHARED_LIBS=YES
                 -D BUILD_TESTING=NO
                 -D CMAKE_BUILD_TYPE=Release
@@ -1445,18 +1464,22 @@ stages:
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
                 -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share/windows-vfs-overlay.yaml"
+                -D CMAKE_Swift_COMPILER_WORKS=YES
+                -D CMAKE_Swift_FLAGS="-sdk $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
                 -D CMAKE_Swift_FLAGS_RELEASE="-O"
+                -D CMAKE_SYSTEM_NAME=Windows
+                -D CMAKE_SYSTEM_PROCESSOR=$(platform)
                 -G Ninja
                 -S $(Build.SourcesDirectory)/swift-argument-parser
           - task: CMake@1
             inputs:
               cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-argument-parser
+                --build $(Build.BinariesDirectory)/$(arch)/swift-argument-parser
+
           - task: CMake@1
             inputs:
               cmakeArgs:
-                -B $(Agent.BuildDirectory)/swift-collections
+                -B $(Build.BinariesDirectory)/$(arch)/swift-collections
                 -D BUILD_SHARED_LIBS=YES
                 -D BUILD_TESTING=NO
                 -D CMAKE_BUILD_TYPE=Release
@@ -1470,18 +1493,22 @@ stages:
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
                 -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share/windows-vfs-overlay.yaml"
+                -D CMAKE_Swift_COMPILER_WORKS=YES
+                -D CMAKE_Swift_FLAGS="-sdk $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
                 -D CMAKE_Swift_FLAGS_RELEASE="-O"
+                -D CMAKE_SYSTEM_NAME=Windows
+                -D CMAKE_SYSTEM_PROCESSOR=$(platform)
                 -G Ninja
                 -S $(Build.SourcesDirectory)/swift-collections
           - task: CMake@1
             inputs:
               cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-collections
+                --build $(Build.BinariesDirectory)/$(arch)/swift-collections
+
           - task: CMake@1
             inputs:
               cmakeArgs:
-                -B $(Agent.BuildDirectory)/swift-crypto
+                -B $(Build.BinariesDirectory)/$(arch)/swift-crypto
                 -D BUILD_SHARED_LIBS=NO
                 -D BUILD_TESTING=NO
                 -D CMAKE_BUILD_TYPE=Release
@@ -1495,18 +1522,22 @@ stages:
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
                 -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share/windows-vfs-overlay.yaml"
+                -D CMAKE_Swift_COMPILER_WORKS=YES
+                -D CMAKE_Swift_FLAGS="-sdk $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
                 -D CMAKE_Swift_FLAGS_RELEASE="-O"
+                -D CMAKE_SYSTEM_NAME=Windows
+                -D CMAKE_SYSTEM_PROCESSOR=$(platform)
                 -G Ninja
                 -S $(Build.SourcesDirectory)/swift-crypto
           - task: CMake@1
             inputs:
               cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-crypto
+                --build $(Build.BinariesDirectory)/$(arch)/swift-crypto
+
           - task: CMake@1
             inputs:
               cmakeArgs:
-                -B $(Agent.BuildDirectory)/Yams
+                -B $(Build.BinariesDirectory)/$(arch)/Yams
                 -D BUILD_SHARED_LIBS=NO
                 -D BUILD_TESTING=NO
                 -D CMAKE_BUILD_TYPE=Release
@@ -1520,18 +1551,22 @@ stages:
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
                 -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share/windows-vfs-overlay.yaml"
+                -D CMAKE_Swift_COMPILER_WORKS=YES
+                -D CMAKE_Swift_FLAGS="-sdk $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
                 -D CMAKE_Swift_FLAGS_RELEASE="-O"
+                -D CMAKE_SYSTEM_NAME=Windows
+                -D CMAKE_SYSTEM_PROCESSOR=$(platform)
                 -G Ninja
                 -S $(Build.SourcesDirectory)/Yams
           - task: CMake@1
             inputs:
               cmakeArgs:
-                --build $(Agent.BuildDirectory)/Yams
+                --build $(Build.BinariesDirectory)/$(arch)/Yams
+
           - task: CMake@1
             inputs:
               cmakeArgs:
-                -B $(Agent.BuildDirectory)/swift-llbuild
+                -B $(Build.BinariesDirectory)/$(arch)/swift-llbuild
                 -D BUILD_SHARED_LIBS=YES
                 -D BUILD_TESTING=NO
                 -D CMAKE_BUILD_TYPE=Release
@@ -1545,8 +1580,11 @@ stages:
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
                 -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share/windows-vfs-overlay.yaml"
+                -D CMAKE_Swift_COMPILER_WORKS=YES
+                -D CMAKE_Swift_FLAGS="-sdk $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
                 -D CMAKE_Swift_FLAGS_RELEASE="-O"
+                -D CMAKE_SYSTEM_NAME=Windows
+                -D CMAKE_SYSTEM_PROCESSOR=$(platform)
                 -G Ninja
                 -S $(Build.SourcesDirectory)/swift-llbuild
                 -D LLBUILD_SUPPORT_BINDINGS=Swift
@@ -1555,11 +1593,12 @@ stages:
           - task: CMake@1
             inputs:
               cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-llbuild
+                --build $(Build.BinariesDirectory)/$(arch)/swift-llbuild
+
           - task: CMake@1
             inputs:
               cmakeArgs:
-                -B $(Agent.BuildDirectory)/swift-system
+                -B $(Build.BinariesDirectory)/$(arch)/swift-system
                 -D BUILD_SHARED_LIBS=YES
                 -D BUILD_TESTING=NO
                 -D CMAKE_BUILD_TYPE=Release
@@ -1573,18 +1612,22 @@ stages:
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
                 -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share/windows-vfs-overlay.yaml"
+                -D CMAKE_Swift_COMPILER_WORKS=YES
+                -D CMAKE_Swift_FLAGS="-sdk $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
                 -D CMAKE_Swift_FLAGS_RELEASE="-O"
+                -D CMAKE_SYSTEM_NAME=Windows
+                -D CMAKE_SYSTEM_PROCESSOR=$(platform)
                 -G Ninja
                 -S $(Build.SourcesDirectory)/swift-system
           - task: CMake@1
             inputs:
               cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-system
+                --build $(Build.BinariesDirectory)/$(arch)/swift-system
+
           - task: CMake@1
             inputs:
               cmakeArgs:
-                -B $(Agent.BuildDirectory)/swift-tools-support-core
+                -B $(Build.BinariesDirectory)/$(arch)/swift-tools-support-core
                 -D BUILD_SHARED_LIBS=YES
                 -D BUILD_TESTING=NO
                 -D CMAKE_BUILD_TYPE=Release
@@ -1598,172 +1641,23 @@ stages:
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
                 -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share/windows-vfs-overlay.yaml"
+                -D CMAKE_Swift_COMPILER_WORKS=YES
+                -D CMAKE_Swift_FLAGS="-sdk $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
                 -D CMAKE_Swift_FLAGS_RELEASE="-O"
+                -D CMAKE_SYSTEM_NAME=Windows
+                -D CMAKE_SYSTEM_PROCESSOR=$(platform)
                 -G Ninja
                 -S $(Build.SourcesDirectory)/swift-tools-support-core
-                -D SwiftSystem_DIR=$(Agent.BuildDirectory)/swift-system/cmake/modules
+                -D SwiftSystem_DIR=$(Build.BinariesDirectory)/$(arch)/swift-system/cmake/modules
           - task: CMake@1
             inputs:
               cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-tools-support-core
+                --build $(Build.BinariesDirectory)/$(arch)/swift-tools-support-core
+
           - task: CMake@1
             inputs:
               cmakeArgs:
-                -B $(Agent.BuildDirectory)/swift-driver
-                -D BUILD_SHARED_LIBS=YES
-                -D BUILD_TESTING=NO
-                -D CMAKE_BUILD_TYPE=Release
-                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
-                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-                -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
-                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
-                -D CMAKE_MT=mt
-                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
-                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share/windows-vfs-overlay.yaml"
-                -D CMAKE_Swift_FLAGS_RELEASE="-O"
-                -G Ninja
-                -S $(Build.SourcesDirectory)/swift-driver
-                -D ArgumentParser_DIR=$(Agent.BuildDirectory)/swift-argument-parser/cmake/modules
-                -D LLBuild_DIR=$(Agent.BuildDirectory)/swift-llbuild/cmake/modules
-                -D SwiftSystem_DIR=$(Agent.BuildDirectory)/swift-system/cmake/modules
-                -D TSC_DIR=$(Agent.BuildDirectory)/swift-tools-support-core/cmake/modules
-                -D Yams_DIR=$(Agent.BuildDirectory)/Yams/cmake/modules
-                -D SQLite3_LIBRARY=$(Pipeline.Workspace)/sqlite-$(arch)-3.43.2/Library/sqlite-3.43.2/usr/lib/SQLite3.lib
-                -D SQLite3_INCLUDE_DIR=$(Pipeline.Workspace)/sqlite-$(arch)-3.43.2/Library/sqlite-3.43.2/usr/include
-          - task: CMake@1
-            inputs:
-              cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-driver
-          - task: CMake@1
-            inputs:
-              cmakeArgs:
-                -B $(Agent.BuildDirectory)/swift-asn1
-                -D BUILD_SHARED_LIBS=NO
-                -D CMAKE_BUILD_TYPE=Release
-                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
-                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share/windows-vfs-overlay.yaml"
-                -D CMAKE_Swift_FLAGS_RELEASE="-O"
-                -G Ninja
-                -S $(Build.SourcesDirectory)/swift-asn1
-          - task: CMake@1
-            inputs:
-              cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-asn1
-          - task: CMake@1
-            inputs:
-              cmakeArgs:
-                -B $(Agent.BuildDirectory)/swift-certificates
-                -D BUILD_SHARED_LIBS=NO
-                -D CMAKE_BUILD_TYPE=Release
-                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
-                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share/windows-vfs-overlay.yaml"
-                -D CMAKE_Swift_FLAGS_RELEASE="-O"
-                -G Ninja
-                -S $(Build.SourcesDirectory)/swift-certificates
-                -D SwiftASN1_DIR=$(Agent.BuildDirectory)/swift-asn1/cmake/modules
-                -D SwiftCrypto_DIR=$(Agent.BuildDirectory)/swift-crypto/cmake/modules
-          - task: CMake@1
-            inputs:
-              cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-certificates
-          - task: CMake@1
-            inputs:
-              cmakeArgs:
-                -B $(Agent.BuildDirectory)/swift-package-manager
-                -D BUILD_SHARED_LIBS=YES
-                -D BUILD_TESTING=NO
-                -D CMAKE_BUILD_TYPE=Release
-                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
-                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-                -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
-                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
-                -D CMAKE_MT=mt
-                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
-                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share/windows-vfs-overlay.yaml"
-                -D CMAKE_Swift_FLAGS_RELEASE="-O"
-                -G Ninja
-                -S $(Build.SourcesDirectory)/swift-package-manager
-                -D ArgumentParser_DIR=$(Agent.BuildDirectory)/swift-argument-parser/cmake/modules
-                -D LLBuild_DIR=$(Agent.BuildDirectory)/swift-llbuild/cmake/modules
-                -D SwiftCollections_DIR=$(Agent.BuildDirectory)/swift-collections/cmake/modules
-                -D SwiftASN1_DIR=$(Agent.BuildDirectory)/swift-asn1/cmake/modules
-                -D SwiftCertificates_DIR=$(Agent.BuildDirectory)/swift-certificates/cmake/modules
-                -D SwiftCrypto_DIR=$(Agent.BuildDirectory)/swift-crypto/cmake/modules
-                -D SwiftDriver_DIR=$(Agent.BuildDirectory)/swift-driver/cmake/modules
-                -D SwiftSystem_DIR=$(Agent.BuildDirectory)/swift-system/cmake/modules
-                -D TSC_DIR=$(Agent.BuildDirectory)/swift-tools-support-core/cmake/modules
-                -D Yams_DIR=$(Agent.BuildDirectory)/Yams/cmake/modules
-                -D SQLite3_LIBRARY=$(Pipeline.Workspace)/sqlite-$(arch)-3.43.2/Library/sqlite-3.43.2/usr/lib/SQLite3.lib
-                -D SQLite3_INCLUDE_DIR=$(Pipeline.Workspace)/sqlite-$(arch)-3.43.2/Library/sqlite-3.43.2/usr/include
-          - task: CMake@1
-            inputs:
-              cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-package-manager
-          - task: CMake@1
-            inputs:
-              cmakeArgs:
-                -B $(Agent.BuildDirectory)/indexstore-db
-                -D BUILD_SHARED_LIBS=NO
-                -D BUILD_TESTING=NO
-                -D CMAKE_BUILD_TYPE=Release
-                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
-                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/Block"
-                -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
-                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/Block"
-                -D CMAKE_MT=mt
-                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
-                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -I$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -I$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/Block -vfsoverlay $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share/windows-vfs-overlay.yaml"
-                -D CMAKE_Swift_FLAGS_RELEASE="-O"
-                -G Ninja
-                -S $(Build.SourcesDirectory)/indexstore-db
-          - task: CMake@1
-            inputs:
-              cmakeArgs:
-                --build $(Agent.BuildDirectory)/indexstore-db
-          - task: CMake@1
-            inputs:
-              cmakeArgs:
-                -B $(Agent.BuildDirectory)/swift-syntax
-                -D BUILD_SHARED_LIBS=NO
-                -D BUILD_TESTING=NO
-                -D CMAKE_BUILD_TYPE=Release
-                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
-                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
-                -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
-                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
-                -D CMAKE_MT=mt
-                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
-                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share/windows-vfs-overlay.yaml"
-                -D CMAKE_Swift_FLAGS_RELEASE="-O"
-                -G Ninja
-                -S $(Build.SourcesDirectory)/swift-syntax
-          - task: CMake@1
-            inputs:
-              cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-syntax
-          - task: CMake@1
-            inputs:
-              cmakeArgs:
-                -B $(Agent.BuildDirectory)/sourcekit-lsp
+                -B $(Build.BinariesDirectory)/$(arch)/swift-driver
                 -D BUILD_SHARED_LIBS=YES
                 -D BUILD_TESTING=NO
                 -D CMAKE_BUILD_TYPE=Release
@@ -1777,55 +1671,277 @@ stages:
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
                 -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share/windows-vfs-overlay.yaml"
+                -D CMAKE_Swift_COMPILER_WORKS=YES
+                -D CMAKE_Swift_FLAGS="-Xlinker -incremental:no -Xlinker -opt:ref -Xlinker -opt:icf -sdk $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
                 -D CMAKE_Swift_FLAGS_RELEASE="-O"
+                -D CMAKE_SYSTEM_NAME=Windows
+                -D CMAKE_SYSTEM_PROCESSOR=$(platform)
+                -G Ninja
+                -S $(Build.SourcesDirectory)/swift-driver
+                -D ArgumentParser_DIR=$(Build.BinariesDirectory)/$(arch)/swift-argument-parser/cmake/modules
+                -D LLBuild_DIR=$(Build.BinariesDirectory)/$(arch)/swift-llbuild/cmake/modules
+                -D SwiftSystem_DIR=$(Build.BinariesDirectory)/$(arch)/swift-system/cmake/modules
+                -D TSC_DIR=$(Build.BinariesDirectory)/$(arch)/swift-tools-support-core/cmake/modules
+                -D Yams_DIR=$(Build.BinariesDirectory)/$(arch)/Yams/cmake/modules
+                -D SQLite3_LIBRARY=$(Pipeline.Workspace)/sqlite-$(arch)-3.43.2/Library/sqlite-3.43.2/usr/lib/SQLite3.lib
+                -D SQLite3_INCLUDE_DIR=$(Pipeline.Workspace)/sqlite-$(arch)-3.43.2/Library/sqlite-3.43.2/usr/include
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                --build $(Build.BinariesDirectory)/$(arch)/swift-driver
+
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                -B $(Build.BinariesDirectory)/$(arch)/swift-asn1
+                -D BUILD_SHARED_LIBS=NO
+                -D CMAKE_BUILD_TYPE=Release
+                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_Swift_COMPILER_WORKS=YES
+                -D CMAKE_Swift_FLAGS="-sdk $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
+                -D CMAKE_Swift_FLAGS_RELEASE="-O"
+                -D CMAKE_SYSTEM_NAME=Windows
+                -D CMAKE_SYSTEM_PROCESSOR=$(platform)
+                -G Ninja
+                -S $(Build.SourcesDirectory)/swift-asn1
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                --build $(Build.BinariesDirectory)/$(arch)/swift-asn1
+
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                -B $(Build.BinariesDirectory)/$(arch)/swift-certificates
+                -D BUILD_SHARED_LIBS=NO
+                -D CMAKE_BUILD_TYPE=Release
+                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_Swift_COMPILER_WORKS=YES
+                -D CMAKE_Swift_FLAGS="-sdk $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
+                -D CMAKE_Swift_FLAGS_RELEASE="-O"
+                -D CMAKE_SYSTEM_NAME=Windows
+                -D CMAKE_SYSTEM_PROCESSOR=$(platform)
+                -G Ninja
+                -S $(Build.SourcesDirectory)/swift-certificates
+                -D SwiftASN1_DIR=$(Build.BinariesDirectory)/$(arch)/swift-asn1/cmake/modules
+                -D SwiftCrypto_DIR=$(Build.BinariesDirectory)/$(arch)/swift-crypto/cmake/modules
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                --build $(Build.BinariesDirectory)/$(arch)/swift-certificates
+
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                -B $(Build.BinariesDirectory)/$(arch)/swift-package-manager
+                -D BUILD_SHARED_LIBS=YES
+                -D BUILD_TESTING=NO
+                -D CMAKE_BUILD_TYPE=Release
+                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
+                -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
+                -D CMAKE_MT=mt
+                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
+                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_Swift_COMPILER_WORKS=YES
+                -D CMAKE_Swift_FLAGS="-sdk $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
+                -D CMAKE_Swift_FLAGS_RELEASE="-O"
+                -D CMAKE_SYSTEM_NAME=Windows
+                -D CMAKE_SYSTEM_PROCESSOR=$(platform)
+                -G Ninja
+                -S $(Build.SourcesDirectory)/swift-package-manager
+                -D ArgumentParser_DIR=$(Build.BinariesDirectory)/$(arch)/swift-argument-parser/cmake/modules
+                -D LLBuild_DIR=$(Build.BinariesDirectory)/$(arch)/swift-llbuild/cmake/modules
+                -D SwiftCollections_DIR=$(Build.BinariesDirectory)/$(arch)/swift-collections/cmake/modules
+                -D SwiftASN1_DIR=$(Build.BinariesDirectory)/$(arch)/swift-asn1/cmake/modules
+                -D SwiftCertificates_DIR=$(Build.BinariesDirectory)/$(arch)/swift-certificates/cmake/modules
+                -D SwiftCrypto_DIR=$(Build.BinariesDirectory)/$(arch)/swift-crypto/cmake/modules
+                -D SwiftDriver_DIR=$(Build.BinariesDirectory)/$(arch)/swift-driver/cmake/modules
+                -D SwiftSystem_DIR=$(Build.BinariesDirectory)/$(arch)/swift-system/cmake/modules
+                -D TSC_DIR=$(Build.BinariesDirectory)/$(arch)/swift-tools-support-core/cmake/modules
+                -D Yams_DIR=$(Build.BinariesDirectory)/$(arch)/Yams/cmake/modules
+                -D SQLite3_LIBRARY=$(Pipeline.Workspace)/sqlite-$(arch)-3.43.2/Library/sqlite-3.43.2/usr/lib/SQLite3.lib
+                -D SQLite3_INCLUDE_DIR=$(Pipeline.Workspace)/sqlite-$(arch)-3.43.2/Library/sqlite-3.43.2/usr/include
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                --build $(Build.BinariesDirectory)/$(arch)/swift-package-manager
+
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                -B $(Build.BinariesDirectory)/$(arch)/swift-markdown
+                -D BUILD_SHARED_LIBS=NO
+                -D CMAKE_BUILD_TYPE=Release
+                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
+                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
+                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_Swift_COMPILER_WORKS=YES
+                -D CMAKE_Swift_FLAGS="-sdk $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
+                -D CMAKE_Swift_FLAGS_RELEASE="-O"
+                -D CMAKE_SYSTEM_NAME=Windows
+                -D CMAKE_SYSTEM_PROCESSOR=$(platform)
+                -G Ninja
+                -S $(Build.SourcesDirectory)/swift-markdown
+                -D ArgumentParser_DIR=$(Build.BinariesDirectory)/$(arch)/swift-argument-parser/cmake/modules
+                -D cmark-gfm_DIR=$(Agent.BuildDirectory)/cmark-gfm-$(arch)-0.29.0.gfm.13/usr/lib/cmake
+          - task: CMake@1
+            displayName: Build swift-markdown
+            inputs:
+              cmakeArgs:
+                --build $(Build.BinariesDirectory)/$(arch)/swift-markdown
+
+          - task: PowerShell@2
+            displayName: Extract swift-syntax
+            inputs:
+              targetType: 'inline'
+              script: |
+                $module = "$(Agent.BuildDirectory)/swift-syntax-$(arch)/cmake/modules/SwiftSyntaxConfig.cmake"
+                $bindir = cygpath -m $(Agent.BuildDirectory)/swift-syntax-$(arch)
+                (Get-Content $module).Replace('<BINARY_DIR>', "${bindir}") | Set-Content $module
+
+          - task: CMake@1
+            displayName: Configure swift-format
+            inputs:
+              cmakeArgs:
+                -B $(Build.BinariesDirectory)/$(arch)/swift-format
+                -D BUILD_SHARED_LIBS=YES
+                -D CMAKE_BUILD_TYPE=Release
+                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
+                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy"
+                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_Swift_COMPILER_WORKS=YES
+                -D CMAKE_Swift_FLAGS="-sdk $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
+                -D CMAKE_Swift_FLAGS_RELEASE="-O"
+                -D CMAKE_SYSTEM_NAME=Windows
+                -D CMAKE_SYSTEM_PROCESSOR=$(platform)
+                -G Ninja
+                -S $(Build.SourcesDirectory)/swift-format
+                -D ArgumentParser_DIR=$(Build.BinariesDirectory)/$(arch)/swift-argument-parser/cmake/modules
+                -D SwiftMarkdown_DIR=$(Build.BinariesDirectory)/$(arch)/swift-markdown/cmake/modules
+                -D cmark-gfm_DIR=$(Agent.BuildDirectory)/cmark-gfm-$(arch)-0.29.0.gfm.13/usr/lib/cmake
+                -D SwiftSyntax_DIR=$(Agent.BuildDirectory)/swift-syntax-$(arch)/cmake/modules
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                --build $(Build.BinariesDirectory)/$(arch)/swift-format
+
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                -B $(Build.BinariesDirectory)/$(arch)/indexstore-db
+                -D BUILD_SHARED_LIBS=NO
+                -D BUILD_TESTING=NO
+                -D CMAKE_BUILD_TYPE=Release
+                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code"
+                -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/include -I $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/include/Block"
+                -D CMAKE_MT=mt
+                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
+                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_Swift_COMPILER_WORKS=YES
+                -D CMAKE_Swift_FLAGS="-sdk $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
+                -D CMAKE_Swift_FLAGS_RELEASE="-O"
+                -D CMAKE_SYSTEM_NAME=Windows
+                -D CMAKE_SYSTEM_PROCESSOR=$(platform)
+                -G Ninja
+                -S $(Build.SourcesDirectory)/indexstore-db
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                --build $(Build.BinariesDirectory)/$(arch)/indexstore-db
+          
+          - task: CMake@1
+            inputs:
+              cmakeArgs:
+                -B $(Build.BinariesDirectory)/$(arch)/sourcekit-lsp
+                -D BUILD_SHARED_LIBS=YES
+                -D BUILD_TESTING=NO
+                -D CMAKE_BUILD_TYPE=Release
+                -D CMAKE_C_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_C_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code"
+                -D CMAKE_CXX_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+                -D CMAKE_CXX_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy -Xclang -fno-split-cold-code"
+                -D CMAKE_MT=mt
+                -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
+                -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D CMAKE_Swift_COMPILER_WORKS=YES
+                -D CMAKE_Swift_FLAGS="-sdk $(Pipeline.Workspace)/windows-sdk-$(arch)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
+                -D CMAKE_Swift_FLAGS_RELEASE="-O"
+                -D CMAKE_SYSTEM_NAME=Windows
+                -D CMAKE_SYSTEM_PROCESSOR=$(platform)
                 -G Ninja
                 -S $(Build.SourcesDirectory)/sourcekit-lsp
-                -D ArgumentParser_DIR=$(Agent.BuildDirectory)/swift-argument-parser/cmake/modules
-                -D IndexStoreDB_DIR=$(Agent.BuildDirectory)/indexstore-db/cmake/modules
-                -D LLBuild_DIR=$(Agent.BuildDirectory)/swift-llbuild/cmake/modules
-                -D SwiftCollections_DIR=$(Agent.BuildDirectory)/swift-collections/cmake/modules
-                -D SwiftPM_DIR=$(Agent.BuildDirectory)/swift-package-manager/cmake/modules
-                -D SwiftSystem_DIR=$(Agent.BuildDirectory)/swift-system/cmake/modules
-                -D SwiftCrypto_DIR=$(Agent.BuildDirectory)/swift-crypto/cmake/modules
-                -D TSC_DIR=$(Agent.BuildDirectory)/swift-tools-support-core/cmake/modules
-                -D SwiftSyntax_DIR=$(Agent.BuildDirectory)/swift-syntax/cmake/modules
+                -D ArgumentParser_DIR=$(Build.BinariesDirectory)/$(arch)/swift-argument-parser/cmake/modules
+                -D IndexStoreDB_DIR=$(Build.BinariesDirectory)/$(arch)/indexstore-db/cmake/modules
+                -D LLBuild_DIR=$(Build.BinariesDirectory)/$(arch)/swift-llbuild/cmake/modules
+                -D SwiftCollections_DIR=$(Build.BinariesDirectory)/$(arch)/swift-collections/cmake/modules
+                -D SwiftCrypto_DIR=$(Build.BinariesDirectory)/$(arch)/swift-crypto/cmake/modules
+                -D SwiftPM_DIR=$(Build.BinariesDirectory)/$(arch)/swift-package-manager/cmake/modules
+                -D SwiftSystem_DIR=$(Build.BinariesDirectory)/$(arch)/swift-system/cmake/modules
+                -D TSC_DIR=$(Build.BinariesDirectory)/$(arch)/swift-tools-support-core/cmake/modules
+                -D SwiftSyntax_DIR=$(Agent.BuildDirectory)/swift-syntax-$(arch)/cmake/modules
           - task: CMake@1
             inputs:
               cmakeArgs:
-                --build $(Agent.BuildDirectory)/sourcekit-lsp
+                --build $(Build.BinariesDirectory)/$(arch)/sourcekit-lsp
+
           - task: CMake@1
             inputs:
               cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-argument-parser --target install
+                --build $(Build.BinariesDirectory)/$(arch)/swift-argument-parser --target install
           - task: CMake@1
             inputs:
               cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-collections --target install
+                --build $(Build.BinariesDirectory)/$(arch)/swift-collections --target install
           - task: CMake@1
             inputs:
               cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-llbuild --target install
+                --build $(Build.BinariesDirectory)/$(arch)/swift-llbuild --target install
           - task: CMake@1
             inputs:
               cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-system --target install
+                --build $(Build.BinariesDirectory)/$(arch)/swift-system --target install
           - task: CMake@1
             inputs:
               cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-tools-support-core --target install
+                --build $(Build.BinariesDirectory)/$(arch)/swift-tools-support-core --target install
           - task: CMake@1
             inputs:
               cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-driver --target install
+                --build $(Build.BinariesDirectory)/$(arch)/swift-driver --target install
           - task: CMake@1
             inputs:
               cmakeArgs:
-                --build $(Agent.BuildDirectory)/swift-package-manager --target install
+                --build $(Build.BinariesDirectory)/$(arch)/swift-package-manager --target install
           - task: CMake@1
             inputs:
               cmakeArgs:
-                --build $(Agent.BuildDirectory)/sourcekit-lsp --target install
+                --build $(Build.BinariesDirectory)/$(arch)/sourcekit-lsp --target install
+          - task: CMake@1
+            displayName: Install swift-format
+            inputs:
+              cmakeArgs:
+                --build $(Build.BinariesDirectory)/$(arch)/swift-format --target install
           - publish: $(Build.StagingDirectory)
             artifact: devtools-$(arch)
 

--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -1142,7 +1142,7 @@ stages:
                 -D CMAKE_SYSTEM_PROCESSOR=$(arch)
                 -G Ninja
                 -S $(Build.SourcesDirectory)/llvm-project/llvm
-                -D LLVM_ENABLE_ASSERTIONS=NO
+                -D LLVM_ENABLE_ASSERTIONS=YES
           - task: CMake@1
             inputs:
              cmakeArgs:
@@ -1159,9 +1159,11 @@ stages:
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr
                 -D CMAKE_SYSTEM_NAME=Windows
                 -D CMAKE_SYSTEM_PROCESSOR=$(platform)
+                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
+                -D MSVC_C_ARCHITECTURE_ID=$(arch)
+                -D MSVC_CXX_ARCHITECTURE_ID=$(arch)
                 -G Ninja
                 -S $(Build.SourcesDirectory)/swift
-                -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
                 -D LLVM_DIR=$(Agent.BuildDirectory)/llvm/lib/cmake/llvm
                 -D SWIFT_NATIVE_SWIFT_TOOLS_PATH=$(Workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin
                 -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE=$(Build.SourcesDirectory)/swift-corelibs-libdispatch
@@ -1172,6 +1174,7 @@ stages:
                 -D SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING=YES
                 -D SWIFT_ENABLE_EXPERIMENTAL_OBSERVATION=YES
                 -D SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING=YES
+                -D SWIFT_ENABLE_SYNCHRONIZATION=YES
                 -D EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR=$(Build.SourcesDirectory)/swift-experimental-string-processing
                 -D SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE=$(Build.SourcesDirectory)/swift-syntax
                 -D SWIFT_PARALLEL_LINK_JOBS=2
@@ -1206,7 +1209,7 @@ stages:
                 -D CMAKE_SYSTEM_PROCESSOR=$(platform)
                 -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Agent.BuildDirectory)/swift/stdlib/windows-vfs-overlay.yaml"
+                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Agent.BuildDirectory)/swift/stdlib/windows-vfs-overlay.yaml -strict-implicit-module-context -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules"
                 -D CMAKE_Swift_FLAGS_RELEASE="-O"
                 -G Ninja
                 -S $(Build.SourcesDirectory)/swift-corelibs-libdispatch
@@ -1239,13 +1242,15 @@ stages:
                 -D CMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr
                 -D CMAKE_SYSTEM_NAME=Windows
                 -D CMAKE_SYSTEM_PROCESSOR=$(platform)
+                -D MSVC_C_ARCHITECTURE_ID=$(arch)
+                -D MSVC_CXX_ARCHITECTURE_ID=$(arch)
                 -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Agent.BuildDirectory)/swift/stdlib/windows-vfs-overlay.yaml"
+                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Agent.BuildDirectory)/swift/stdlib/windows-vfs-overlay.yaml -strict-implicit-module-context -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules"
                 -D CMAKE_Swift_FLAGS_RELEASE="-O"
                 -G Ninja
                 -S $(Build.SourcesDirectory)/swift-corelibs-foundation
-                -D BUILD_TESTING=NO
+                -D ENABLE_TESTING=NO
                 -D dispatch_DIR=$(Agent.BuildDirectory)/libdispatch/cmake/modules
                 -D ICU_ROOT=$(Pipeline.Workspace)/icu-$(arch)-69.1/Library/icu-69.1/usr
                 -D ICU_DATA_LIBRARY_RELEASE=$(Pipeline.Workspace)/icu-$(arch)-69.1/Library/icu-69.1/usr/lib/sicudt69.lib
@@ -1284,11 +1289,11 @@ stages:
                 -D CMAKE_SYSTEM_PROCESSOR=$(platform)
                 -D CMAKE_Swift_COMPILER=$(workspace.root)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
                 -D CMAKE_Swift_COMPILER_TARGET=$(platform)-unknown-windows-msvc
-                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Agent.BuildDirectory)/swift/stdlib/windows-vfs-overlay.yaml"
+                -D CMAKE_Swift_FLAGS="-resource-dir $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L$(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay $(Agent.BuildDirectory)/swift/stdlib/windows-vfs-overlay.yaml -strict-implicit-module-context -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules"
                 -D CMAKE_Swift_FLAGS_RELEASE="-O"
                 -G Ninja
                 -S $(Build.SourcesDirectory)/swift-corelibs-xctest
-                -D BUILD_TESTING=NO
+                -D ENABLE_TESTING=NO
                 -D dispatch_DIR=$(Agent.BuildDirectory)/libdispatch/cmake/modules
                 -D Foundation_DIR=$(Agent.BuildDirectory)/foundation/cmake/modules
           - task: CMake@1

--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -50,7 +50,7 @@ resources:
     - repository: apple/swift-collections
       endpoint: GitHub
       name: apple/swift-collections
-      ref: refs/tags/1.0.4
+      ref: refs/tags/1.0.5
       type: github
     - repository: apple/swift-cmark
       endpoint: GitHub
@@ -110,7 +110,7 @@ resources:
     - repository: apple/swift-system
       endpoint: GitHub
       name: apple/swift-system
-      ref: refs/tags/1.1.1
+      ref: refs/tags/1.2.1
       type: github
     - repository: apple/swift-tools-support-core
       endpoint: GitHub

--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -1955,18 +1955,24 @@ stages:
               arch: amd64
               platform: x86_64
               binDir: bin64
-            # TODO(compnerd) enable AArch64 toolchain
-            # 'arm64':
-            #   arch: arm64
-            #   platform: aarch64
-            #   binDir: bin64a
+            'arm64':
+              arch: arm64
+              platform: aarch64
+              binDir: bin64a
         steps:
           - download: current
             artifact: toolchain-amd64
+            displayName: Download Compilers
           - download: current
             artifact: windows-sdk-$(arch)
+            displayName: Download SDK ($(arch))
+          - download: current
+            artifact: windows-sdk-amd64
+            displayName: Download SDK (Host)
+            condition: and(succeeded(), ne(variables['arch'], 'amd64'))
           - download: current
             artifact: devtools-amd64
+            displayName: Download devtools
           - download: current
             artifact: cmark-gfm-amd64-0.29.0.gfm.13
             displayName: Download cmark-gfm
@@ -1978,8 +1984,6 @@ stages:
                 Copy-Item $(Pipeline.Workspace)/cmark-gfm-amd64-0.29.0.gfm.13/usr/bin/*.dll $(Pipeline.Workspace)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/
           - checkout: apple/swift
             fetchDepth: 1
-          - checkout: apple/swift-format
-            fetchDepth: 1
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -1990,10 +1994,11 @@ stages:
                 $SDKInstallRoot = "$PlatformInstallRoot/Developer/SDKs/Windows.sdk"
                 $ToolchainBinaryCache = "$(Agent.BuildDirectory)/toolchain-amd64"
                 $DevtoolsBinaryCache = "$(Agent.BuildDirectory)/devtools-amd64"
+                $HostPlatformBinaryCache = "$(Agent.BuildDirectory)/windows-sdk-amd64"
                 $PlatformBinaryCache = "$(Agent.BuildDirectory)/windows-sdk-$(arch)"
 
+                $HostSDKSourceRoot = "$HostPlatformBinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
                 $SDKSourceRoot = "$PlatformBinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
-                $XCTestSourceRoot = "$PlatformBinaryCache/Library/Developer/Platforms/Windows.platform/Developer/Library/XCTest-development"
 
                 function Move-File($Src, $Dst) {
                   $DstDir = [IO.Path]::GetDirectoryName($Dst)
@@ -2015,19 +2020,39 @@ stages:
                   }
                 }
 
+                function Install-PlatformLibraries($Src, $Dst, $Platform) {
+                  $LibSrc = "$Src/usr/lib/swift/windows"
+                  $LibDst = "$Dst/usr/lib/swift/windows"
+                  Move-File $LibSrc/*.lib $LibDst/$Platform/
+                  Move-File $LibSrc/$Platform/*.lib $LibDst/$Platform/
+                  Move-Directory $LibSrc/*.swiftmodule $LibDst
+
+                  Get-ChildItem -Recurse $LibSrc/$Platform | ForEach-Object {
+                    if (".swiftmodule", ".swiftdoc", ".swiftinterface" -contains $_.Extension) {
+                      $DstDir = "$LibDst/$($_.BaseName).swiftmodule"
+                      Move-File $_.FullName $DstDir/$Platform-unknown-windows-msvc$($_.Extension)
+                    } else {
+                      Move-File $_.FullName $LibDst/$Platform/
+                    }
+                  }
+                }
+
                 Remove-Item $LibraryRoot -Recurse -ErrorAction Ignore
 
                 # Install toolchain
                 #-----------------------------------------------------------------------------
+                Write-Host "-- Installing compilers..."
                 Move-Directory $ToolchainBinaryCache/Library/Developer $LibraryRoot
                 Move-Directory $ToolchainInstallRoot/usr/lib/swift/_InternalSwiftScan $ToolchainInstallRoot/usr/include
                 Move-File $ToolchainInstallRoot/usr/lib/swift/windows/_InternalSwiftScan.lib $ToolchainInstallRoot/usr/lib/
+                Write-Host "-- Installing devtools..."
                 Move-Directory $DevtoolsBinaryCache/Library/Developer $LibraryRoot
                 Move-File $ToolchainInstallRoot/usr/bin/swift-driver.exe $ToolchainInstallRoot/usr/bin/swift.exe
                 Copy-Item -Force $ToolchainInstallRoot/usr/bin/swift.exe $ToolchainInstallRoot/usr/bin/swiftc.exe
 
                 # Install platform
                 #-----------------------------------------------------------------------------
+                Write-Host "-- Installing platforms..."
                 Move-Directory $SDKSourceRoot/usr/include/swift/SwiftRemoteMirror $SDKInstallRoot/usr/include/swift
                 Move-Directory $SDKSourceRoot/usr/lib/swift/shims $SDKInstallRoot/usr/lib/swift
                 foreach ($Module in ("Block", "dispatch", "os")) {
@@ -2035,41 +2060,24 @@ stages:
                 }
                 Move-File $SDKSourceRoot/usr/share/*.* $SDKInstallRoot/usr/share/
 
-                $WindowsLibSrc = "$SDKSourceRoot/usr/lib/swift/windows"
-                $WindowsLibDst = "$SDKInstallRoot/usr/lib/swift/windows"
-                Move-File $WindowsLibSrc/*.lib $WindowsLibDst/$(platform)/
-                Move-File $WindowsLibSrc/$(platform)/*.lib $WindowsLibDst/$(platform)/
-                Move-Directory $WindowsLibSrc/*.swiftmodule $WindowsLibDst
-
-                Get-ChildItem -Recurse $WindowsLibSrc/$(platform) | ForEach-Object {
-                  if (".swiftmodule", ".swiftdoc", ".swiftinterface" -contains $_.Extension) {
-                    $DstDir = "$WindowsLibDst/$($_.BaseName).swiftmodule"
-                    Move-File $_.FullName $DstDir/$(platform)-unknown-windows-msvc$($_.Extension)
-                  } else {
-                    Move-File $_.FullName $WindowsLibDst/$(platform)/
-                  }
+                if ($HostSDKSourceRoot -ne $SDKSourceRoot) {
+                  Write-Host "     x86_64 (host)..."
+                  Install-PlatformLibraries $HostSDKSourceRoot $SDKInstallRoot "x86_64"
                 }
 
-                $XCTestInstallRoot = "$PlatformInstallRoot/Developer/Library/XCTest-development"
-                Move-File $XCTestSourceRoot/usr/bin/XCTest.dll $XCTestInstallRoot/usr/$(binDir)/
-                Move-File $XCTestSourceRoot/usr/lib/swift/windows/XCTest.lib $XCTestInstallRoot/usr/lib/swift/windows/$(platform)/
-                Move-File $XCTestSourceRoot/usr/lib/swift/windows/$(platform)/XCTest.swiftmodule $XCTestInstallRoot/usr/lib/swift/windows/XCTest.swiftmodule/$(platform)-unknown-windows-msvc.swiftmodule
-                Move-File $XCTestSourceRoot/usr/lib/swift/windows/$(platform)/XCTest.swiftdoc $XCTestInstallRoot/usr/lib/swift/windows/XCTest.swiftmodule/$(platform)-unknown-windows-msvc.swiftdoc
+                Write-Host "     $platform..."
+                Install-PlatformLibraries $SDKSourceRoot $SDKInstallRoot "$(platform)"
 
                 Move-File $PlatformBinaryCache/Library/Developer/Platforms/Windows.platform/Info.plist $PlatformInstallRoot/
                 Move-File $SDKSourceRoot/SDKSettings.plist $SDKInstallRoot/
 
                 # Set up environment
                 #-----------------------------------------------------------------------------
-                Write-Host "##vso[task.setvariable variable=PATH;]$(Agent.BuildDirectory)\windows-sdk-$(arch)\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk\usr\bin;$(Agent.BuildDirectory)\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin;${env:Path}"
+                Write-Host "##vso[task.prependpath]$(Agent.BuildDirectory)\windows-sdk-amd64\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk\usr\bin;$(Agent.BuildDirectory)\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin"
                 Write-Host "##vso[task.setvariable variable=SDKROOT;]$(Agent.BuildDirectory)\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk"
           - script: |
-              swift build -c release -debug-info-format none --package-path $(Build.SourcesDirectory)/swift-format --scratch-path $(Agent.BuildDirectory)/swift-format
-          - publish: $(Agent.BuildDirectory)/swift-format/release/swift-format.exe
-            artifact: swift-format-$(arch)
-          - script: |
-              swift build -c release -debug-info-format none --package-path $(Build.SourcesDirectory)/swift/tools/swift-inspect --scratch-path $(Agent.BuildDirectory)/swift-inspect -Xcc -I%SDKROOT%\usr\include\swift\SwiftRemoteMirror -Xlinker %SDKROOT%\usr\lib\swift\windows\$(platform)\swiftRemoteMirror.lib
-          - publish: $(Agent.BuildDirectory)/swift-inspect/release/swift-inspect.exe
+              swift build -c release --triple $(platform)-unknown-windows-msvc -debug-info-format none --package-path $(Build.SourcesDirectory)/tools/swift-inspect --scratch-path $(Build.BinariesDirectory)/$(arch)/swift-inspect -Xcc -I%SDKROOT%\usr\include\swift\SwiftRemoteMirror -Xlinker %SDKROOT%\usr\lib\swift\windows\$(platform)\swiftRemoteMirror.lib
+          - publish: $(Build.BinariesDirectory)/$(arch)/swift-inspect/release/swift-inspect.exe
             artifact: swift-inspect-$(arch)
 
   - stage: package_tools

--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -239,18 +239,15 @@ stages:
     jobs:
       - job: x64
         steps:
+          - download: current
+            artifact: cmark-gfm-amd64-0.29.0.gfm.13
+            displayName: Download cmark-gfm
           - script: |
               git config --global --add core.autocrlf false
               git config --global --add core.symlinks true
           - checkout: apple/llvm-project
             fetchDepth: 1
-          - checkout: apple/swift-cmark
-            fetchDepth: 1
           - checkout: apple/swift
-            fetchDepth: 1
-          - checkout: apple/swift-syntax
-            fetchDepth: 1
-          - checkout: apple/swift-corelibs-libdispatch
             fetchDepth: 1
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
@@ -277,29 +274,31 @@ stages:
                 -D CMAKE_CXX_COMPILER=cl
                 -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy"
                 -D CMAKE_MT=mt
+                -D cmark-gfm_DIR=$(Pipeline.Workspace)/cmark-gfm-amd64-0.29.0.gfm.13/usr/lib/cmake
                 -G Ninja
                 -S $(Build.SourcesDirectory)/llvm-project/llvm
                 -D LLVM_ENABLE_ASSERTIONS=NO
                 -D LLVM_ENABLE_LIBEDIT=NO
                 -D LLVM_ENABLE_LIBXML2=NO
                 -D LLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lldb"
-                -D LLVM_EXTERNAL_PROJECTS="cmark;swift"
-                -D LLVM_EXTERNAL_CMARK_SOURCE_DIR=$(Build.SourcesDirectory)/swift-cmark
+                -D LLVM_EXTERNAL_PROJECTS="swift"
                 -D LLVM_EXTERNAL_SWIFT_SOURCE_DIR=$(Build.SourcesDirectory)/swift
                 -D LLDB_ENABLE_PYTHON=NO
                 -D LLDB_INCLUDE_TESTS=NO
                 -D LLDB_ENABLE_SWIFT_SUPPORT=NO
                 -D SWIFT_BUILD_DYNAMIC_SDK_OVERLAY=NO
                 -D SWIFT_BUILD_DYNAMIC_STDLIB=NO
-                -D SWIFT_BUILD_LIBEXEC=NO 
+                -D SWIFT_BUILD_HOST_DISPATCH=NO
+                -D SWIFT_BUILD_LIBEXEC=NO
+                -D SWIFT_BUILD_REGEX_PARSER_IN_COMPILER=NO
                 -D SWIFT_BUILD_REMOTE_MIRROR=NO
                 -D SWIFT_BUILD_STATIC_SDK_OVERLAY=NO
                 -D SWIFT_BUILD_STATIC_STDLIB=NO
+                -D SWIFT_BUILD_SWIFT_SYNTAX=NO
+                -D SWIFT_ENABLE_DISPATCH=NO
                 -D SWIFT_INCLUDE_APINOTES=NO
                 -D SWIFT_INCLUDE_DOCS=NO
                 -D SWIFT_INCLUDE_TESTS=NO
-                -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE=$(Build.SourcesDirectory)/swift-corelibs-libdispatch
-                -D SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE=$(Build.SourcesDirectory)/swift-syntax
           - task: CMake@1
             inputs:
               cmakeArgs:
@@ -354,7 +353,7 @@ stages:
             artifact: build-tools
 
   - stage: toolchain
-    dependsOn: [tools]
+    dependsOn: [tools, cmark_gfm]
     jobs:
       - job: build
         timeoutInMinutes: 0
@@ -371,12 +370,12 @@ stages:
         steps:
           - download: current
             artifact: build-tools
+          - download: current
+            artifact: cmark-gfm-$(arch)-0.29.0.gfm.13
           - script: |
               git config --global --add core.autocrlf false
               git config --global --add core.symlinks true
           - checkout: apple/llvm-project
-            fetchDepth: 1
-          - checkout: apple/swift-cmark
             fetchDepth: 1
           - checkout: apple/swift
             fetchDepth: 1
@@ -527,7 +526,6 @@ stages:
                 -D LLDB_TABLEGEN=$(Pipeline.Workspace)/build-tools/bin/lldb-tblgen.exe
                 -D LLVM_CONFIG_PATH=$(Pipeline.Workspace)/build-tools/bin/llvm-config.exe
                 -D LLVM_ENABLE_PDB=NO
-                -D LLVM_EXTERNAL_CMARK_SOURCE_DIR=$(Build.SourcesDirectory)/swift-cmark
                 -D LLVM_EXTERNAL_SWIFT_SOURCE_DIR=$(Build.SourcesDirectory)/swift
                 -D LLVM_NATIVE_TOOL_DIR=$(Pipeline.Workspace)/build-tools/bin
                 -D LLVM_TABLEGEN=$(Pipeline.Workspace)/build-tools/bin/llvm-tblgen.exe
@@ -543,6 +541,7 @@ stages:
                 -D SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING=YES
                 -D SWIFT_ENABLE_EXPERIMENTAL_OBSERVATION=YES
                 -D SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING=YES
+                -D SWIFT_ENABLE_SYNCHRONIZATION=YES
                 -D SWIFT_NATIVE_SWIFT_TOOLS_PATH=$(Pipeline.Workspace)/build-tools/bin
                 -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE=$(Build.SourcesDirectory)/swift-corelibs-libdispatch
                 -D SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE=$(Build.SourcesDirectory)/swift-syntax
@@ -550,6 +549,7 @@ stages:
                 -D SWIFT_PATH_TO_SWIFT_SDK=$(workspace.binaries)/toolchains/20231016.0/LocalApp/Programs/Swift/Platforms/0.0.0/Windows.platform/Developer/SDKs/Windows.sdk
                 -D CLANG_VENDOR=compnerd.org
                 -D CLANG_VENDOR_UTI=org.compnerd.dt
+                -D cmark-gfm_DIR=$(Pipeline.Workspace)/cmark-gfm-$(arch)-0.29.0.gfm.13/usr/lib/cmake
                 -D PACKAGE_VENDOR=compnerd.org
                 -D SWIFT_VENDOR=compnerd.org
                 -D LLVM_PARALLEL_LINK_JOBS=2
@@ -1036,7 +1036,7 @@ stages:
             artifact: libxml2-$(arch)-2.11.5
 
   - stage: sdk
-    dependsOn: [icu, libxml2, curl, zlib, toolchain]
+    dependsOn: [icu, libxml2, curl, zlib, toolchain, cmark_gfm]
     jobs:
       - job: build
         strategy:
@@ -1066,6 +1066,14 @@ stages:
             artifact: toolchain-amd64
           - download: current
             artifact: pinned-toolchain-runtime
+          - download: current
+            artifact: cmark-gfm-amd64-0.29.0.gfm.13
+          - task: PowerShell@2
+            displayName: cmark-gfm Setup 
+            inputs:
+              targetType: 'inline'
+              script: |
+                Copy-Item $(Pipeline.Workspace)/cmark-gfm-amd64-0.29.0.gfm.13/usr/bin/*.dll $(Pipeline.Workspace)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/
           - checkout: apple/llvm-project
             fetchDepth: 1
           - checkout: apple/swift
@@ -1333,6 +1341,12 @@ stages:
             artifact: windows-sdk-$(arch)
           - download: current
             artifact: windows-sdk-amd64
+          - download: current
+            artifact: cmark-gfm-$(arch)-0.29.0.gfm.13
+            displayName: Download cmark-gfm ($(arch))
+          - download: current
+            artifact: cmark-gfm-amd64-0.29.0.gfm.13
+            displayName: Download cmark-gfm (Host)
             condition: and(succeeded(), ne(variables['arch'], 'amd64'))
           - checkout: apple/indexstore-db
             fetchDepth: 1
@@ -1364,6 +1378,12 @@ stages:
             fetchDepth: 1
           - checkout: apple/swift-syntax
             fetchDepth: 1
+          - task: PowerShell@2
+            displayName: cmark-gfm Setup 
+            inputs:
+              targetType: 'inline'
+              script: |
+                Copy-Item $(Pipeline.Workspace)/cmark-gfm-amd64-0.29.0.gfm.13/usr/bin/*.dll $(Pipeline.Workspace)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/
           - script: |
               SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
               FOR /f "usebackq delims=" %%i IN (`%vswhere% -products * -latest -property installationPath`) DO (
@@ -1810,6 +1830,15 @@ stages:
             artifact: windows-sdk-$(arch)
           - download: current
             artifact: devtools-amd64
+          - download: current
+            artifact: cmark-gfm-amd64-0.29.0.gfm.13
+            displayName: Download cmark-gfm
+          - task: PowerShell@2
+            displayName: cmark-gfm Setup 
+            inputs:
+              targetType: 'inline'
+              script: |
+                Copy-Item $(Pipeline.Workspace)/cmark-gfm-amd64-0.29.0.gfm.13/usr/bin/*.dll $(Pipeline.Workspace)/toolchain-amd64/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/
           - checkout: apple/swift
             fetchDepth: 1
           - checkout: apple/swift-format
@@ -1929,6 +1958,15 @@ stages:
             artifact: swift-format-$(arch)
           - download: current
             artifact: swift-inspect-$(arch)
+          - download: current
+            artifact: cmark-gfm-$(arch)-0.29.0.gfm.13
+            displayName: Download cmark-gfm
+          - task: PowerShell@2
+            displayName: cmark-gfm Setup 
+            inputs:
+              targetType: 'inline'
+              script: |
+                Copy-Item $(Pipeline.Workspace)/cmark-gfm-$(arch)-0.29.0.gfm.13/usr/bin/*.dll $(Pipeline.Workspace)/$(arch)/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/
           - checkout: apple/swift-installer-scripts
             fetchDepth: 1
           - script: |


### PR DESCRIPTION
This aligns AzDO build with GHA workflow. Mostly about swift-format and cmark-gfm changes, but there are also many small changes in SDK and devtools CMake configuration, so they are closer to the build flow from `build.ps1` now.

Also
- fixed zlib path in curl configuration
- adjusted devtools build directory for more convenient self-hosted process
- enabled arm64 swift-inspect in auxtools
- enabled arm64 tools packaging
- enabled arm64 installer
- removed arm64 performance hack, as it is in LLVM already

This is quite a big changeset (that's why it comes as a bunch of commits instead of single commit), but it is minimal piece of work which passes build check completely.