### PR TITLE
GHA: download the SDK to the proper location

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2735,7 +2735,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: Windows-sdk-amd64
-          path: ${{ github.workspace }}/BinaryCache
+          path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform
       - name: Download SDK
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
We would previously download the AMD64 SDK to the wrong location and would thus fail to find the necessary content.

Cherry pick commit https://github.com/compnerd/swift-build/commit/e108a13b914eff4b87c538cefca606933432921d