### PR TITLE
Fix broken publish_release artifacts check

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -11,6 +11,7 @@ on:
       swift_tag:
         description: 'Swift Build Tag'
         required: false
+        type: string
 
       swift_version:
         description: 'Swift Version'
@@ -29,9 +30,9 @@ on:
         type: boolean
 
       publish_artifacts:
-        description: 'If true, skip publishing release artifacts'
+        description: 'If true, publish release artifacts'
         type: boolean
-        default: false
+        default: true
         required: false
 
   workflow_call:
@@ -44,6 +45,7 @@ on:
       swift_tag:
         description: 'Swift Build Tag'
         required: false
+        type: string
 
       swift_version:
         description: 'Swift Version'
@@ -62,7 +64,7 @@ on:
         type: boolean
 
       publish_artifacts:
-        description: 'If true, skip publishing release artifacts'
+        description: 'If true, publish release artifacts'
         type: boolean
         default: false
         required: false
@@ -2693,7 +2695,7 @@ jobs:
   snapshot:
     runs-on: ubuntu-latest
     needs: [context, smoke_test]
-    if: inputs.publish_artifacts != true
+    if: inputs.publish_artifacts == true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -2716,7 +2718,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [context, smoke_test]
-    if: inputs.publish_artifacts != true
+    if: inputs.publish_artifacts == true
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Fix broken dry run check and `workflow_call.swift_tag` input

- We should upload if `publish_artifacts == true` rather than if `publish_artifacts != true`. This was missed by mistake when switching from `dry_run=true` which is the opposite.
- Add the required 'type' attribute to `workflow_call.swift_tag`. This wasn't checked before by GitHub because we never actually used workflow_call in thebrowsercompany/swift-build, but now GitHub is complaining that this attribute is missing.
- Default to `publish_artifacts = true` so that we don't break existing scheduled workflows that expect uploads to happened by default.

## Test

https://github.com/thebrowsercompany/swift-build/actions/runs/9555537790/job/26338983155