### PR TITLE
GHA: tweak workflow configuration

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -29,8 +29,8 @@ on:
         default: false
         type: boolean
 
-      publish_artifacts:
-        description: 'If true, publish release artifacts'
+      create_release:
+        description: 'Create Release'
         type: boolean
         default: true
         required: false
@@ -69,8 +69,8 @@ on:
         default: false
         type: boolean
 
-      publish_artifacts:
-        description: 'If true, publish release artifacts'
+      create_release:
+        description: 'Create Release'
         type: boolean
         default: true
         required: false
@@ -3332,7 +3332,7 @@ jobs:
   snapshot:
     runs-on: ubuntu-latest
     needs: [context, smoke_test]
-    if: inputs.publish_artifacts == true
+    if: github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -3355,7 +3355,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [context, smoke_test]
-    if: inputs.publish_artifacts == true
+    if: inputs.create_release == true
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -3371,14 +3371,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Create Release
           gh release create ${{ needs.context.outputs.swift_tag }} -R ${{ github.repository }}
+
+          # AMD64
           cd ${{ github.workspace }}/tmp/amd64
+
           mv installer.exe installer-amd64.exe
           gh release upload ${{ needs.context.outputs.swift_tag }} installer-amd64.exe -R ${{ github.repository }}
+
           shasum -a 256 installer-amd64.exe > installer-amd64.exe.sha256
           gh release upload ${{ needs.context.outputs.swift_tag }} installer-amd64.exe.sha256 -R ${{ github.repository }}
+
+          # ARM64
           cd ${{ github.workspace }}/tmp/arm64
+
           mv installer.exe installer-arm64.exe
           gh release upload ${{ needs.context.outputs.swift_tag }} installer-arm64.exe -R ${{ github.repository }}
+
           shasum -a 256 installer-arm64.exe > installer-arm64.exe.sha256
           gh release upload ${{ needs.context.outputs.swift_tag }} installer-arm64.exe.sha256 -R ${{ github.repository }}


### PR DESCRIPTION
Reduce unnecessary verbosity on the configuration. Always generate the snapshot as we want to track any successful build. Add some whitespace to the release creation script.