### PR TITLE
 Install VS build tools 14.39.33519 for sdk and devtools steps on release/5.10

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1097,10 +1097,24 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/swift-experimental-string-processing
           show-progress: false
 
+      - name: Install VS Build Tools v14.39.33519
+        run: |
+          & "C:\Program Files (x86)\Microsoft Visual Studio\installer\setup.exe" `
+            modify `
+            --quiet `
+            --force `
+            --installPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise" `
+            --add Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64 `
+            --add Microsoft.VisualStudio.Component.VC.14.39.17.9.ARM64 `
+            --add Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL `
+            --add Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL.ARM64 `
+            2>&1 | Out-String
+
       - uses: compnerd/gha-setup-vsdevenv@main
         with:
           host_arch: amd64
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+          components: 'Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64;Microsoft.VisualStudio.Component.VC.14.39.17.9.ARM64;Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL;Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL.ARM64'
+          toolset_version: 14.39.33519
           arch: ${{ matrix.arch }}
 
       - name: Install Swift Toolchain
@@ -1469,10 +1483,24 @@ jobs:
           $RTLPath = cygpath -w ${{ github.workspace }}/BinaryCache/Developer/SDKs/Windows.sdk/usr/bin
           echo ${RTLPath} | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      - name: Install VS Build Tools v14.39.33519
+        run: |
+          & "C:\Program Files (x86)\Microsoft Visual Studio\installer\setup.exe" `
+            modify `
+            --quiet `
+            --force `
+            --installPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise" `
+            --add Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64 `
+            --add Microsoft.VisualStudio.Component.VC.14.39.17.9.ARM64 `
+            --add Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL `
+            --add Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL.ARM64 `
+            2>&1 | Out-String
+
       - uses: compnerd/gha-setup-vsdevenv@main
         with:
           host_arch: amd64
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+          components: 'Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64;Microsoft.VisualStudio.Component.VC.14.39.17.9.ARM64;Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL;Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL.ARM64'
+          toolset_version: 14.39.33519
           arch: ${{ matrix.arch }}
 
       - run: |


### PR DESCRIPTION
The SDK and devtools steps on the release/5.10 branch must also use the old version `14.39.33519` of VS build
tools which are still compatible with Clang 16.  

## Test

https://github.com/thebrowsercompany/swift-build/actions/runs/9943835623