### PR TITLE
GHA: Explicitly install nuget

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -646,6 +646,9 @@ jobs:
         with:
           python-version: '${{ env.PYTHON_VERSION }}'
 
+      - uses: nuget/setup-nuget@v2
+        if: matrix.arch == 'arm64'
+
       # TODO(lxbndr) use actions/cache to improve this step timings
       - name: Install Python ${{ env.PYTHON_VERSION }} (arm64)
         if: matrix.arch == 'arm64'


### PR DESCRIPTION
While nuget is preinstalled on GitHub Actions provided Windows images via Chocolatey, it may not be available on custom images.