### PR TITLE
Always download debugging tools before package steps

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2297,7 +2297,6 @@ jobs:
     steps:
       - name: Download Debugging Tools
         uses: actions/download-artifact@v4
-        if: matrix.arch == 'amd64'
         with:
           name: debugging_tools-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/DebuggingTools


### PR DESCRIPTION
The arm64 swift-inspect build has been fixed for quite a while. We want to use it in downstream builds now.