### PR TITLE
swift-toolchain workflow: set publish artifacts to true for workflow_…

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -66,7 +66,7 @@ on:
       publish_artifacts:
         description: 'If true, publish release artifacts'
         type: boolean
-        default: false
+        default: true
         required: false
 
     secrets:


### PR DESCRIPTION
…call

It appears that workflow_call is used when the GHA workflow is triggered by a scheduled run, so it needs to be true there to create a release.