### PR TITLE
Fix default.xml.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -35,13 +35,13 @@
   <project remote="github" name="apple/swift-lmdb" path="swift-lmdb" />
   <project remote="github" name="apple/swift-log" path="swift-log" groups="notdefault" />
   <project remote="github" name="apple/swift-markdown" path="swift-markdown" />
-  <project remote="github" name="apple/swift-nio" path="swift-nio" revisions="refs/tags/2.31.2" />
+  <project remote="github" name="apple/swift-nio" path="swift-nio" revision="refs/tags/2.31.2" />
   <project remote="github" name="apple/swift-numerics" path="swift-numerics" groups="notdefault" revision="refs/tags/1.0.2" />
   <project remote="github" name="apple/swift-package-manager" path="swift-package-manager" />
   <project remote="github" name="apple/swift-protobuf" path="swift-protobuf" groups="notdefault" />
   <project remote="github" name="apple/swift-syntax" path="swift-syntax" />
   <project remote="github" name="apple/swift-system" path="swift-system" revision="refs/tags/1.3.0" />
-  <project remote="github" name="apple/swift-testing" path="swift-testing" />
+  <project remote="github" name="apple/swift-testing" path="swift-testing" revision="main" />
   <project remote="github" name="apple/swift-tools-support-core" path="swift-tools-support-core" />
   <project remote="github" name="apple/swift-xcode-playground-support" path="swift-xcode-playground-support" groups="notdefault" />
 


### PR DESCRIPTION
Fix a typo for swift-nio.
Use main for swift-testing because it doesn't have release branches.

apple/swift-testing:
fatal: couldn't find remote ref refs/heads/release/6.0 apple/swift-testing: sleeping 4.0 seconds before retrying fatal: couldn't find remote ref refs/heads/release/6.0 error: Cannot fetch apple/swift-testing from https://github.com/apple/swift-testing Fetching: 100% (2/2), done in 10.012s
error: Cannot checkout apple/swift-nio: ManifestInvalidRevisionError: revision release/6.0 in apple/swift-nio not found