### PR TITLE
Update default.xml

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -63,6 +63,4 @@
   <project remote="github" name="madler/zlib" path="zlib" revision="refs/tags/v1.3.1" />
 
   <project remote="github" name="ninja-build/ninja" path="ninja" groups="notdefault,dependencies" revision="master" />
-
-  <project remote="github" name="unicode-org/icu" path="icu" revision="maint/maint-69" />
 </manifest>


### PR DESCRIPTION
Remove ICU from the checkout. This has been superseded by swift-foundation-icu.

Cherry pick commit https://github.com/compnerd/swift-build/commit/5183f3207356090be3e17baf620bc26cdb738043