### PR TITLE
Use toolchain clang to build compilers (fix Clang 18 breakage on arm64)

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -698,7 +698,8 @@ jobs:
           }
           $SWIFTC = cygpath -m (Get-Command swiftc).Source
           $SDKROOT = cygpath -m ${env:SDKROOT}
-          $CLANG_LOCATION = cygpath -m (Split-Path (Get-Command clang-cl).Source)
+          # Use toolchain clang to avoid broken __prefetch intrinsic on arm64 in Clang 18.
+          $CLANG_LOCATION = cygpath -m (Split-Path (Get-Command swiftc).Source)
           Remove-Item env:\SDKROOT
           cmake -B ${{ github.workspace }}/BinaryCache/1 `
                 -C ${{ github.workspace }}/SourceCache/swift/cmake/caches/${CACHE} `


### PR DESCRIPTION
Clang 18 is the default version of Clang on GitHub runner images, and has a broken definition of the `__prefetch` intrinsic on arm64 which causes build failures. We can instead use the Clang that comes with the pinned toolchain (Clang 16 on Swift 5.x releases), which does not have this broken definition.

See https://github.com/llvm/llvm-project/pull/93235 for more details.