### PR TITLE
GHA: update curl version

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1015,7 +1015,7 @@ jobs:
       - name: Configure curl
         run: |
           $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          cmake -B ${{ github.workspace }}/BinaryCache/curl-7.77.0 `
+          cmake -B ${{ github.workspace }}/BinaryCache/curl-8.9.1 `
                 -D BUILD_SHARED_LIBS=NO `
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${{ matrix.cc }} `
@@ -1025,7 +1025,7 @@ jobs:
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
                 -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
                 -D CMAKE_MT=mt `
-                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/curl-7.77.0/usr `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/curl-8.9.1/usr `
                 -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
                 ${{ matrix.extra_flags }} `
                 -G Ninja `
@@ -1111,14 +1111,14 @@ jobs:
                 -D CMAKE_POSITION_INDEPENDENT_CODE=YES `
                 -D CMAKE_ANDROID_NDK=$NDKPATH
       - name: Build curl
-        run: cmake --build ${{ github.workspace }}/BinaryCache/curl-7.77.0
+        run: cmake --build ${{ github.workspace }}/BinaryCache/curl-8.9.1
       - name: Install curl
-        run: cmake --build ${{ github.workspace }}/BinaryCache/curl-7.77.0 --target install
+        run: cmake --build ${{ github.workspace }}/BinaryCache/curl-8.9.1 --target install
 
       - uses: actions/upload-artifact@v4
         with:
-          name: curl-${{ matrix.os }}-${{ matrix.arch }}-7.77.0
-          path: ${{ github.workspace }}/BuildRoot/Library/curl-7.77.0/usr
+          name: curl-${{ matrix.os }}-${{ matrix.arch }}-8.9.1
+          path: ${{ github.workspace }}/BuildRoot/Library/curl-8.9.1/usr
 
   libxml2:
     needs: [context]
@@ -1365,8 +1365,8 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library/libxml2-2.11.5/usr
       - uses: actions/download-artifact@v4
         with:
-          name: curl-${{ matrix.os }}-${{ matrix.arch }}-7.77.0
-          path: ${{ github.workspace }}/BuildRoot/Library/curl-7.77.0/usr
+          name: curl-${{ matrix.os }}-${{ matrix.arch }}-8.9.1
+          path: ${{ github.workspace }}/BuildRoot/Library/curl-8.9.1/usr
       - uses: actions/download-artifact@v4
         with:
           name: zlib-${{ matrix.os }}-${{ matrix.arch }}-1.3
@@ -1656,7 +1656,7 @@ jobs:
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/swift-corelibs-foundation `
                 -D dispatch_DIR=${{ github.workspace }}/BinaryCache/libdispatch/cmake/modules `
-                -D CURL_DIR=${{ github.workspace }}/BuildRoot/Library/curl-7.77.0/usr/lib/cmake/CURL `
+                -D CURL_DIR=${{ github.workspace }}/BuildRoot/Library/curl-8.9.1/usr/lib/cmake/CURL `
                 -D FOUNDATION_BUILD_TOOLS=${build_tools} `
                 -D ENABLE_TESTING=NO `
                 -D _SwiftFoundation_SourceDIR=$SWIFT_FOUNDATION_SOURCE_DIR `


### PR DESCRIPTION
CURL was updated to 8.9.1 upstream. Update the build rules to reflect that.