### PR TITLE
Pass -Xcc -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH to CMAKE_Swift_FLAGS

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -712,7 +712,7 @@ jobs:
                 -D CMAKE_MT=mt `
                 -D CMAKE_Swift_COMPILER="${SWIFTC}" `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk `"${SDKROOT}`"" `
+                -D CMAKE_Swift_FLAGS="-sdk `"${SDKROOT}`" -Xcc -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" `
                 -D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.CMAKE_EXE_LINKER_FLAGS }}" `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.CMAKE_SHARED_LINKER_FLAGS }}" `


### PR DESCRIPTION
VS 17.10 introduced a requirement on Clang 17, but the pinned Swift toolchain used to bootstrap the compilers (a 5.10 snapshot) uses Clang 16. We can relax this version requirement with `ALLOW_COMPILER_AND_STL_VERSION_MISMATCH` which needs to be passed via `CMAKE_Swift_FLAGS` when configuring the compilers.

This mirrors the change to build.ps1 in https://github.com/swiftlang/swift/pull/74662