### PR TITLE
Skip upload steps if the trigger is pull_request

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2666,7 +2666,7 @@ jobs:
   snapshot:
     runs-on: ubuntu-latest
     needs: [context, smoke_test]
-
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -2689,7 +2689,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [context, smoke_test]
-
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
The workflow doesn't currently have a pull_request trigger (this decision is specific to the project that runs the workflow) but it's safe to assume that if a pull_request trigger is added, we should skip the snapshot and release steps. This PR adds if-statements to do so.