### PR TITLE
Install VS build tools 14.39.33519 for the compilers step on release/5.10

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -659,7 +659,8 @@ jobs:
           }
           $SWIFTC = cygpath -m (Get-Command swiftc).Source
           $SDKROOT = cygpath -m ${env:SDKROOT}
-          $CLANG_LOCATION = cygpath -m (Split-Path (Get-Command clang-cl).Source)
+          # Use toolchain clang to avoid broken __prefetch intrinsic on arm64 in Clang 18.
+          $CLANG_LOCATION = cygpath -m (Split-Path (Get-Command swiftc).Source)
           Remove-Item env:\SDKROOT
           cmake -B ${{ github.workspace }}/BinaryCache/1 `
                 -C ${{ github.workspace }}/SourceCache/swift/cmake/caches/${CACHE} `

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -607,10 +607,26 @@ jobs:
           echo "PYTHON_LOCATION_amd64=$env:pythonLocation" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "PYTHON_LOCATION_arm64=${{ github.workspace }}\pythonarm64.${{ env.PYTHON_VERSION }}\tools" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+      # Pin VS build tools to version 14.39.33519
+      # See https://github.com/actions/runner-images/blob/win22/20240514.3/images/windows/Windows2022-Readme.md
+      - name: Install VS Build Tools v14.39.33519
+        run: |
+          & "C:\Program Files (x86)\Microsoft Visual Studio\installer\setup.exe" `
+            modify `
+            --quiet `
+            --force `
+            --installPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise" `
+            --add Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64 `
+            --add Microsoft.VisualStudio.Component.VC.14.39.17.9.ARM64 `
+            --add Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL `
+            --add Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL.ARM64 `
+            2>&1 | Out-String
+
       - uses: compnerd/gha-setup-vsdevenv@main
         with:
           host_arch: amd64
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+          components: 'Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64;Microsoft.VisualStudio.Component.VC.14.39.17.9.ARM64;Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL;Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL.ARM64'
+          toolset_version: 14.39.33519
           arch: ${{ matrix.arch }}
 
       - name: Install Swift Toolchain


### PR DESCRIPTION
This PR includes two commits to fix the 5.10 release build:
- The first installed VS build tools 14.39.33135 which work with Clang 16
- The second forces the compilers step to use the Clang from the toolchain build.

This was tested downstream in `thebrowsercompany/swift-build` CI.