### PR TITLE
Fix swift-toolchain.yml after VS 17.10 upgrade on latest GHA image

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -157,17 +157,19 @@ jobs:
             repo manifest -r --suppress-upstream-revision --suppress-dest-branch -o - | sed -E 's,[[:space:]]+$,,' > stable.xml
           fi
 
+          # FIXME(z2oh): Remove /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR when GitHub runner image updates to 20240610.1.
+          #  see: https://github.com/actions/runner-images/issues/10004
           if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.debug_info }}" == "true" ]]; then
             echo debug_info=true >> ${GITHUB_OUTPUT}
             echo CMAKE_C_FLAGS="/GS- /Gw /Gy /Oi /Oy /Z7 /Zc:inline /Zc:preprocessor" >> ${GITHUB_OUTPUT}
-            echo CMAKE_CXX_FLAGS="/GS- /Gw /Gy /Oi /Oy /Z7 /Zc:inline /Zc:preprocessor /Zc:__cplusplus" >> ${GITHUB_OUTPUT}
+            echo CMAKE_CXX_FLAGS="/GS- /Gw /Gy /Oi /Oy /Z7 /Zc:inline /Zc:preprocessor /Zc:__cplusplus /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" >> ${GITHUB_OUTPUT}
             echo CMAKE_EXE_LINKER_FLAGS="-incremental:no -debug -opt:ref -opt:icf" >> ${GITHUB_OUTPUT}
             echo CMAKE_SHARED_LINKER_FLAGS="-incremental:no -debug -opt:ref -opt:icf" >> ${GITHUB_OUTPUT}
             echo CMAKE_Swift_FLAGS="-g -debug-info-format=codeview -Xlinker -debug -Xlinker -incremental:no -Xlinker -opt:ref -Xlinker -opt:icf" >> ${GITHUB_OUTPUT}
           else
             echo debug_info=false >> ${GITHUB_OUTPUT}
             echo CMAKE_C_FLAGS="/GS- /Gw /Gy /Oi /Oy /Zc:inline /Zc:preprocessor" >> ${GITHUB_OUTPUT}
-            echo CMAKE_CXX_FLAGS="/GS- /Gw /Gy /Oi /Oy /Zc:inline /Zc:preprocessor /Zc:__cplusplus" >> ${GITHUB_OUTPUT}
+            echo CMAKE_CXX_FLAGS="/GS- /Gw /Gy /Oi /Oy /Zc:inline /Zc:preprocessor /Zc:__cplusplus /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" >> ${GITHUB_OUTPUT}
             echo CMAKE_EXE_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
             echo CMAKE_SHARED_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
             echo CMAKE_Swift_FLAGS="-Xlinker -incremental:no -Xlinker -opt:ref -Xlinker -opt:icf" >> ${GITHUB_OUTPUT}
@@ -1096,6 +1098,11 @@ jobs:
           host_arch: amd64
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
+
+      # FIXME(z2oh) find another way around this chicken-and-egg bootstrapping compiler problem. As it stands, this will break with every MSVC upgrade.
+      - name: Patch yvals_core.h
+        run: |
+            (Get-Content "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\yvals_core.h").Replace('#if __clang_major__ < 17', '#if __clang_major__ < 16') | Set-Content "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\yvals_core.h"
 
       - name: Install Swift Toolchain
         uses: compnerd/gha-setup-swift@main


### PR DESCRIPTION
The GitHub runner image update introduced two main problems:
1. VS 17.10 STL introduced a hard requirement on Clang 17, which is not available for any 5.10 toolchain. For now, manually patch `yvals_.core.h` to relax this requirement, but this is brittle.
2. An update in VS 17.10 STL made `mutex`'s constructor `constexpr`, which breaks compatibility between mixing different versions of the STL (reasonable). A `PATH` configuration problem on the GHA image causes the linker picks up an old copy of `vcruntime140.dll` from a Python installation rather than `C:\Windows\system32\vcruntime140.dll`, violating this requirement of the STL. This is fixed in the latest GHA windows image, `20240610.1`, but this hasn't made it to our runners yet, so in the meantime, disable the `constexpr` constructor to revert back to the old behavior with `/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR`