### PR TITLE
Disable sccache when building ICU for Android

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -569,6 +569,9 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
+        # TODO: Android ICU builds are consistently failing due to https://github.com/mozilla/sccache/issues/2092
+        # On GitHub and non-GitHub runner images. Reenable once this issue is resolved.
+        if: matrix.os != 'Android'
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
@@ -590,10 +593,10 @@ jobs:
                 -D BUILD_DATA=${{ matrix.BUILD_DATA }} `
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${{ matrix.cc }} `
-                -D CMAKE_C_COMPILER_LAUNCHER=sccache `
+                -D CMAKE_C_COMPILER_LAUNCHER=${{ matrix.os == 'Windows' && 'sccache' || '' }} `
                 -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
                 -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
-                -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
+                -D CMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.os == 'Windows' && 'sccache' || '' }} `
                 -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr `


### PR DESCRIPTION
These jobs are hitting a known fatal error in sccache where files aren't removed from the cache:

```
sccache: encountered fatal error
sccache: error: thread 'tokio-runtime-worker' panicked at src\lru_disk_cache\mod.rs:204:17: Error removing file from cache: `"C:\\a\\swift-build\\swift-build/.sccache\\preprocessor\\8\\f\\2\\8f2e7d1b9af7ff2cc23c6829fc3cae3044c631d88bf597901be5e04795779aad"`: failed to remove file `C:\a\swift-build\swift-build/.sccache\preprocessor\8\f\2\8f2e7d1b9af7ff2cc23c6829fc3cae3044c631d88bf597901be5e04795779aad`
sccache: caused by: thread 'tokio-runtime-worker' panicked at src\lru_disk_cache\mod.rs:204:17: Error removing file from cache: `"C:\\a\\swift-build\\swift-build/.sccache\\preprocessor\\8\\f\\2\\8f2e7d1b9af7ff2cc23c6829fc3cae3044c631d88bf597901be5e04795779aad"`: failed to remove file `C:\a\swift-build\swift-build/.sccache\preprocessor\8\f\2\8f2e7d1b9af7ff2cc23c6829fc3cae3044c631d88bf597901be5e04795779aad`
```

There's an open issue about this at https://github.com/mozilla/sccache/issues/2092.

## Test

https://github.com/thebrowsercompany/swift-build/actions/runs/9749014927