### PR TITLE
Bump up the ICU build sccache size

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -571,7 +571,7 @@ jobs:
       - name: Setup sccache
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
-          max-size: 100M
+          max-size: 200M
           key: ${{ matrix.os }}-${{ matrix.arch }}-icu
           variant: sccache
           append-timestamp: false


### PR DESCRIPTION
100Mib cache size is not able to fit all entries for the Android ICU build, which leads to manifestation of sccache bug happening in subsequent runs (https://github.com/mozilla/sccache/issues/2092).