### PR TITLE
Update android corelibs-foundation pinned checkout

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3097,7 +3097,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-installer-scripts
-          ref: e1adc0d5dde137fa5941316e89a3ed139a273dde
+          ref: 633843b00fc8024dd86674fe43373ae4fd0f2229
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1653,8 +1653,8 @@ jobs:
       - uses: actions/checkout@v4
         if: matrix.os == 'Android'
         with:
-          repository: apple/swift-corelibs-foundation
-          ref: a515f3e15c81d029411c540df7edf52d427ff2cb
+          repository: hyp/swift-corelibs-foundation
+          ref: 6bf677693eb23030eb3646c9b121c665f40aa8b0
           path: ${{ github.workspace }}/SourceCache/swift-corelibs-foundation
           show-progress: false
       - uses: actions/checkout@v4


### PR DESCRIPTION
The checkout needs to be updated after the posix_filesystem apinote fix landed in Swift. I needed to switch to my own remote as I could no longer push a new branch into the Apple remote.