### PR TITLE
[android] checkout unpinned installer script

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2895,7 +2895,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-installer-scripts
-          ref: 633843b00fc8024dd86674fe43373ae4fd0f2229
+          ref: ${{ needs.context.outputs.swift_installer_scripts_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 


### PR DESCRIPTION
The pin will no longer be needed since we're switching to swift-foundation