### PR TITLE
GHA: attempt to track swift-atomics revision

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -68,6 +68,7 @@ jobs:
       sourcekit_lsp_revision: ${{ steps.context.outputs.sourcekit_lsp_revision }}
       swift_argument_parser_revision: ${{ steps.context.outputs.swift_argument_parser_revision }}
       swift_asn1_revision: ${{ steps.context.outputs.swift_asn1_revision }}
+      swift_atomics_revision: ${{ steps.context.outputs.swift_atomics_revision }}
       swift_certificates_revision: ${{ steps.context.outputs.swift_certificates_revision }}
       swift_cmark_revision: ${{ steps.context.outputs.swift_cmark_revision }}
       swift_collections_revision: ${{ steps.context.outputs.swift_collections_revision }}
@@ -126,6 +127,7 @@ jobs:
           swift_revision=refs/tags/${{ inputs.swift_tag }}
           swift_argument_parser_revision=refs/tags/1.2.2
           swift_asn1_revision=refs/tags/0.7.0
+          swift_atomics_revision=refs/tags/1.2.0
           swift_certificates_revision=refs/tags/0.1.0
           swift_cmark_revision=refs/tags/${{ inputs.swift_tag }}
           swift_collections_revision=refs/tags/1.0.4


### PR DESCRIPTION
There is now a swift-atomics dependency in the toolchain. The repo manifest pins the revision and we resolve it as necessary. This just makes it explicit so that we can be certain that it is available when needed and it gets serialised into the stable manifest.