### PR TITLE
Fix arm64 build for swift-inspect

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2186,7 +2186,7 @@ jobs:
           mv ${{ env.SDKROOT }}/usr/lib/swift/windows/FoundationXML.lib ${{ env.SDKROOT }}/usr/lib/swift/windows/x86_64/
           mv ${{ env.SDKROOT }}/usr/lib/swift/windows/FoundationNetworking.lib ${{ env.SDKROOT }}/usr/lib/swift/windows/x86_64/
 
-      - name: Download target ${{ matrix.arch }} Windows SDK
+      - name: Download ${{ matrix.arch }} Windows SDK
         # Only necessary when cross-compiling
         if: ${{ matrix.arch != 'amd64' }}
         uses: actions/download-artifact@v4

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2118,12 +2118,11 @@ jobs:
           symbolsFolder: ${{ github.workspace }}/BinaryCache
           searchPattern: '**/*.exe'
 
+
   debugging_tools:
     name: Debugging Tools
     needs: [context, compilers, devtools, sdk]
     runs-on: ${{ needs.context.outputs.windows_build_runner }}
-    env:
-      TOOLCHAIN_PATH: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin
 
     strategy:
       fail-fast: false
@@ -2132,42 +2131,85 @@ jobs:
           - arch: amd64
             cpu: x86_64
             triple: x86_64-unknown-windows-msvc
-
-          # TODO(thebrowsercompany/swift-build#125): Fix the layout of SDK files so we can cross-compile to arm64 
-          # - arch: arm64
-          #   cpu: aarch64
-          #   triple: aarch64-unknown-windows-msvc
+          - arch: arm64
+            cpu: aarch64
+            triple: aarch64-unknown-windows-msvc
 
     steps:
-      - name: Download compilers
+      - name: Download build compilers
         uses: actions/download-artifact@v4
         with:
           name: compilers-amd64
-          path: ${{ github.workspace }}/BuildRoot/Library
+          path: ${{ github.workspace }}/BuildRoot/
 
-      - name: Download devtools
+      - name: Download build devtools
         uses: actions/download-artifact@v4
         with:
           name: devtools-amd64
-          path: ${{ github.workspace }}/BuildRoot/Library
+          path: ${{ github.workspace }}/BuildRoot/
 
-      - name: Download cmark-gfm-amd64
-        uses: actions/download-artifact@v4
-        with:
-          name: cmark-gfm-amd64-0.29.0.gfm.13
-          path: ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr
-
-      - name: Download amd64 Windows Runtime
+      # We're using the runtime libraries from this one.
+      - name: Download Windows SDK (AMD64)
         uses: actions/download-artifact@v4
         with:
           name: windows-sdk-amd64
-          path: ${{ github.workspace }}/BinaryCache
+          path: ${{ github.workspace }}/BinaryCache/
 
-      - name: Download ${{ matrix.arch }} Windows SDK
+      - name: Download Windows SDK (AMD64)
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-sdk-amd64
+          path: ${{ github.workspace }}/BuildRoot/
+
+      - name: Update environment variables
+        run: |
+          $SDKRoot = cygpath -w "${{ github.workspace }}/BuildRoot/Developer/SDKs/Windows.sdk"
+          $ToolchainPath = cygpath -w "${{ github.workspace }}/BuildRoot/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin"
+          $RTLPath = cygpath -w "${{ github.workspace }}/BinaryCache/Developer/SDKs/Windows.sdk/usr/bin"
+
+          echo "SDKROOT=${SDKRoot}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "TOOLCHAIN_PATH=${ToolchainPath}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "AR=${ToolchainPath}\llvm-ar.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "${ToolchainPath}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "${RTLPath}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Patch the SDK to workaround https://github.com/thebrowsercompany/swift-build#50
+        run: |
+          mv ${{ env.SDKROOT }}/usr/lib/swift/dispatch ${{ env.SDKROOT }}/usr/include/
+          mv ${{ env.SDKROOT }}/usr/lib/swift/os ${{ env.SDKROOT }}/usr/include/
+          mv ${{ env.SDKROOT }}/usr/lib/swift/Block ${{ env.SDKROOT }}/usr/include/
+
+          mv ${{ env.SDKROOT }}/usr/lib/swift/windows/BlocksRuntime.lib ${{ env.SDKROOT }}/usr/lib/swift/windows/x86_64/
+          mv ${{ env.SDKROOT }}/usr/lib/swift/windows/dispatch.lib ${{ env.SDKROOT }}/usr/lib/swift/windows/x86_64/
+          mv ${{ env.SDKROOT }}/usr/lib/swift/windows/swiftDispatch.lib ${{ env.SDKROOT }}/usr/lib/swift/windows/x86_64/
+          mv ${{ env.SDKROOT }}/usr/lib/swift/windows/Foundation.lib ${{ env.SDKROOT }}/usr/lib/swift/windows/x86_64/
+          mv ${{ env.SDKROOT }}/usr/lib/swift/windows/FoundationXML.lib ${{ env.SDKROOT }}/usr/lib/swift/windows/x86_64/
+          mv ${{ env.SDKROOT }}/usr/lib/swift/windows/FoundationNetworking.lib ${{ env.SDKROOT }}/usr/lib/swift/windows/x86_64/
+
+      - name: Download target ${{ matrix.arch }} Windows SDK
+        # Only necessary when cross-compiling
+        if: ${{ matrix.arch != 'amd64' }}
         uses: actions/download-artifact@v4
         with:
           name: windows-sdk-${{ matrix.arch }}
-          path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform
+          path: ${{ github.workspace }}/BuildRoot/
+
+      - name: Patch the SDK to workaround https://github.com/thebrowsercompany/swift-build#50
+        # Only necessary when cross-compiling
+        if: ${{ matrix.arch != 'amd64' }}
+        run: |
+          # We already copied these above.
+          # Remove them to prevent 'module defined more than once' errors.
+          rm -Force -Recurse ${{ env.SDKROOT }}/usr/lib/swift/dispatch
+          rm -Force -Recurse ${{ env.SDKROOT }}/usr/lib/swift/os
+          rm -Force -Recurse ${{ env.SDKROOT }}/usr/lib/swift/Block
+
+          mv -Force ${{ env.SDKROOT }}/usr/lib/swift/windows/BlocksRuntime.lib ${{ env.SDKROOT }}/usr/lib/swift/windows/${{ matrix.cpu }}/
+          mv -Force ${{ env.SDKROOT }}/usr/lib/swift/windows/dispatch.lib ${{ env.SDKROOT }}/usr/lib/swift/windows/${{ matrix.cpu }}/
+          mv -Force ${{ env.SDKROOT }}/usr/lib/swift/windows/swiftDispatch.lib ${{ env.SDKROOT }}/usr/lib/swift/windows/${{ matrix.cpu }}/
+          mv -Force ${{ env.SDKROOT }}/usr/lib/swift/windows/Foundation.lib ${{ env.SDKROOT }}/usr/lib/swift/windows/${{ matrix.cpu }}/
+          mv -Force ${{ env.SDKROOT }}/usr/lib/swift/windows/FoundationXML.lib ${{ env.SDKROOT }}/usr/lib/swift/windows/${{ matrix.cpu }}/
+          mv -Force ${{ env.SDKROOT }}/usr/lib/swift/windows/FoundationNetworking.lib ${{ env.SDKROOT }}/usr/lib/swift/windows/${{ matrix.cpu }}/
 
       - name: Checkout apple/swift
         uses: actions/checkout@v4
@@ -2177,49 +2219,32 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/swift
           show-progress: false
 
+      # Note: We didn't need to explicitly download cmark-gfm above because it's packaged inside
+      # compilers-${{ matrix.arch }}.
       - name: Setup cmark-gfm
-        run: Copy-Item ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr/bin/*.dll ${env:TOOLCHAIN_PATH}
-
-      - name: Add runtime libraries to path
-        run: |
-          $RTLPath = cygpath -w ${{ github.workspace }}/BinaryCache/Developer/SDKs/Windows.sdk/usr/bin
-          echo ${RTLPath} | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      - name: Add Toolchain to path
-        run: |
-          echo ${env:TOOLCHAIN_PATH} | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      - uses: compnerd/gha-setup-vsdevenv@main
-        with:
-          host_arch: amd64
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }}
-
-      # TODO(thebrowsercompany/swift-build#50): Workaround a file layout bug in the Windows SDK.
-      - name: Patch SDK file layout
-        run: |
-          $env:SDKROOT="${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
-          mv ${env:SDKROOT}/usr/lib/swift/dispatch ${env:SDKROOT}/usr/include/
-          mv ${env:SDKROOT}/usr/lib/swift/os ${env:SDKROOT}/usr/include/
-          mv ${env:SDKROOT}/usr/lib/swift/Block ${env:SDKROOT}/usr/include/
-          mv ${env:SDKROOT}/usr/lib/swift/windows/BlocksRuntime.lib ${env:SDKROOT}/usr/lib/swift/windows/${{ matrix.cpu }}/
-          mv ${env:SDKROOT}/usr/lib/swift/windows/dispatch.lib ${env:SDKROOT}/usr/lib/swift/windows/${{ matrix.cpu }}/
-          mv ${env:SDKROOT}/usr/lib/swift/windows/swiftDispatch.lib ${env:SDKROOT}/usr/lib/swift/windows/${{ matrix.cpu }}/
-          mv ${env:SDKROOT}/usr/lib/swift/windows/Foundation.lib ${env:SDKROOT}/usr/lib/swift/windows/${{ matrix.cpu }}/
-          mv ${env:SDKROOT}/usr/lib/swift/windows/FoundationXML.lib ${env:SDKROOT}/usr/lib/swift/windows/${{ matrix.cpu }}/
-          mv ${env:SDKROOT}/usr/lib/swift/windows/FoundationNetworking.lib ${env:SDKROOT}/usr/lib/swift/windows/${{ matrix.cpu }}/
+        run: Copy-Item ${{ github.workspace }}/BuildRoot/cmark-gfm-0.29.0.gfm.13/usr/bin/*.dll ${{ env.TOOLCHAIN_PATH }}
 
       - name: Build swift-inspect
+        id: swift_inspect
+        shell: cmd
         run: |
-          $env:SDKROOT="${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
-          # TODO(kendal): Figure out why Powershell won't execute this command when it's split into multiple lines.
-          swift build --triple=${{ matrix.triple }} --scratch-path="${{ github.workspace }}/BinaryCache/${{ matrix.arch }}/swift-inspect" --sdk="${env:SDKROOT}" --package-path="${{ github.workspace }}/SourceCache/swift/tools/swift-inspect" -c="release" -Xbuild-tools-swiftc="-I${env:SDKROOT}/usr/lib/swift" -Xbuild-tools-swiftc="-L${env:SDKROOT}/usr/lib/swift/windows" -Xcc="-I${env:SDKROOT}/usr/lib/swift" -Xlinker="-L${env:SDKROOT}/usr/lib/swift/windows" -debug-info-format="none" -Xcc="-I${env:SDKROOT}/usr/include/swift/SwiftRemoteMirror" -Xlinker="${env:SDKROOT}/usr/lib/swift/windows/${{ matrix.cpu }}/swiftRemoteMirror.lib"
+          swift build ^
+              --triple=${{ matrix.triple }} ^
+              --scratch-path="${{ github.workspace }}/BinaryCache/${{ matrix.arch }}/swift-inspect" ^
+              --sdk="${{ env.SDKROOT }}" ^
+              --package-path="${{ github.workspace }}/SourceCache/swift/tools/swift-inspect" ^
+              -c="release" ^
+              -Xbuild-tools-swiftc="-L${{ env.SDKROOT }}/usr/lib/swift/windows" ^
+              -Xbuild-tools-swiftc="-I${{ env.SDKROOT }}/usr/lib/swift -use-ld=lld" ^
+              -Xcc="-I${{ env.SDKROOT }}/usr/include/swift/SwiftRemoteMirror" ^
+              -Xlinker="${{ env.SDKROOT }}/usr/lib/swift/windows/${{ matrix.cpu }}/swiftRemoteMirror.lib" ^
+              -Xswiftc="-use-ld=lld"
 
       - name: Copy swift-inspect executable
-        id: copy-swift-inspect-exe
         run: |
           New-Item -Path ${{ github.workspace }}/BuildRoot-DebuggingTools/swift-inspect -ItemType Directory -Force | Out-Null
-          Copy-Item ${{ github.workspace }}/BinaryCache/${{ matrix.arch }}/swift-inspect/${{ matrix.triple }}/release/swift-inspect.exe -Destination ${{ github.workspace }}/BuildRoot-DebuggingTools/swift-inspect
+          $SwiftInspectPath="${{ github.workspace }}/BinaryCache/${{ matrix.arch }}/swift-inspect/${{ matrix.triple }}/release/swift-inspect.exe"
+          Copy-Item ${SwiftInspectPath} -Destination "${{ github.workspace }}/BuildRoot-DebuggingTools/swift-inspect/"
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Changes

- Remove some unnecessary swift build flags
- Skip vsdevenv setup - it interferes with the link step.
- Place host SDK in different directory
- Download both target and host SDKs
- Duplicate steps to patch misplaced SDK libs
- Split the build command across multiple lines

Fixes thebrowsercompany/swift-build#125