### PR TITLE
[Mac build] Move build to sub-workflow

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -1,0 +1,381 @@
+name: Development Snapshot
+
+on:
+  workflow_dispatch:
+    inputs:
+      swift_version:
+        description: 'Swift Version'
+        default: '0.0.0'
+        required: false
+        type: string
+
+      android_api_level:
+        description: 'Android API Level'
+        default: 28
+        required: false
+        type: number
+
+      swift_tag:
+        description: 'Swift Build Tag'
+        required: false
+        type: string
+
+      debug_info:
+        description: 'Emit PDBs (Debug Info)'
+        default: false
+        type: boolean
+
+      signed:
+        description: 'Code Sign'
+        default: false
+        type: boolean
+
+      create_release:
+        description: 'Create Release'
+        type: boolean
+        default: true
+        required: false
+
+  workflow_call:
+    inputs:
+      swift_version:
+        description: 'Swift Version'
+        default: '0.0.0'
+        required: false
+        type: string
+
+      android_api_level:
+        description: 'Android API Level'
+        default: 28
+        required: false
+        type: number
+
+      swift_tag:
+        description: 'Swift Build Tag'
+        required: false
+        type: string
+
+      debug_info:
+        description: 'Emit PDBs (Debug Info)'
+        default: true
+        type: boolean
+
+      signed:
+        description: 'Code Sign'
+        default: false
+        type: boolean
+
+      create_release:
+        description: 'Create Release'
+        type: boolean
+        default: true
+        required: false
+
+    secrets:
+      SYMBOL_SERVER_PAT:
+        required: true
+      CERTIFICATE:
+        required: true
+      PASSPHRASE:
+        required: true
+
+env:
+  SCCACHE_DIRECT: yes
+
+jobs:
+  context:
+    runs-on: ubuntu-latest
+    outputs:
+      curl_revision: ${{ steps.context.outputs.curl_revision }}
+      indexstore_db_revision: ${{ steps.context.outputs.indexstore_db_revision }}
+      libxml2_revision: ${{ steps.context.outputs.libxml2_revision }}
+      llvm_project_revision: ${{ steps.context.outputs.llvm_project_revision }}
+      sourcekit_lsp_revision: ${{ steps.context.outputs.sourcekit_lsp_revision }}
+      swift_argument_parser_revision: ${{ steps.context.outputs.swift_argument_parser_revision }}
+      swift_asn1_revision: ${{ steps.context.outputs.swift_asn1_revision }}
+      swift_atomics_revision: ${{ steps.context.outputs.swift_atomics_revision }}
+      swift_certificates_revision: ${{ steps.context.outputs.swift_certificates_revision }}
+      swift_cmark_revision: ${{ steps.context.outputs.swift_cmark_revision }}
+      swift_collections_revision: ${{ steps.context.outputs.swift_collections_revision }}
+      swift_corelibs_foundation_revision: ${{ steps.context.outputs.swift_corelibs_foundation_revision }}
+      swift_corelibs_libdispatch_revision: ${{ steps.context.outputs.swift_corelibs_libdispatch_revision }}
+      swift_corelibs_xctest_revision: ${{ steps.context.outputs.swift_corelibs_xctest_revision }}
+      swift_crypto_revision: ${{ steps.context.outputs.swift_crypto_revision }}
+      swift_driver_revision: ${{ steps.context.outputs.swift_driver_revision }}
+      swift_experimental_string_processing_revision: ${{ steps.context.outputs.swift_experimental_string_processing_revision }}
+      swift_format_revision: ${{ steps.context.outputs.swift_format_revision }}
+      swift_foundation_revision: ${{ steps.context.outputs.swift_foundation_revision }}
+      swift_foundation_icu_revision: ${{ steps.context.outputs.swift_foundation_icu_revision }}
+      swift_installer_scripts_revision: ${{ steps.context.outputs.swift_installer_scripts_revision }}
+      swift_llbuild_revision: ${{ steps.context.outputs.swift_llbuild_revision }}
+      swift_markdown_revision: ${{ steps.context.outputs.swift_markdown_revision }}
+      swift_package_manager_revision: ${{ steps.context.outputs.swift_package_manager_revision }}
+      swift_revision: ${{ steps.context.outputs.swift_revision }}
+      swift_syntax_revision: ${{ steps.context.outputs.swift_syntax_revision }}
+      swift_system_revision: ${{ steps.context.outputs.swift_system_revision }}
+      swift_toolchain_sqlite_revision: ${{ steps.context.outputs.swift_toolchain_sqlite_revision }}
+      swift_toolchain_sqlite_version: ${{ steps.context.outputs.swift_toolchain_sqlite_version }}
+      swift_tools_support_core_revision: ${{ steps.context.outputs.swift_tools_support_core_revision }}
+      yams_revision: ${{ steps.context.outputs.yams_revision }}
+      zlib_revision: ${{ steps.context.outputs.zlib_revision }}
+      ANDROID_API_LEVEL: ${{ steps.context.outputs.ANDROID_API_LEVEL }}
+      WINDOWS_CMAKE_C_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+      WINDOWS_CMAKE_CXX_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+      WINDOWS_CMAKE_EXE_LINKER_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}
+      WINDOWS_CMAKE_SHARED_LINKER_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}
+      ANDROID_CMAKE_C_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+      ANDROID_CMAKE_CXX_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+      ANDROID_CMAKE_EXE_LINKER_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}
+      ANDROID_CMAKE_SHARED_LINKER_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}
+      CMAKE_Swift_FLAGS: ${{ steps.context.outputs.CMAKE_Swift_FLAGS }}
+      debug_info: ${{ steps.context.outputs.debug_info }}
+      signed: ${{ steps.context.outputs.signed }}
+      swift_version: ${{ steps.context.outputs.swift_version }}
+      swift_tag: ${{ steps.context.outputs.swift_tag }}
+      windows_build_runner: ${{ steps.context.outputs.windows_build_runner }}
+      compilers_build_runner: ${{ steps.context.outputs.compilers_build_runner }}
+    steps:
+      - id: context
+        name: Generate Build Context
+        run: |
+          # TODO(compnerd) can we make this more silent?
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qq update -yq
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qq -o Dpkg::Use-Pty=0 install -yq repo libxml2-utils
+
+          # Which branch is this workflow based on
+          branch_version_string=${{ inputs.swift_version || '0.0.0' }}
+          if [[ $branch_version_string == *.* ]]; then
+            branch_name=$(echo ${branch_version_string} | awk -F. '{ ver=$1"."$2; print (ver == "0.0") ? "main" : "release/"ver }')
+          else
+            branch_name="release/$branch_version_string"
+          fi
+
+          repo init --quiet --groups default --depth 1 -u https://github.com/compnerd/swift-build -b $branch_name
+          repo sync --quiet --no-clone-bundle --no-tags --jobs $(nproc --all)
+
+          if [[ "${{ inputs.swift_tag }}" != "" ]] ; then
+            tee -a "${GITHUB_OUTPUT}" <<-EOF
+          indexstore_db_revision=refs/tags/${{ inputs.swift_tag }}
+          llvm_project_revision=refs/tags/${{ inputs.swift_tag }}
+          sourcekit_lsp_revision=refs/tags/${{ inputs.swift_tag }}
+          swift_revision=refs/tags/${{ inputs.swift_tag }}
+          swift_argument_parser_revision=refs/tags/1.4.0
+          swift_asn1_revision=refs/tags/0.7.0
+          swift_atomics_revision=refs/tags/1.2.0
+          swift_certificates_revision=refs/tags/0.1.0
+          swift_cmark_revision=refs/tags/${{ inputs.swift_tag }}
+          swift_collections_revision=refs/tags/1.1.2
+          swift_corelibs_foundation_revision=refs/tags/${{ inputs.swift_tag }}
+          swift_corelibs_libdispatch_revision=refs/tags/${{ inputs.swift_tag }}
+          swift_corelibs_xctest_revision=refs/tags/${{ inputs.swift_tag }}
+          swift_crypto_revision=refs/tags/3.0.0
+          swift_driver_revision=refs/tags/${{ inputs.swift_tag }}
+          swift_experimental_string_processing_revision=refs/tags/${{ inputs.swift_tag }}
+          swift_format_revision=refs/heads/main
+          swift_foundation_revison=refs/heads/main
+          swift_foundation_icu_revision=refs/tags/0.0.8
+          swift_installer_scripts_revision=refs/heads/main
+          swift_llbuild_revision=refs/tags/${{ inputs.swift_tag }}
+          swift_markdown_revision=refs/tags/${{ inputs.swift_tag }}
+          swift_package_manager_revision=refs/tags/${{ inputs.swift_tag }}
+          swift_syntax_revision=refs/tags/${{ inputs.swift_tag }}
+          swift_system_revision=refs/tags/1.3.0
+          swift_toolchain_sqlite_revision=refs/tags/main
+          swift_toolchain_sqlite_version=3.46.0
+          swift_tools_support_core_revision=refs/tags/${{ inputs.swift_tag }}
+          curl_revision=refs/tags/curl-8_5_0
+          libxml2_revision=refs/tags/v2.11.5
+          yams_revision=refs/tags/5.0.6
+          zlib_revision=refs/tags/v1.3.1
+          EOF
+          else
+            repo manifest -r --suppress-upstream-revision --suppress-dest-branch | \
+                  xmllint --xpath "//project/@name | //project/@revision" - | \
+                  xargs -n2 | \
+                  awk -F'[= ]' '{
+                    split($2, repo, "/");
+                    gsub(/-/, "_", repo[2]);
+                    print tolower(repo[2]) "_revision=" $4
+                  }' | tee -a "${GITHUB_OUTPUT}"
+            repo manifest -r --suppress-upstream-revision --suppress-dest-branch -o - | sed -E 's,[[:space:]]+$,,' > stable.xml
+          fi
+
+          # FIXME(z2oh): Remove /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR when GitHub runner image updates to 20240610.1.
+          #  see: https://github.com/actions/runner-images/issues/10004
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.debug_info }}" == "true" ]]; then
+            echo debug_info=true >> ${GITHUB_OUTPUT}
+            echo WINDOWS_CMAKE_C_FLAGS="/GS- /Gw /Gy /Oi /Oy /Z7 /Zc:inline /Zc:preprocessor" >> ${GITHUB_OUTPUT}
+            echo WINDOWS_CMAKE_CXX_FLAGS="/GS- /Gw /Gy /Oi /Oy /Z7 /Zc:inline /Zc:preprocessor /Zc:__cplusplus /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" >> ${GITHUB_OUTPUT}
+            echo ANDROID_CMAKE_C_FLAGS="-ffunction-sections -fdata-sections -g" >> ${GITHUB_OUTPUT}
+            echo ANDROID_CMAKE_CXX_FLAGS="-ffunction-sections -fdata-sections -g" >> ${GITHUB_OUTPUT}
+            echo WINDOWS_CMAKE_EXE_LINKER_FLAGS="-incremental:no -debug -opt:ref -opt:icf" >> ${GITHUB_OUTPUT}
+            echo WINDOWS_CMAKE_SHARED_LINKER_FLAGS="-incremental:no -debug -opt:ref -opt:icf" >> ${GITHUB_OUTPUT}
+            echo CMAKE_Swift_FLAGS="-g -debug-info-format=codeview -Xlinker -debug -Xlinker -incremental:no -Xlinker -opt:ref -Xlinker -opt:icf" >> ${GITHUB_OUTPUT}
+          else
+            echo debug_info=false >> ${GITHUB_OUTPUT}
+            echo WINDOWS_CMAKE_C_FLAGS="/GS- /Gw /Gy /Oi /Oy /Zc:inline /Zc:preprocessor" >> ${GITHUB_OUTPUT}
+            echo WINDOWS_CMAKE_CXX_FLAGS="/GS- /Gw /Gy /Oi /Oy /Zc:inline /Zc:preprocessor /Zc:__cplusplus /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" >> ${GITHUB_OUTPUT}
+            echo ANDROID_CMAKE_C_FLAGS="-ffunction-sections -fdata-sections" >> ${GITHUB_OUTPUT}
+            echo ANDROID_CMAKE_CXX_FLAGS="-ffunction-sections -fdata-sections" >> ${GITHUB_OUTPUT}
+            echo WINDOWS_CMAKE_EXE_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
+            echo WINDOWS_CMAKE_SHARED_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
+            echo CMAKE_Swift_FLAGS="-Xlinker -incremental:no -Xlinker -opt:ref -Xlinker -opt:icf" >> ${GITHUB_OUTPUT}
+          fi
+          echo ANDROID_CMAKE_EXE_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
+          echo ANDROID_CMAKE_SHARED_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
+
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.signed }}" == "true" ]]; then
+            # FIXME(compnerd) enable this when requested
+            echo signed=false >> ${GITHUB_OUTPUT}
+          else
+            echo signed=false >> ${GITHUB_OUTPUT}
+          fi
+
+          echo swift_version=${{ inputs.swift_version || '0.0.0' }} | tee -a ${GITHUB_OUTPUT}
+          if [[ -n "${{ inputs.swift_tag }}" ]] ; then
+            echo swift_tag=${{ inputs.swift_tag }} | tee -a ${GITHUB_OUTPUT}
+          else
+            if [[ "$branch_name" == "main" ]] ; then
+              echo swift_tag=$(date +%Y%m%d.$(date +%-H/6 | bc)) | tee -a ${GITHUB_OUTPUT}
+            else
+              echo swift_tag=swift-"$branch_version_string"-$(date +%Y%m%d.$(date +%-H/6 | bc)) | tee -a ${GITHUB_OUTPUT}
+            fi
+          fi
+
+          echo windows_build_runner=${{ vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
+          echo compilers_build_runner=${{ vars.COMPILERS_BUILD_RUNNER || vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
+
+          echo ANDROID_API_LEVEL=${{ inputs.android_api_level }} >> ${GITHUB_OUTPUT}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: stable.xml
+          path: stable.xml
+          if-no-files-found: ignore
+
+  windows-build:
+    needs: [context]
+    name: Windows Swift Toolchains Build
+    uses: ./.github/workflows/swift-toolchain.yml
+    with:
+      curl_revision: ${{ needs.context.outputs.curl_revision }}
+      indexstore_db_revision: ${{ needs.context.outputs.indexstore_db_revision }}
+      libxml2_revision: ${{ needs.context.outputs.libxml2_revision }}
+      llvm_project_revision: ${{ needs.context.outputs.llvm_project_revision }}
+      sourcekit_lsp_revision: ${{ needs.context.outputs.sourcekit_lsp_revision }}
+      swift_argument_parser_revision: ${{ needs.context.outputs.swift_argument_parser_revision }}
+      swift_asn1_revision: ${{ needs.context.outputs.swift_asn1_revision }}
+      swift_atomics_revision: ${{ needs.context.outputs.swift_atomics_revision }}
+      swift_certificates_revision: ${{ needs.context.outputs.swift_certificates_revision }}
+      swift_cmark_revision: ${{ needs.context.outputs.swift_cmark_revision }}
+      swift_collections_revision: ${{ needs.context.outputs.swift_collections_revision }}
+      swift_corelibs_foundation_revision: ${{ needs.context.outputs.swift_corelibs_foundation_revision }}
+      swift_corelibs_libdispatch_revision: ${{ needs.context.outputs.swift_corelibs_libdispatch_revision }}
+      swift_corelibs_xctest_revision: ${{ needs.context.outputs.swift_corelibs_xctest_revision }}
+      swift_crypto_revision: ${{ needs.context.outputs.swift_crypto_revision }}
+      swift_driver_revision: ${{ needs.context.outputs.swift_driver_revision }}
+      swift_experimental_string_processing_revision: ${{ needs.context.outputs.swift_experimental_string_processing_revision }}
+      swift_format_revision: ${{ needs.context.outputs.swift_format_revision }}
+      swift_foundation_revision: ${{ needs.context.outputs.swift_foundation_revision }}
+      swift_foundation_icu_revision: ${{ needs.context.outputs.swift_foundation_icu_revision }}
+      swift_installer_scripts_revision: ${{ needs.context.outputs.swift_installer_scripts_revision }}
+      swift_llbuild_revision: ${{ needs.context.outputs.swift_llbuild_revision }}
+      swift_markdown_revision: ${{ needs.context.outputs.swift_markdown_revision }}
+      swift_package_manager_revision: ${{ needs.context.outputs.swift_package_manager_revision }}
+      swift_revision: ${{ needs.context.outputs.swift_revision }}
+      swift_syntax_revision: ${{ needs.context.outputs.swift_syntax_revision }}
+      swift_system_revision: ${{ needs.context.outputs.swift_system_revision }}
+      swift_toolchain_sqlite_revision: ${{ needs.context.outputs.swift_toolchain_sqlite_revision }}
+      swift_toolchain_sqlite_version: ${{ needs.context.outputs.swift_toolchain_sqlite_version }}
+      swift_tools_support_core_revision: ${{ needs.context.outputs.swift_tools_support_core_revision }}
+      yams_revision: ${{ needs.context.outputs.yams_revision }}
+      zlib_revision: ${{ needs.context.outputs.zlib_revision }}
+      ANDROID_API_LEVEL: ${{ needs.context.outputs.ANDROID_API_LEVEL }}
+      WINDOWS_CMAKE_C_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+      WINDOWS_CMAKE_CXX_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+      WINDOWS_CMAKE_EXE_LINKER_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}
+      WINDOWS_CMAKE_SHARED_LINKER_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}
+      ANDROID_CMAKE_C_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+      ANDROID_CMAKE_CXX_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+      ANDROID_CMAKE_EXE_LINKER_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}
+      ANDROID_CMAKE_SHARED_LINKER_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}
+      CMAKE_Swift_FLAGS: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
+      debug_info: ${{ needs.context.outputs.debug_info }}
+      signed: ${{ needs.context.outputs.signed }}
+      swift_version: ${{ needs.context.outputs.swift_version }}
+      swift_tag: ${{ needs.context.outputs.swift_tag }}
+      default_build_runner: ${{ needs.context.outputs.windows_build_runner }}
+      compilers_build_runner: ${{ needs.context.outputs.compilers_build_runner }}
+    secrets:
+      SYMBOL_SERVER_PAT: ${{ secrets.SYMBOL_SERVER_PAT }}
+      CERTIFICATE: ${{ secrets.CERTIFICATE }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
+
+  snapshot:
+    runs-on: ubuntu-latest
+    needs: [context, windows-build]
+    if: github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/heads/main
+          show-progress: false
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: stable.xml
+
+      - run: |
+          git config --global user.name 'github-action[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          if ! git diff --exit-code ; then
+            git add stable.xml
+            git commit -m "repo: update stable revision snapshot ${{ needs.context.outputs.swift_tag }}"
+            git push origin HEAD:main
+          fi
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [context, windows-build]
+    if: inputs.create_release == true
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: installer-amd64
+          path: ${{ github.workspace }}/tmp/amd64
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: installer-arm64
+          path: ${{ github.workspace }}/tmp/arm64
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          branch_version_string=${{ inputs.swift_version || '0.0.0' }}
+          if [[ $branch_version_string == "0.0.0" ]]; then
+            latest="true"
+          else
+            latest="false"
+          fi
+          # Create Release
+          gh release create ${{ needs.context.outputs.swift_tag }} -R ${{ github.repository }} --latest=${latest}
+
+          # AMD64
+          cd ${{ github.workspace }}/tmp/amd64
+
+          mv installer.exe installer-amd64.exe
+          gh release upload ${{ needs.context.outputs.swift_tag }} installer-amd64.exe -R ${{ github.repository }}
+
+          shasum -a 256 installer-amd64.exe > installer-amd64.exe.sha256
+          gh release upload ${{ needs.context.outputs.swift_tag }} installer-amd64.exe.sha256 -R ${{ github.repository }}
+
+          # ARM64
+          cd ${{ github.workspace }}/tmp/arm64
+
+          mv installer.exe installer-arm64.exe
+          gh release upload ${{ needs.context.outputs.swift_tag }} installer-arm64.exe -R ${{ github.repository }}
+
+          shasum -a 256 installer-arm64.exe > installer-arm64.exe.sha256
+          gh release upload ${{ needs.context.outputs.swift_tag }} installer-arm64.exe.sha256 -R ${{ github.repository }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1,75 +1,200 @@
-name: Development Snapshot
+name: Swift Toolchains Build
 
 on:
-  workflow_dispatch:
-    inputs:
-      swift_version:
-        description: 'Swift Version'
-        default: '0.0.0'
-        required: false
-        type: string
-
-      android_api_level:
-        description: 'Android API Level'
-        default: 28
-        required: false
-        type: number
-
-      swift_tag:
-        description: 'Swift Build Tag'
-        required: false
-        type: string
-
-      debug_info:
-        description: 'Emit PDBs (Debug Info)'
-        default: false
-        type: boolean
-
-      signed:
-        description: 'Code Sign'
-        default: false
-        type: boolean
-
-      create_release:
-        description: 'Create Release'
-        type: boolean
-        default: true
-        required: false
-
   workflow_call:
     inputs:
-      swift_version:
-        description: 'Swift Version'
-        default: '0.0.0'
-        required: false
+      curl_revision:
+        required: true
         type: string
 
-      android_api_level:
-        description: 'Android API Level'
-        default: 28
-        required: false
-        type: number
+      indexstore_db_revision:
+        required: true
+        type: string
 
-      swift_tag:
-        description: 'Swift Build Tag'
-        required: false
+      libxml2_revision:
+        required: true
+        type: string
+
+      llvm_project_revision:
+        required: true
+        type: string
+
+      sourcekit_lsp_revision:
+        required: true
+        type: string
+
+      swift_argument_parser_revision:
+        required: true
+        type: string
+
+      swift_asn1_revision:
+        required: true
+        type: string
+
+      swift_atomics_revision:
+        required: true
+        type: string
+
+      swift_certificates_revision:
+        required: true
+        type: string
+
+      swift_cmark_revision:
+        required: true
+        type: string
+
+      swift_collections_revision:
+        required: true
+        type: string
+
+      swift_corelibs_foundation_revision:
+        required: true
+        type: string
+
+      swift_corelibs_libdispatch_revision:
+        required: true
+        type: string
+
+      swift_corelibs_xctest_revision:
+        required: true
+        type: string
+
+      swift_crypto_revision:
+        required: true
+        type: string
+
+      swift_driver_revision:
+        required: true
+        type: string
+
+      swift_experimental_string_processing_revision:
+        required: true
+        type: string
+
+      swift_format_revision:
+        required: true
+        type: string
+
+      swift_foundation_revision:
+        required: true
+        type: string
+
+      swift_foundation_icu_revision:
+        required: true
+        type: string
+
+      swift_installer_scripts_revision:
+        required: true
+        type: string
+
+      swift_llbuild_revision:
+        required: true
+        type: string
+
+      swift_markdown_revision:
+        required: true
+        type: string
+
+      swift_package_manager_revision:
+        required: true
+        type: string
+
+      swift_revision:
+        required: true
+        type: string
+
+      swift_syntax_revision:
+        required: true
+        type: string
+
+      swift_system_revision:
+        required: true
+        type: string
+
+      swift_toolchain_sqlite_revision:
+        required: true
+        type: string
+
+      swift_toolchain_sqlite_version:
+        required: true
+        type: string
+
+      swift_tools_support_core_revision:
+        required: true
+        type: string
+
+      yams_revision:
+        required: true
+        type: string
+
+      zlib_revision:
+        required: true
+        type: string
+
+      ANDROID_API_LEVEL:
+        required: true
+        type: string
+
+      WINDOWS_CMAKE_C_FLAGS:
+        required: true
+        type: string
+
+      WINDOWS_CMAKE_CXX_FLAGS:
+        required: true
+        type: string
+
+      WINDOWS_CMAKE_EXE_LINKER_FLAGS:
+        required: true
+        type: string
+
+      WINDOWS_CMAKE_SHARED_LINKER_FLAGS:
+        required: true
+        type: string
+
+      ANDROID_CMAKE_C_FLAGS:
+        required: true
+        type: string
+
+      ANDROID_CMAKE_CXX_FLAGS:
+        required: true
+        type: string
+
+      ANDROID_CMAKE_EXE_LINKER_FLAGS:
+        required: true
+        type: string
+
+      ANDROID_CMAKE_SHARED_LINKER_FLAGS:
+        required: true
+        type: string
+
+      CMAKE_Swift_FLAGS:
+        required: true
         type: string
 
       debug_info:
-        description: 'Emit PDBs (Debug Info)'
-        default: true
-        type: boolean
+        required: true
+        type: string
 
       signed:
-        description: 'Code Sign'
-        default: false
-        type: boolean
+        required: true
+        type: string
 
-      create_release:
-        description: 'Create Release'
-        type: boolean
-        default: true
-        required: false
+      swift_version:
+        required: true
+        type: string
+
+      swift_tag:
+        required: true
+        type: string
+
+      default_build_runner:
+        required: true
+        type: string
+
+      compilers_build_runner:
+        required: true
+        type: string
+
 
     secrets:
       SYMBOL_SERVER_PAT:
@@ -83,179 +208,8 @@ env:
   SCCACHE_DIRECT: yes
 
 jobs:
-  context:
-    runs-on: ubuntu-latest
-    outputs:
-      curl_revision: ${{ steps.context.outputs.curl_revision }}
-      indexstore_db_revision: ${{ steps.context.outputs.indexstore_db_revision }}
-      libxml2_revision: ${{ steps.context.outputs.libxml2_revision }}
-      llvm_project_revision: ${{ steps.context.outputs.llvm_project_revision }}
-      sourcekit_lsp_revision: ${{ steps.context.outputs.sourcekit_lsp_revision }}
-      swift_argument_parser_revision: ${{ steps.context.outputs.swift_argument_parser_revision }}
-      swift_asn1_revision: ${{ steps.context.outputs.swift_asn1_revision }}
-      swift_atomics_revision: ${{ steps.context.outputs.swift_atomics_revision }}
-      swift_certificates_revision: ${{ steps.context.outputs.swift_certificates_revision }}
-      swift_cmark_revision: ${{ steps.context.outputs.swift_cmark_revision }}
-      swift_collections_revision: ${{ steps.context.outputs.swift_collections_revision }}
-      swift_corelibs_foundation_revision: ${{ steps.context.outputs.swift_corelibs_foundation_revision }}
-      swift_corelibs_libdispatch_revision: ${{ steps.context.outputs.swift_corelibs_libdispatch_revision }}
-      swift_corelibs_xctest_revision: ${{ steps.context.outputs.swift_corelibs_xctest_revision }}
-      swift_crypto_revision: ${{ steps.context.outputs.swift_crypto_revision }}
-      swift_driver_revision: ${{ steps.context.outputs.swift_driver_revision }}
-      swift_experimental_string_processing_revision: ${{ steps.context.outputs.swift_experimental_string_processing_revision }}
-      swift_format_revision: ${{ steps.context.outputs.swift_format_revision }}
-      swift_foundation_revision: ${{ steps.context.outputs.swift_foundation_revision }}
-      swift_foundation_icu_revision: ${{ steps.context.outputs.swift_foundation_icu_revision }}
-      swift_installer_scripts_revision: ${{ steps.context.outputs.swift_installer_scripts_revision }}
-      swift_llbuild_revision: ${{ steps.context.outputs.swift_llbuild_revision }}
-      swift_markdown_revision: ${{ steps.context.outputs.swift_markdown_revision }}
-      swift_package_manager_revision: ${{ steps.context.outputs.swift_package_manager_revision }}
-      swift_revision: ${{ steps.context.outputs.swift_revision }}
-      swift_syntax_revision: ${{ steps.context.outputs.swift_syntax_revision }}
-      swift_system_revision: ${{ steps.context.outputs.swift_system_revision }}
-      swift_toolchain_sqlite_revision: ${{ steps.context.outputs.swift_toolchain_sqlite_revision }}
-      swift_toolchain_sqlite_version: ${{ steps.context.outputs.swift_toolchain_sqlite_version }}
-      swift_tools_support_core_revision: ${{ steps.context.outputs.swift_tools_support_core_revision }}
-      yams_revision: ${{ steps.context.outputs.yams_revision }}
-      zlib_revision: ${{ steps.context.outputs.zlib_revision }}
-      ANDROID_API_LEVEL: ${{ steps.context.outputs.ANDROID_API_LEVEL }}
-      WINDOWS_CMAKE_C_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
-      WINDOWS_CMAKE_CXX_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
-      WINDOWS_CMAKE_EXE_LINKER_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}
-      WINDOWS_CMAKE_SHARED_LINKER_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}
-      ANDROID_CMAKE_C_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}
-      ANDROID_CMAKE_CXX_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
-      ANDROID_CMAKE_EXE_LINKER_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}
-      ANDROID_CMAKE_SHARED_LINKER_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}
-      CMAKE_Swift_FLAGS: ${{ steps.context.outputs.CMAKE_Swift_FLAGS }}
-      debug_info: ${{ steps.context.outputs.debug_info }}
-      signed: ${{ steps.context.outputs.signed }}
-      swift_version: ${{ steps.context.outputs.swift_version }}
-      swift_tag: ${{ steps.context.outputs.swift_tag }}
-      default_build_runner: ${{ steps.context.outputs.windows_build_runner }}
-      compilers_build_runner: ${{ steps.context.outputs.compilers_build_runner }}
-    steps:
-      - id: context
-        name: Generate Build Context
-        run: |
-          # TODO(compnerd) can we make this more silent?
-          sudo DEBIAN_FRONTEND=noninteractive apt-get -qq update -yq
-          sudo DEBIAN_FRONTEND=noninteractive apt-get -qq -o Dpkg::Use-Pty=0 install -yq repo libxml2-utils
-
-          # Which branch is this workflow based on
-          branch_version_string=${{ inputs.swift_version || '0.0.0' }}
-          if [[ $branch_version_string == *.* ]]; then
-            branch_name=$(echo ${branch_version_string} | awk -F. '{ ver=$1"."$2; print (ver == "0.0") ? "main" : "release/"ver }')
-          else
-            branch_name="release/$branch_version_string"
-          fi
-
-          repo init --quiet --groups default --depth 1 -u https://github.com/compnerd/swift-build -b $branch_name
-          repo sync --quiet --no-clone-bundle --no-tags --jobs $(nproc --all)
-
-          if [[ "${{ inputs.swift_tag }}" != "" ]] ; then
-            tee -a "${GITHUB_OUTPUT}" <<-EOF
-          indexstore_db_revision=refs/tags/${{ inputs.swift_tag }}
-          llvm_project_revision=refs/tags/${{ inputs.swift_tag }}
-          sourcekit_lsp_revision=refs/tags/${{ inputs.swift_tag }}
-          swift_revision=refs/tags/${{ inputs.swift_tag }}
-          swift_argument_parser_revision=refs/tags/1.4.0
-          swift_asn1_revision=refs/tags/0.7.0
-          swift_atomics_revision=refs/tags/1.2.0
-          swift_certificates_revision=refs/tags/0.1.0
-          swift_cmark_revision=refs/tags/${{ inputs.swift_tag }}
-          swift_collections_revision=refs/tags/1.1.2
-          swift_corelibs_foundation_revision=refs/tags/${{ inputs.swift_tag }}
-          swift_corelibs_libdispatch_revision=refs/tags/${{ inputs.swift_tag }}
-          swift_corelibs_xctest_revision=refs/tags/${{ inputs.swift_tag }}
-          swift_crypto_revision=refs/tags/3.0.0
-          swift_driver_revision=refs/tags/${{ inputs.swift_tag }}
-          swift_experimental_string_processing_revision=refs/tags/${{ inputs.swift_tag }}
-          swift_format_revision=refs/heads/main
-          swift_foundation_revison=refs/heads/main
-          swift_foundation_icu_revision=refs/tags/0.0.8
-          swift_installer_scripts_revision=refs/heads/main
-          swift_llbuild_revision=refs/tags/${{ inputs.swift_tag }}
-          swift_markdown_revision=refs/tags/${{ inputs.swift_tag }}
-          swift_package_manager_revision=refs/tags/${{ inputs.swift_tag }}
-          swift_syntax_revision=refs/tags/${{ inputs.swift_tag }}
-          swift_system_revision=refs/tags/1.3.0
-          swift_toolchain_sqlite_revision=refs/tags/main
-          swift_toolchain_sqlite_version=3.46.0
-          swift_tools_support_core_revision=refs/tags/${{ inputs.swift_tag }}
-          curl_revision=refs/tags/curl-8_5_0
-          libxml2_revision=refs/tags/v2.11.5
-          yams_revision=refs/tags/5.0.6
-          zlib_revision=refs/tags/v1.3.1
-          EOF
-          else
-            repo manifest -r --suppress-upstream-revision --suppress-dest-branch | \
-                  xmllint --xpath "//project/@name | //project/@revision" - | \
-                  xargs -n2 | \
-                  awk -F'[= ]' '{
-                    split($2, repo, "/");
-                    gsub(/-/, "_", repo[2]);
-                    print tolower(repo[2]) "_revision=" $4
-                  }' | tee -a "${GITHUB_OUTPUT}"
-            repo manifest -r --suppress-upstream-revision --suppress-dest-branch -o - | sed -E 's,[[:space:]]+$,,' > stable.xml
-          fi
-
-          # FIXME(z2oh): Remove /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR when GitHub runner image updates to 20240610.1.
-          #  see: https://github.com/actions/runner-images/issues/10004
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.debug_info }}" == "true" ]]; then
-            echo debug_info=true >> ${GITHUB_OUTPUT}
-            echo WINDOWS_CMAKE_C_FLAGS="/GS- /Gw /Gy /Oi /Oy /Z7 /Zc:inline /Zc:preprocessor" >> ${GITHUB_OUTPUT}
-            echo WINDOWS_CMAKE_CXX_FLAGS="/GS- /Gw /Gy /Oi /Oy /Z7 /Zc:inline /Zc:preprocessor /Zc:__cplusplus /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" >> ${GITHUB_OUTPUT}
-            echo ANDROID_CMAKE_C_FLAGS="-ffunction-sections -fdata-sections -g" >> ${GITHUB_OUTPUT}
-            echo ANDROID_CMAKE_CXX_FLAGS="-ffunction-sections -fdata-sections -g" >> ${GITHUB_OUTPUT}
-            echo WINDOWS_CMAKE_EXE_LINKER_FLAGS="-incremental:no -debug -opt:ref -opt:icf" >> ${GITHUB_OUTPUT}
-            echo WINDOWS_CMAKE_SHARED_LINKER_FLAGS="-incremental:no -debug -opt:ref -opt:icf" >> ${GITHUB_OUTPUT}
-            echo CMAKE_Swift_FLAGS="-g -debug-info-format=codeview -Xlinker -debug -Xlinker -incremental:no -Xlinker -opt:ref -Xlinker -opt:icf" >> ${GITHUB_OUTPUT}
-          else
-            echo debug_info=false >> ${GITHUB_OUTPUT}
-            echo WINDOWS_CMAKE_C_FLAGS="/GS- /Gw /Gy /Oi /Oy /Zc:inline /Zc:preprocessor" >> ${GITHUB_OUTPUT}
-            echo WINDOWS_CMAKE_CXX_FLAGS="/GS- /Gw /Gy /Oi /Oy /Zc:inline /Zc:preprocessor /Zc:__cplusplus /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" >> ${GITHUB_OUTPUT}
-            echo ANDROID_CMAKE_C_FLAGS="-ffunction-sections -fdata-sections" >> ${GITHUB_OUTPUT}
-            echo ANDROID_CMAKE_CXX_FLAGS="-ffunction-sections -fdata-sections" >> ${GITHUB_OUTPUT}
-            echo WINDOWS_CMAKE_EXE_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
-            echo WINDOWS_CMAKE_SHARED_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
-            echo CMAKE_Swift_FLAGS="-Xlinker -incremental:no -Xlinker -opt:ref -Xlinker -opt:icf" >> ${GITHUB_OUTPUT}
-          fi
-          echo ANDROID_CMAKE_EXE_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
-          echo ANDROID_CMAKE_SHARED_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
-
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.signed }}" == "true" ]]; then
-            # FIXME(compnerd) enable this when requested
-            echo signed=false >> ${GITHUB_OUTPUT}
-          else
-            echo signed=false >> ${GITHUB_OUTPUT}
-          fi
-
-          echo swift_version=${{ inputs.swift_version || '0.0.0' }} | tee -a ${GITHUB_OUTPUT}
-          if [[ -n "${{ inputs.swift_tag }}" ]] ; then
-            echo swift_tag=${{ inputs.swift_tag }} | tee -a ${GITHUB_OUTPUT}
-          else
-            if [[ "$branch_name" == "main" ]] ; then
-              echo swift_tag=$(date +%Y%m%d.$(date +%-H/6 | bc)) | tee -a ${GITHUB_OUTPUT}
-            else
-              echo swift_tag=swift-"$branch_version_string"-$(date +%Y%m%d.$(date +%-H/6 | bc)) | tee -a ${GITHUB_OUTPUT}
-            fi
-          fi
-
-          echo windows_build_runner=${{ vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
-          echo compilers_build_runner=${{ vars.COMPILERS_BUILD_RUNNER || vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
-
-          echo ANDROID_API_LEVEL=${{ inputs.android_api_level }} >> ${GITHUB_OUTPUT}
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: stable.xml
-          path: stable.xml
-          if-no-files-found: ignore
-
   sqlite:
-    needs: [context]
-    runs-on: ${{ needs.context.outputs.default_build_runner }}
+    runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -263,16 +217,16 @@ jobs:
         include:
           - arch: amd64
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
 
           - arch: arm64
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
 
     name: ${{ matrix.os }} ${{ matrix.arch }} SQLite3
@@ -286,7 +240,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: swiftlang/swift-toolchain-sqlite
-          ref: ${{ needs.context.outputs.swift_toolchain_sqlite_revision }}
+          ref: ${{ inputs.swift_toolchain_sqlite_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-toolchain-sqlite
           show-progress: false
 
@@ -305,7 +259,7 @@ jobs:
 
       - name: Configure SQLite
         run: |
-          cmake -B ${{ github.workspace }}/BinaryCache/sqlite-${{ needs.context.outputs.swift_toolchain_sqlite_version }} `
+          cmake -B ${{ github.workspace }}/BinaryCache/sqlite-${{ inputs.swift_toolchain_sqlite_version }} `
                 -D BUILD_SHARED_LIBS=NO `
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${{ matrix.cc }} `
@@ -315,23 +269,22 @@ jobs:
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
                 -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
                 -D CMAKE_MT=mt `
-                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ needs.context.outputs.swift_toolchain_sqlite_version }}/usr `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr `
                 -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/swift-toolchain-sqlite
       - name: Build SQLite
-        run: cmake --build ${{ github.workspace }}/BinaryCache/sqlite-${{ needs.context.outputs.swift_toolchain_sqlite_version }}
+        run: cmake --build ${{ github.workspace }}/BinaryCache/sqlite-${{ inputs.swift_toolchain_sqlite_version }}
       - name: Install SQLite
-        run: cmake --build ${{ github.workspace }}/BinaryCache/sqlite-${{ needs.context.outputs.swift_toolchain_sqlite_version }} --target install
+        run: cmake --build ${{ github.workspace }}/BinaryCache/sqlite-${{ inputs.swift_toolchain_sqlite_version }} --target install
 
       - uses: actions/upload-artifact@v4
         with:
-          name: sqlite-${{ matrix.os }}-${{ matrix.arch }}-${{ needs.context.outputs.swift_toolchain_sqlite_version }}
-          path: ${{ github.workspace }}/BuildRoot/Library/sqlite-${{ needs.context.outputs.swift_toolchain_sqlite_version }}/usr
+          name: sqlite-${{ matrix.os }}-${{ matrix.arch }}-${{ inputs.swift_toolchain_sqlite_version }}
+          path: ${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr
 
   cmark_gfm:
-    needs: [context]
-    runs-on: ${{ needs.context.outputs.default_build_runner }}
+    runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -342,7 +295,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-cmark
-          ref: ${{ needs.context.outputs.swift_cmark_revision }}
+          ref: ${{ inputs.swift_cmark_revision }}
           path: ${{ github.workspace }}/SourceCache/cmark-gfm
           show-progress: false
 
@@ -367,10 +320,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_COMPILER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_COMPILER_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr `
                 -D CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=YES `
@@ -386,8 +339,8 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr
 
   build_tools:
-    needs: [context, cmark_gfm]
-    runs-on: ${{ needs.context.outputs.default_build_runner }}
+    needs: [cmark_gfm]
+    runs-on: ${{ inputs.default_build_runner }}
 
     steps:
       - uses: actions/download-artifact@v4
@@ -398,13 +351,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: apple/llvm-project
-          ref: ${{ needs.context.outputs.llvm_project_revision }}
+          ref: ${{ inputs.llvm_project_revision }}
           path: ${{ github.workspace }}/SourceCache/llvm-project
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift
-          ref: ${{ needs.context.outputs.swift_revision }}
+          ref: ${{ inputs.swift_revision }}
           path: ${{ github.workspace }}/SourceCache/swift
           show-progress: false
 
@@ -423,10 +376,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D cmark-gfm_DIR=${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr/lib/cmake `
                 -G Ninja `
@@ -488,8 +441,8 @@ jobs:
             ${{ github.workspace }}/BinaryCache/0/bin/swift-compatibility-symbols.exe
 
   compilers:
-    needs: [context, build_tools, cmark_gfm]
-    runs-on: ${{ needs.context.outputs.compilers_build_runner }}
+    needs: [build_tools, cmark_gfm]
+    runs-on: ${{ inputs.compilers_build_runner }}
 
     env:
       # Must be a full version string from https://www.nuget.org/packages/pythonarm64
@@ -520,31 +473,31 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: apple/llvm-project
-          ref: ${{ needs.context.outputs.llvm_project_revision }}
+          ref: ${{ inputs.llvm_project_revision }}
           path: ${{ github.workspace }}/SourceCache/llvm-project
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift
-          ref: ${{ needs.context.outputs.swift_revision }}
+          ref: ${{ inputs.swift_revision }}
           path: ${{ github.workspace }}/SourceCache/swift
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-experimental-string-processing
-          ref: ${{ needs.context.outputs.swift_experimental_string_processing_revision }}
+          ref: ${{ inputs.swift_experimental_string_processing_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-experimental-string-processing
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-syntax
-          ref: ${{ needs.context.outputs.swift_syntax_revision }}
+          ref: ${{ inputs.swift_syntax_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-syntax
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-corelibs-libdispatch
-          ref: ${{ needs.context.outputs.swift_corelibs_libdispatch_revision }}
+          ref: ${{ inputs.swift_corelibs_libdispatch_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch
           show-progress: false
 
@@ -622,17 +575,17 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }} -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" `
+                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }} -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_Swift_COMPILER="${SWIFTC}" `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk `"${SDKROOT}`" -Xcc -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" `
-                -D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" `
+                -D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
-                -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}" `
+                -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}" `
                 ${CMAKE_SYSTEM_NAME} `
                 ${CMAKE_SYSTEM_PROCESSOR} `
                 -G Ninja `
@@ -711,7 +664,7 @@ jobs:
 
       # TODO(compnerd) this takes ~1h due to the size, see if we can compress first
       - uses: actions/upload-artifact@v4
-        if: false # ${{ needs.context.outputs.debug_info }}
+        if: false # ${{ inputs.debug_info }}
         with:
           name: compilers-${{ matrix.arch }}-debug-info
           path: |
@@ -719,7 +672,7 @@ jobs:
 
       - name: Upload PDBs to Azure
         uses: microsoft/action-publish-symbols@v2.1.6
-        if: ${{ needs.context.outputs.debug_info }}
+        if: ${{ inputs.debug_info }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -728,7 +681,7 @@ jobs:
 
       - name: Upload DLLs to Azure
         uses: microsoft/action-publish-symbols@v2.1.6
-        if: ${{ needs.context.outputs.debug_info }}
+        if: ${{ inputs.debug_info }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -737,7 +690,7 @@ jobs:
 
       - name: Upload EXEs to Azure
         uses: microsoft/action-publish-symbols@v2.1.6
-        if: ${{ needs.context.outputs.debug_info }}
+        if: ${{ inputs.debug_info }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -745,8 +698,7 @@ jobs:
           searchPattern: '**/*.exe'
 
   zlib:
-    needs: [context]
-    runs-on: ${{ needs.context.outputs.default_build_runner }}
+    runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -754,59 +706,59 @@ jobs:
         include:
           - arch: amd64
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: arm64
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: x86
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: arm64
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
             os: Android
-            extra_flags: -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a
+            extra_flags: -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a
 
           - arch: armv7
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
             os: Android
-            extra_flags: -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a
+            extra_flags: -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a
 
           - arch: i686
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
             os: Android
-            extra_flags: -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86
+            extra_flags: -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86
 
           - arch: x86_64
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
             os: Android
-            extra_flags: -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86_64
+            extra_flags: -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86_64
 
     name: ${{ matrix.os }} ${{ matrix.arch }} zlib
 
@@ -814,7 +766,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: madler/zlib
-          ref: ${{ needs.context.outputs.zlib_revision }}
+          ref: ${{ inputs.zlib_revision }}
           path: ${{ github.workspace }}/SourceCache/zlib
           show-progress: false
 
@@ -868,8 +820,8 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library/zlib-1.3/usr
 
   curl:
-    needs: [context, zlib]
-    runs-on: ${{ needs.context.outputs.default_build_runner }}
+    needs: [zlib]
+    runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -877,59 +829,59 @@ jobs:
         include:
           - arch: amd64
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: arm64
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: x86
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: arm64
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
             os: Android
-            extra_flags: -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a
+            extra_flags: -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a
 
           - arch: armv7
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
             os: Android
-            extra_flags: -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a
+            extra_flags: -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a
 
           - arch: i686
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
             os: Android
-            extra_flags: -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86
+            extra_flags: -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86
 
           - arch: x86_64
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
             os: Android
-            extra_flags: -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86_64
+            extra_flags: -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86_64
 
     name: ${{ matrix.os }} ${{ matrix.arch }} curl
 
@@ -937,7 +889,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: curl/curl
-          ref: ${{ needs.context.outputs.curl_revision }}
+          ref: ${{ inputs.curl_revision }}
           path: ${{ github.workspace }}/SourceCache/curl
           show-progress: false
 
@@ -1073,8 +1025,7 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library/curl-8.9.1/usr
 
   libxml2:
-    needs: [context]
-    runs-on: ${{ needs.context.outputs.default_build_runner }}
+    runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -1082,59 +1033,59 @@ jobs:
         include:
           - arch: amd64
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: arm64
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: x86
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: arm64
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
             os: Android
-            extra_flags: -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a
+            extra_flags: -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a
 
           - arch: armv7
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
             os: Android
-            extra_flags: -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a
+            extra_flags: -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a
 
           - arch: i686
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
             os: Android
-            extra_flags: -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86
+            extra_flags: -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86
 
           - arch: x86_64
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
             os: Android
-            extra_flags: -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86_64
+            extra_flags: -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86_64
 
     name: ${{ matrix.os }} ${{ matrix.arch }} libxml2
 
@@ -1142,7 +1093,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: gnome/libxml2
-          ref: ${{ needs.context.outputs.libxml2_revision }}
+          ref: ${{ inputs.libxml2_revision }}
           path: ${{ github.workspace }}/SourceCache/libxml2
           show-progress: false
 
@@ -1202,8 +1153,8 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library/libxml2-2.11.5/usr
 
   stdlib:
-    needs: [context, compilers, cmark_gfm]
-    runs-on: ${{ needs.context.outputs.default_build_runner }}
+    needs: [compilers, cmark_gfm]
+    runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -1214,13 +1165,13 @@ jobs:
             triple: 'x86_64-unknown-windows-msvc'
             triple_no_api_level: 'x86_64-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
-            swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
+            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            swiftflags: ${{ inputs.CMAKE_Swift_FLAGS }}
             os: Windows
             llvm_flags:
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags:
 
           - arch: arm64
@@ -1228,13 +1179,13 @@ jobs:
             triple: 'aarch64-unknown-windows-msvc'
             triple_no_api_level: 'aarch64-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
-            swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
+            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            swiftflags: ${{ inputs.CMAKE_Swift_FLAGS }}
             os: Windows
             llvm_flags:
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags: 
 
           - arch: x86
@@ -1242,70 +1193,70 @@ jobs:
             triple: 'i686-unknown-windows-msvc'
             triple_no_api_level: 'i686-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
-            swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
+            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            swiftflags: ${{ inputs.CMAKE_Swift_FLAGS }}
             os: Windows
             llvm_flags:
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags: 
 
           - arch: arm64
             cpu: 'aarch64'
-            triple: 'aarch64-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }}'
+            triple: 'aarch64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}'
             triple_no_api_level: aarch64-unknown-linux-android
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
-            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker aarch64-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
+            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker aarch64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
             os: Android
-            llvm_flags: -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DLLVM_HOST_TRIPLE=aarch64-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }}
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
-            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a
+            llvm_flags: -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DLLVM_HOST_TRIPLE=aarch64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
+            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a
 
           - arch: armv7
             cpu: armv7
-            triple: 'armv7a-unknown-linux-androideabi${{ needs.context.outputs.ANDROID_API_LEVEL }}'
+            triple: 'armv7a-unknown-linux-androideabi${{ inputs.ANDROID_API_LEVEL }}'
             triple_no_api_level: armv7-unknown-linux-androideabi
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
-            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker armv7a-unknown-linux-androideabi${{ needs.context.outputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
+            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker armv7a-unknown-linux-androideabi${{ inputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
             os: Android
-            llvm_flags: -DCMAKE_SYSTEM_PROCESSOR=armv7-a -DLLVM_HOST_TRIPLE=armv7a-unknown-linux-androideabi${{ needs.context.outputs.ANDROID_API_LEVEL }}
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
-            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a
+            llvm_flags: -DCMAKE_SYSTEM_PROCESSOR=armv7-a -DLLVM_HOST_TRIPLE=armv7a-unknown-linux-androideabi${{ inputs.ANDROID_API_LEVEL }}
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
+            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a
 
           - arch: i686
             cpu: i686
-            triple: 'i686-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }}'
+            triple: 'i686-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}'
             triple_no_api_level: i686-unknown-linux-android
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
-            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker i686-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
+            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker i686-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
             os: Android
-            llvm_flags: -DCMAKE_SYSTEM_PROCESSOR=i686 -DLLVM_HOST_TRIPLE=i686-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }}
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
-            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86
+            llvm_flags: -DCMAKE_SYSTEM_PROCESSOR=i686 -DLLVM_HOST_TRIPLE=i686-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
+            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86
 
           - arch: x86_64
             cpu: 'x86_64'
-            triple: 'x86_64-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }}'
+            triple: 'x86_64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}'
             triple_no_api_level: x86_64-unknown-linux-android
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
-            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker x86_64-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
+            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker x86_64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
             os: Android
-            llvm_flags: -DCMAKE_SYSTEM_PROCESSOR=x86_64 -DLLVM_HOST_TRIPLE=x86_64-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }}
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
-            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86_64
+            llvm_flags: -DCMAKE_SYSTEM_PROCESSOR=x86_64 -DLLVM_HOST_TRIPLE=x86_64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
+            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86_64
 
     name: ${{ matrix.os }} ${{ matrix.arch }} Standard Library
 
@@ -1326,25 +1277,25 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: apple/llvm-project
-          ref: ${{ needs.context.outputs.llvm_project_revision }}
+          ref: ${{ inputs.llvm_project_revision }}
           path: ${{ github.workspace }}/SourceCache/llvm-project
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift
-          ref: ${{ needs.context.outputs.swift_revision }}
+          ref: ${{ inputs.swift_revision }}
           path: ${{ github.workspace }}/SourceCache/swift
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-corelibs-libdispatch
-          ref: ${{ needs.context.outputs.swift_corelibs_libdispatch_revision }}
+          ref: ${{ inputs.swift_corelibs_libdispatch_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-experimental-string-processing
-          ref: ${{ needs.context.outputs.swift_experimental_string_processing_revision }}
+          ref: ${{ inputs.swift_experimental_string_processing_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-experimental-string-processing
           show-progress: false
 
@@ -1471,7 +1422,7 @@ jobs:
 
       - name: Upload PDBs to Azure
         uses: microsoft/action-publish-symbols@v2.1.6
-        if: ${{ needs.context.outputs.debug_info && matrix.os == 'Windows' }}
+        if: ${{ inputs.debug_info && matrix.os == 'Windows' }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -1480,7 +1431,7 @@ jobs:
 
       - name: Upload DLLs to Azure
         uses: microsoft/action-publish-symbols@v2.1.6
-        if: ${{ needs.context.outputs.debug_info && matrix.os == 'Windows' }}
+        if: ${{ inputs.debug_info && matrix.os == 'Windows' }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -1488,8 +1439,8 @@ jobs:
           searchPattern: '**/*.dll'
 
   macros:
-    needs: [context, compilers, cmark_gfm, stdlib]
-    runs-on: ${{ needs.context.outputs.default_build_runner }}
+    needs: [compilers, cmark_gfm, stdlib]
+    runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -1540,13 +1491,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: apple/swift
-          ref: ${{ needs.context.outputs.swift_revision }}
+          ref: ${{ inputs.swift_revision }}
           path: ${{ github.workspace }}/SourceCache/swift
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-foundation
-          ref: ${{ needs.context.outputs.swift_foundation_revision }}
+          ref: ${{ inputs.swift_foundation_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-foundation
           show-progress: false
 
@@ -1577,7 +1528,7 @@ jobs:
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay ${WINDOWS_VFS_OVERLAY} -strict-implicit-module-context -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules ${{ needs.context.otuputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift -L${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows -vfsoverlay ${WINDOWS_VFS_OVERLAY} -strict-implicit-module-context -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
@@ -1598,7 +1549,7 @@ jobs:
 
       - name: Upload PDBs to Azure
         uses: microsoft/action-publish-symbols@v2.1.6
-        if: ${{ needs.context.outputs.debug_info }}
+        if: ${{ inputs.debug_info }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -1607,7 +1558,7 @@ jobs:
 
       - name: Upload DLLs to Azure
         uses: microsoft/action-publish-symbols@v2.1.6
-        if: ${{ needs.context.outputs.debug_info }}
+        if: ${{ inputs.debug_info }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -1616,7 +1567,7 @@ jobs:
 
       - name: Upload EXEs to Azure
         uses: microsoft/action-publish-symbols@v2.1.6
-        if: ${{ needs.context.outputs.debug_info }}
+        if: ${{ inputs.debug_info }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -1625,8 +1576,8 @@ jobs:
 
   sdk:
     continue-on-error: ${{ matrix.arch != 'amd64' }}
-    needs: [context, libxml2, curl, zlib, compilers, cmark_gfm, stdlib, macros]
-    runs-on: ${{ needs.context.outputs.default_build_runner }}
+    needs: [libxml2, curl, zlib, compilers, cmark_gfm, stdlib, macros]
+    runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -1637,12 +1588,12 @@ jobs:
             triple: 'x86_64-unknown-windows-msvc'
             triple_no_api_level: 'x86_64-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
-            swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
+            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            swiftflags: ${{ inputs.CMAKE_Swift_FLAGS }}
             os: Windows
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags:
 
           - arch: arm64
@@ -1650,12 +1601,12 @@ jobs:
             triple: 'aarch64-unknown-windows-msvc'
             triple_no_api_level: 'aarch64-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
-            swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
+            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            swiftflags: ${{ inputs.CMAKE_Swift_FLAGS }}
             os: Windows
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags:
 
           - arch: x86
@@ -1663,65 +1614,65 @@ jobs:
             triple: 'i686-unknown-windows-msvc'
             triple_no_api_level: 'i686-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
-            swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
+            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            swiftflags: ${{ inputs.CMAKE_Swift_FLAGS }}
             os: Windows
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags:
 
           - arch: arm64
             cpu: 'aarch64'
-            triple: 'aarch64-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }}'
+            triple: 'aarch64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}'
             triple_no_api_level: aarch64-unknown-linux-android
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
-            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker aarch64-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
+            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker aarch64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
             os: Android
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
-            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
+            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a
 
           - arch: armv7
             cpu: armv7
-            triple: 'armv7a-unknown-linux-androideabi${{ needs.context.outputs.ANDROID_API_LEVEL }}'
+            triple: 'armv7a-unknown-linux-androideabi${{ inputs.ANDROID_API_LEVEL }}'
             triple_no_api_level: armv7-unknown-linux-androideabi
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
-            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker armv7a-unknown-linux-androideabi${{ needs.context.outputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
+            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker armv7a-unknown-linux-androideabi${{ inputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
             os: Android
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
-            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
+            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a
 
           - arch: i686
             cpu: i686
-            triple: 'i686-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }}'
+            triple: 'i686-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}'
             triple_no_api_level: i686-unknown-linux-android
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
-            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker i686-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
+            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker i686-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
             os: Android
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
-            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
+            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86
 
           - arch: x86_64
             cpu: 'x86_64'
-            triple: 'x86_64-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }}'
+            triple: 'x86_64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}'
             triple_no_api_level: x86_64-unknown-linux-android
             cc: clang
-            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
             cxx: clang++
-            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
-            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker x86_64-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
+            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker x86_64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
             os: Android
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
-            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86_64
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
+            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86_64
 
     name: ${{ matrix.os }} ${{ matrix.arch }} SDK
 
@@ -1772,7 +1723,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-corelibs-libdispatch
-          ref: ${{ needs.context.outputs.swift_corelibs_libdispatch_revision }}
+          ref: ${{ inputs.swift_corelibs_libdispatch_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch
           show-progress: false
       - uses: actions/checkout@v4
@@ -1786,31 +1737,31 @@ jobs:
         if: matrix.os == 'Windows'
         with:
           repository: apple/swift-corelibs-foundation
-          ref: ${{ needs.context.outputs.swift_corelibs_foundation_revision }}
+          ref: ${{ inputs.swift_corelibs_foundation_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-corelibs-foundation
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-foundation
-          ref: ${{ needs.context.outputs.swift_foundation_revision }}
+          ref: ${{ inputs.swift_foundation_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-foundation
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-foundation-icu
-          ref: ${{ needs.context.outputs.swift_foundation_icu_revision }}
+          ref: ${{ inputs.swift_foundation_icu_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-foundation-icu
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-collections
-          ref: ${{ needs.context.outputs.swift_collections_revision }}
+          ref: ${{ inputs.swift_collections_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-collections
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-corelibs-xctest
-          ref: ${{ needs.context.outputs.swift_corelibs_xctest_revision }}
+          ref: ${{ inputs.swift_corelibs_xctest_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-corelibs-xctest
           show-progress: false
 
@@ -1914,7 +1865,7 @@ jobs:
                 -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" `
+                -D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2027,7 +1978,7 @@ jobs:
 
       - name: Upload PDBs to Azure
         uses: microsoft/action-publish-symbols@v2.1.6
-        if: ${{ needs.context.outputs.debug_info && matrix.os == 'Windows' }}
+        if: ${{ inputs.debug_info && matrix.os == 'Windows' }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -2036,7 +1987,7 @@ jobs:
 
       - name: Upload DLLs to Azure
         uses: microsoft/action-publish-symbols@v2.1.6
-        if: ${{ needs.context.outputs.debug_info && matrix.os == 'Windows' }}
+        if: ${{ inputs.debug_info && matrix.os == 'Windows' }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -2044,8 +1995,8 @@ jobs:
           searchPattern: '**/*.dll'
 
   devtools:
-    needs: [context, sqlite, compilers, stdlib, sdk]
-    runs-on: ${{ needs.context.outputs.default_build_runner }}
+    needs: [sqlite, compilers, stdlib, sdk]
+    runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -2062,8 +2013,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: sqlite-Windows-${{ matrix.arch }}-${{ needs.context.outputs.swift_toolchain_sqlite_version }}
-          path: ${{ github.workspace }}/BuildRoot/Library/sqlite-${{ needs.context.outputs.swift_toolchain_sqlite_version }}/usr
+          name: sqlite-Windows-${{ matrix.arch }}-${{ inputs.swift_toolchain_sqlite_version }}
+          path: ${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr
       - name: Download Compilers
         uses: actions/download-artifact@v4
         with:
@@ -2100,97 +2051,97 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: apple/indexstore-db
-          ref: ${{ needs.context.outputs.indexstore_db_revision }}
+          ref: ${{ inputs.indexstore_db_revision }}
           path: ${{ github.workspace }}/SourceCache/indexstore-db
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/sourcekit-lsp
-          ref: ${{ needs.context.outputs.sourcekit_lsp_revision }}
+          ref: ${{ inputs.sourcekit_lsp_revision }}
           path: ${{ github.workspace }}/SourceCache/sourcekit-lsp
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-argument-parser
-          ref: ${{ needs.context.outputs.swift_argument_parser_revision }}
+          ref: ${{ inputs.swift_argument_parser_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-argument-parser
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-asn1
-          ref: ${{ needs.context.outputs.swift_asn1_revision }}
+          ref: ${{ inputs.swift_asn1_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-asn1
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-certificates
-          ref: ${{ needs.context.outputs.swift_certificates_revision }}
+          ref: ${{ inputs.swift_certificates_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-certificates
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-collections
-          ref: ${{ needs.context.outputs.swift_collections_revision }}
+          ref: ${{ inputs.swift_collections_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-collections
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-crypto
-          ref: ${{ needs.context.outputs.swift_crypto_revision }}
+          ref: ${{ inputs.swift_crypto_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-crypto
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-driver
-          ref: ${{ needs.context.outputs.swift_driver_revision }}
+          ref: ${{ inputs.swift_driver_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-driver
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-format
-          ref: ${{ needs.context.outputs.swift_format_revision }}
+          ref: ${{ inputs.swift_format_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-format
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-llbuild
-          ref: ${{ needs.context.outputs.swift_llbuild_revision }}
+          ref: ${{ inputs.swift_llbuild_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-llbuild
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-markdown
-          ref: ${{ needs.context.outputs.swift_markdown_revision }}
+          ref: ${{ inputs.swift_markdown_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-markdown
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-package-manager
-          ref: ${{ needs.context.outputs.swift_package_manager_revision }}
+          ref: ${{ inputs.swift_package_manager_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-package-manager
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-system
-          ref: ${{ needs.context.outputs.swift_system_revision }}
+          ref: ${{ inputs.swift_system_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-system
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-tools-support-core
-          ref: ${{ needs.context.outputs.swift_tools_support_core_revision }}
+          ref: ${{ inputs.swift_tools_support_core_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-tools-support-core
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: jpsim/Yams
-          ref: ${{ needs.context.outputs.yams_revision }}
+          ref: ${{ inputs.yams_revision }}
           path: ${{ github.workspace }}/SourceCache/Yams
           show-progress: false
       - uses: actions/checkout@v4
         with:
           repository: apple/swift
-          ref: ${{ needs.context.outputs.swift_revision }}
+          ref: ${{ inputs.swift_revision }}
           path: ${{ github.workspace }}/SourceCache/swift
           show-progress: false
 
@@ -2235,16 +2186,16 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
@@ -2265,16 +2216,16 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
@@ -2294,16 +2245,16 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
@@ -2323,16 +2274,16 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
@@ -2352,24 +2303,24 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/swift-llbuild `
                 -D LLBUILD_SUPPORT_BINDINGS=Swift `
-                -D SQLite3_LIBRARY=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ needs.context.outputs.swift_toolchain_sqlite_version }}/usr/lib/SQLite3.lib `
-                -D SQLite3_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ needs.context.outputs.swift_toolchain_sqlite_version }}/usr/include
+                -D SQLite3_LIBRARY=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/lib/SQLite3.lib `
+                -D SQLite3_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/include
       - name: Build swift-llbuild
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-llbuild
 
@@ -2385,16 +2336,16 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
@@ -2415,24 +2366,24 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/swift-tools-support-core `
                 -D SwiftSystem_DIR=${{ github.workspace }}/BinaryCache/swift-system/cmake/modules `
-                -D SQLite3_LIBRARY=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ needs.context.outputs.swift_toolchain_sqlite_version }}/usr/lib/SQLite3.lib `
-                -D SQLite3_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ needs.context.outputs.swift_toolchain_sqlite_version }}/usr/include
+                -D SQLite3_LIBRARY=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/lib/SQLite3.lib `
+                -D SQLite3_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/include
       - name: Build swift-tools-support-core
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-tools-support-core
 
@@ -2448,16 +2399,16 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
@@ -2466,8 +2417,8 @@ jobs:
                 -D ArgumentParser_DIR=${{ github.workspace }}/BinaryCache/swift-argument-parser/cmake/modules `
                 -D LLBuild_DIR=${{ github.workspace }}/BinaryCache/swift-llbuild/cmake/modules `
                 -D SwiftSystem_DIR=${{ github.workspace }}/BinaryCache/swift-system/cmake/modules `
-                -D SQLite3_LIBRARY=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ needs.context.outputs.swift_toolchain_sqlite_version }}/usr/lib/SQLite3.lib `
-                -D SQLite3_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ needs.context.outputs.swift_toolchain_sqlite_version }}/usr/include `
+                -D SQLite3_LIBRARY=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/lib/SQLite3.lib `
+                -D SQLite3_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/include `
                 -D TSC_DIR=${{ github.workspace }}/BinaryCache/swift-tools-support-core/cmake/modules `
                 -D Yams_DIR=${{ github.workspace }}/BinaryCache/yams/cmake/modules
       - name: Build swift-driver
@@ -2535,16 +2486,16 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
@@ -2552,8 +2503,8 @@ jobs:
                 -S ${{ github.workspace }}/SourceCache/swift-package-manager `
                 -D ArgumentParser_DIR=${{ github.workspace }}/BinaryCache/swift-argument-parser/cmake/modules `
                 -D LLBuild_DIR=${{ github.workspace }}/BinaryCache/swift-llbuild/cmake/modules `
-                -D SQLite3_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ needs.context.outputs.swift_toolchain_sqlite_version }}/usr/include `
-                -D SQLite3_LIBRARY=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ needs.context.outputs.swift_toolchain_sqlite_version }}/usr/lib/SQLite3.lib `
+                -D SQLite3_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/include `
+                -D SQLite3_LIBRARY=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/lib/SQLite3.lib `
                 -D SwiftASN1_DIR=${{ github.workspace }}/BinaryCache/swift-asn1/cmake/modules `
                 -D SwiftCertificates_DIR=${{ github.workspace }}/BinaryCache/swift-certificates/cmake/modules `
                 -D SwiftCollections_DIR=${{ github.workspace }}/BinaryCache/swift-collections/cmake/modules `
@@ -2578,11 +2529,11 @@ jobs:
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
@@ -2605,11 +2556,11 @@ jobs:
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
@@ -2634,16 +2585,16 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }} -Xclang -fno-split-cold-code" `
+                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }} -Xclang -fno-split-cold-code" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }} -Xclang -fno-split-cold-code -I ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/include -I ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/include/Block" `
+                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }} -Xclang -fno-split-cold-code -I ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/include -I ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/include/Block" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
@@ -2664,16 +2615,16 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }} -Xclang -fno-split-cold-code" `
+                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }} -Xclang -fno-split-cold-code" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }} -Xclang -fno-split-cold-code" `
+                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }} -Xclang -fno-split-cold-code" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
@@ -2717,7 +2668,7 @@ jobs:
 
       - name: Upload PDBs to Azure
         uses: microsoft/action-publish-symbols@v2.1.6
-        if: ${{ needs.context.outputs.debug_info }}
+        if: ${{ inputs.debug_info }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -2726,7 +2677,7 @@ jobs:
 
       - name: Upload DLLs to Azure
         uses: microsoft/action-publish-symbols@v2.1.6
-        if: ${{ needs.context.outputs.debug_info }}
+        if: ${{ inputs.debug_info }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -2735,7 +2686,7 @@ jobs:
 
       - name: Upload EXEs to Azure
         uses: microsoft/action-publish-symbols@v2.1.6
-        if: ${{ needs.context.outputs.debug_info }}
+        if: ${{ inputs.debug_info }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -2745,8 +2696,8 @@ jobs:
 
   debugging_tools:
     name: Debugging Tools
-    needs: [context, compilers, devtools, stdlib, sdk]
-    runs-on: ${{ needs.context.outputs.default_build_runner }}
+    needs: [compilers, devtools, stdlib, sdk]
+    runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -2853,7 +2804,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: apple/swift
-          ref: ${{ needs.context.outputs.swift_revision }}
+          ref: ${{ inputs.swift_revision }}
           path: ${{ github.workspace }}/SourceCache/swift
           show-progress: false
 
@@ -2887,8 +2838,8 @@ jobs:
 
   package_tools:
     name: Package Tools
-    needs: [context, compilers, macros, debugging_tools, devtools]
-    runs-on: ${{ needs.context.outputs.main_build_runner }}
+    needs: [compilers, macros, debugging_tools, devtools]
+    runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -2932,7 +2883,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-installer-scripts
-          ref: ${{ needs.context.outputs.swift_installer_scripts_revision }}
+          ref: ${{ inputs.swift_installer_scripts_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 
@@ -2948,7 +2899,7 @@ jobs:
           Set-Content -Path $CertificatePath -Value '${{ secrets.CERTIFICATE }}'
           certutil -decode $CertificatePath $PFXPath
           Echo CERTIFICATE=$PFXPath | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
-        if: ${{ needs.context.outputs.signed }}
+        if: ${{ inputs.signed }}
 
       - name: Install WixToolset.Sdk
         run: |
@@ -2964,13 +2915,13 @@ jobs:
           msbuild -nologo -restore -maxCpuCount `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
               -p:Configuration=Release `
-              -p:SignOutput=${{ needs.context.outputs.signed }} `
+              -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:DEVTOOLS_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
               -p:TOOLCHAIN_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
               -p:ProductArchitecture=${{ matrix.arch }} `
-              -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
+              -p:ProductVersion=${{ inputs.swift_version }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bld/bld.wixproj
 
       - name: Package CLI Tools
@@ -2978,13 +2929,13 @@ jobs:
           msbuild -nologo -restore -maxCpuCount `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
               -p:Configuration=Release `
-              -p:SignOutput=${{ needs.context.outputs.signed }} `
+              -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:DEVTOOLS_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
               -p:TOOLCHAIN_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
               -p:ProductArchitecture=${{ matrix.arch }} `
-              -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
+              -p:ProductVersion=${{ inputs.swift_version }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/cli/cli.wixproj
 
       - name: Package Debugging Tools
@@ -2992,7 +2943,7 @@ jobs:
           msbuild -nologo -restore -maxCpuCount `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
               -p:Configuration=Release `
-              -p:SignOutput=${{ needs.context.outputs.signed }} `
+              -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:DEVTOOLS_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
@@ -3000,7 +2951,7 @@ jobs:
               -p:INCLUDE_SWIFT_INSPECT=true `
               -p:SWIFT_INSPECT_BUILD=${{ github.workspace }}/BuildRoot/DebuggingTools/swift-inspect `
               -p:ProductArchitecture=${{ matrix.arch }} `
-              -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
+              -p:ProductVersion=${{ inputs.swift_version }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/dbg/dbg.wixproj
 
       - name: Package IDE Tools
@@ -3008,13 +2959,13 @@ jobs:
           msbuild -nologo -restore -maxCpuCount `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
               -p:Configuration=Release `
-              -p:SignOutput=${{ needs.context.outputs.signed }} `
+              -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:DEVTOOLS_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
               -p:TOOLCHAIN_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain `
               -p:ProductArchitecture=${{ matrix.arch }} `
-              -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
+              -p:ProductVersion=${{ inputs.swift_version }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/ide/ide.wixproj
 
       - uses: actions/upload-artifact@v4
@@ -3047,8 +2998,8 @@ jobs:
 
   package_sdk_runtime:
     name: Package Windows SDK & Runtime
-    needs: [context, stdlib, sdk]
-    runs-on: ${{ needs.context.outputs.default_build_runner }}
+    needs: [stdlib, sdk]
+    runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -3070,7 +3021,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-installer-scripts
-          ref: ${{ needs.context.outputs.swift_installer_scripts_revision }}
+          ref: ${{ inputs.swift_installer_scripts_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 
@@ -3086,7 +3037,7 @@ jobs:
           Set-Content -Path $CertificatePath -Value '${{ secrets.CERTIFICATE }}'
           certutil.exe -decode $CertificatePath $PFXPath
           Write-Output CERTIFICATE=$PFXPath | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
-        if: ${{ needs.context.outputs.signed }}
+        if: ${{ inputs.signed }}
 
       - name: Install WixToolset.Sdk
         run: |
@@ -3102,12 +3053,12 @@ jobs:
           msbuild -nologo -restore -maxCpuCount `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
               -p:Configuration=Release `
-              -p:SignOutput=${{ needs.context.outputs.signed }} `
+              -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:PLATFORM_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform `
               -p:SDK_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk `
-              -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
+              -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/sdk/sdk.wixproj
 
@@ -3116,12 +3067,12 @@ jobs:
           msbuild -nologo -restore -maxCpuCount `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
               -p:Configuration=Release `
-              -p:SignOutput=${{ needs.context.outputs.signed }} `
+              -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:PLATFORM_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform `
               -p:SDK_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk `
-              -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
+              -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
               -p:VCRedistDir="${env:VCToolsRedistDir}\${env:VSCMD_ARG_TGT_ARCH}\Microsoft.VC143.CRT\" `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/rtl/msi/rtlmsi.wixproj
@@ -3147,8 +3098,8 @@ jobs:
 
   package_android_sdk:
     name: Package Android SDK & Runtime
-    needs: [context, stdlib, sdk]
-    runs-on: ${{ needs.context.outputs.default_build_runner }}
+    needs: [stdlib, sdk]
+    runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -3172,7 +3123,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-installer-scripts
-          ref: ${{ needs.context.outputs.swift_installer_scripts_revision }}
+          ref: ${{ inputs.swift_installer_scripts_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 
@@ -3188,7 +3139,7 @@ jobs:
           Set-Content -Path $CertificatePath -Value '${{ secrets.CERTIFICATE }}'
           certutil.exe -decode $CertificatePath $PFXPath
           Write-Output CERTIFICATE=$PFXPath | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
-        if: ${{ needs.context.outputs.signed }}
+        if: ${{ inputs.signed }}
 
       - name: Install WixToolset.Sdk
         run: |
@@ -3204,12 +3155,12 @@ jobs:
           msbuild -nologo -restore -maxCpuCount `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
               -p:Configuration=Release `
-              -p:SignOutput=${{ needs.context.outputs.signed }} `
+              -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:PLATFORM_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Android.platform `
               -p:SDK_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Android.platform/Developer/SDKs/Android.sdk `
-              -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
+              -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.cpu }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/android_sdk/android_sdk.wixproj
 
@@ -3221,8 +3172,8 @@ jobs:
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.cpu }}/android_sdk.${{ matrix.cpu }}.cab
 
   installer:
-    needs: [context, package_tools, package_sdk_runtime, package_android_sdk]
-    runs-on: ${{ needs.context.outputs.default_build_runner }}
+    needs: [package_tools, package_sdk_runtime, package_android_sdk]
+    runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -3296,7 +3247,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-installer-scripts
-          ref: ${{ needs.context.outputs.swift_installer_scripts_revision }}
+          ref: ${{ inputs.swift_installer_scripts_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 
@@ -3312,7 +3263,7 @@ jobs:
           Set-Content -Path $CertificatePath -Value '${{ secrets.CERTIFICATE }}'
           certutil -decode $CertificatePath $PFXPath
           Echo CERTIFICATE=$PFXPath | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
-        if: ${{ needs.context.outputs.signed }}
+        if: ${{ inputs.signed }}
 
       # The installer bundle needs the shared project for localization strings,
       # but it won't build the dependency on its own due to -p:BuildProjectReferences=false.
@@ -3321,11 +3272,11 @@ jobs:
           msbuild -nologo -restore -maxCpuCount `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
               -p:Configuration=Release `
-              -p:SignOutput=${{ needs.context.outputs.signed }} `
+              -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
-              -p:ProductVersion=${{ needs.context.outputs.swift_version }}-${{ needs.context.outputs.swift_tag }} `
+              -p:ProductVersion=${{ inputs.swift_version }}-${{ inputs.swift_tag }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/shared/shared.wixproj
 
       - name: Build installer bundle
@@ -3334,7 +3285,7 @@ jobs:
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
               -p:Configuration=Release `
               -p:BuildProjectReferences=false `
-              -p:SignOutput=${{ needs.context.outputs.signed }} `
+              -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:BundleFlavor=offline `
@@ -3346,7 +3297,7 @@ jobs:
               -p:ANDROID_INCLUDE_ARM_SDK=true `
               -p:ANDROID_INCLUDE_X86_SDK=true `
               -p:ProductArchitecture=${{ matrix.arch }} `
-              -p:ProductVersion=${{ needs.context.outputs.swift_version }}-${{ needs.context.outputs.swift_tag }} `
+              -p:ProductVersion=${{ inputs.swift_version }}-${{ inputs.swift_tag }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bundle/installer.wixproj
 
       - uses: actions/upload-artifact@v4
@@ -3355,8 +3306,8 @@ jobs:
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/installer.exe
 
   smoke_test:
-    needs: [context, installer]
-    runs-on: ${{ needs.context.outputs.default_build_runner }}
+    needs: [installer]
+    runs-on: ${{ inputs.default_build_runner }}
 
     steps:
       - uses: actions/download-artifact@v4
@@ -3410,72 +3361,3 @@ jobs:
 
       - run: swift test -Xswiftc -DENABLE_TESTING
         working-directory: ${{ github.workspace }}/SourceCache/swift-win32
-
-  snapshot:
-    runs-on: ubuntu-latest
-    needs: [context, smoke_test]
-    if: github.event_name == 'schedule'
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: refs/heads/main
-          show-progress: false
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: stable.xml
-
-      - run: |
-          git config --global user.name 'github-action[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          if ! git diff --exit-code ; then
-            git add stable.xml
-            git commit -m "repo: update stable revision snapshot ${{ needs.context.outputs.swift_tag }}"
-            git push origin HEAD:main
-          fi
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [context, smoke_test]
-    if: inputs.create_release == true
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: installer-amd64
-          path: ${{ github.workspace }}/tmp/amd64
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: installer-arm64
-          path: ${{ github.workspace }}/tmp/arm64
-
-      - name: Create Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          branch_version_string=${{ inputs.swift_version || '0.0.0' }}
-          if [[ $branch_version_string == "0.0.0" ]]; then
-            latest="true"
-          else
-            latest="false"
-          fi
-          # Create Release
-          gh release create ${{ needs.context.outputs.swift_tag }} -R ${{ github.repository }} --latest=${latest}
-
-          # AMD64
-          cd ${{ github.workspace }}/tmp/amd64
-
-          mv installer.exe installer-amd64.exe
-          gh release upload ${{ needs.context.outputs.swift_tag }} installer-amd64.exe -R ${{ github.repository }}
-
-          shasum -a 256 installer-amd64.exe > installer-amd64.exe.sha256
-          gh release upload ${{ needs.context.outputs.swift_tag }} installer-amd64.exe.sha256 -R ${{ github.repository }}
-
-          # ARM64
-          cd ${{ github.workspace }}/tmp/arm64
-
-          mv installer.exe installer-arm64.exe
-          gh release upload ${{ needs.context.outputs.swift_tag }} installer-arm64.exe -R ${{ github.repository }}
-
-          shasum -a 256 installer-arm64.exe > installer-arm64.exe.sha256
-          gh release upload ${{ needs.context.outputs.swift_tag }} installer-arm64.exe.sha256 -R ${{ github.repository }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1,4 +1,4 @@
-name: Swift Toolchains Build
+name: Swift Toolchain Build
 
 on:
   workflow_call:


### PR DESCRIPTION
This is a preliminary step to eventually add the Mac build. The Mac build will be using a separate job with its own matrix.