### PR TITLE
GHA: split out standard library phase

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1249,9 +1249,8 @@ jobs:
           name: libxml2-${{ matrix.os }}-${{ matrix.arch }}-2.11.5
           path: ${{ github.workspace }}/BuildRoot/Library/libxml2-2.11.5/usr
 
-  sdk:
-    continue-on-error: ${{ matrix.arch != 'amd64' }}
-    needs: [context, libxml2, curl, zlib, compilers, cmark_gfm]
+  stdlib:
+    needs: [context, compilers, cmark_gfm]
     runs-on: ${{ needs.context.outputs.windows_build_runner }}
 
     strategy:
@@ -1356,6 +1355,286 @@ jobs:
             linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86_64
 
+    name: ${{ matrix.os }} ${{ matrix.arch }} Standard Library
+
+    steps:
+      - name: Download Compilers
+        uses: actions/download-artifact@v4
+        with:
+          name: compilers-amd64
+          path: ${{ github.workspace }}/BuildRoot/Library
+      - uses: actions/download-artifact@v4
+        with:
+          name: cmark-gfm-amd64-0.29.0.gfm.13
+          path: ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr
+
+      - name: cmark-gfm Setup
+        run: Copy-Item ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr/bin/*.dll ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/
+
+      - uses: actions/checkout@v4
+        with:
+          repository: apple/llvm-project
+          ref: ${{ needs.context.outputs.llvm_project_revision }}
+          path: ${{ github.workspace }}/SourceCache/llvm-project
+          show-progress: false
+      - uses: actions/checkout@v4
+        with:
+          repository: apple/swift
+          ref: ${{ needs.context.outputs.swift_revision }}
+          path: ${{ github.workspace }}/SourceCache/swift
+          show-progress: false
+      - uses: actions/checkout@v4
+        with:
+          repository: apple/swift-corelibs-libdispatch
+          ref: ${{ needs.context.outputs.swift_corelibs_libdispatch_revision }}
+          path: ${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch
+          show-progress: false
+      - uses: actions/checkout@v4
+        with:
+          repository: apple/swift-experimental-string-processing
+          ref: ${{ needs.context.outputs.swift_experimental_string_processing_revision }}
+          path: ${{ github.workspace }}/SourceCache/swift-experimental-string-processing
+          show-progress: false
+
+      # NOTE(compnerd) While we do not have ABI stability on Windows yet, we use
+      # Swift in the compiler, which requires that we have the Swift runtime. As
+      # we have not yet built the runtime, this requires that we use the runtime
+      # from the previous build.
+      - name: Install Swift Toolchain
+        uses: compnerd/gha-setup-swift@main
+        with:
+          github-repo: thebrowsercompany/swift-build
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          release-asset-name: installer-amd64.exe
+          release-tag-name: '20231016.0'
+
+      # NOTE(compnerd): we execute unconditionally as we use CMake from VSDevEnv
+      - uses: compnerd/gha-setup-vsdevenv@main
+        with:
+          host_arch: amd64
+          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+          arch: ${{ matrix.arch }}
+
+      # NOTE(compnerd): we execute unconditionally as we reference outputs
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r26b
+
+      - name: Configure LLVM
+        run: |
+          # NOTE: used by `matrix.cc`
+          $CLANG_CL = "cl"
+          $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
+
+          cmake -B ${{ github.workspace }}/BinaryCache/llvm `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
+                -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
+                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
+                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr `
+                -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
+                ${{ matrix.llvm_flags }} `
+                ${{ matrix.extra_flags }} `
+                -D CMAKE_ANDROID_NDK=${NDKPATH} `
+                -D SWIFT_ANDROID_NDK_PATH=${NDKPATH} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/llvm-project/llvm `
+                -D LLVM_ENABLE_ASSERTIONS=YES
+
+      - name: Configure Swift Standard Library
+        run: |
+          # NOTE: used by `matrix.cc`
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
+
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
+          $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
+
+          $CMAKE_CPU = if ("${{ matrix.cpu }}" -eq "armv7") {
+            "armv7-a"
+          } else {
+            "${{ matrix.cpu }}"
+          }
+
+          Remove-Item env:\SDKROOT
+          cmake -B ${{ github.workspace }}/BinaryCache/swift `
+                -C ${{ github.workspace }}/SourceCache/swift/cmake/caches/Runtime-${{ matrix.os }}-${{ matrix.cpu }}.cmake `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
+                -D CMAKE_C_FLAGS="${{ matrix.cflags }}"  `
+                -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
+                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
+                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
+                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr `
+                -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
+                -D CMAKE_SYSTEM_PROCESSOR=${CMAKE_CPU} `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_COMPILER_WORKS=YES `
+                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple_no_api_level }} `
+                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BinaryCache/swift/lib/swift ${{ matrix.swiftflags }}" `
+                -D MSVC_C_ARCHITECTURE_ID=${{ matrix.arch }} `
+                -D MSVC_CXX_ARCHITECTURE_ID=${{ matrix.arch }} `
+                ${{ matrix.linker_flags }} `
+                ${{ matrix.extra_flags }} `
+                -D CMAKE_ANDROID_NDK=${NDKPATH} `
+                -D SWIFT_ANDROID_NDK_PATH=${NDKPATH} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift `
+                -D LLVM_DIR=${{ github.workspace }}/BinaryCache/llvm/lib/cmake/llvm `
+                -D SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=YES `
+                -D SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP=YES `
+                -D SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED=YES `
+                -D SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING=YES `
+                -D SWIFT_ENABLE_EXPERIMENTAL_OBSERVATION=YES `
+                -D SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING=YES `
+                -D SWIFT_ENABLE_SYNCHRONIZATION=YES `
+                -D SWIFT_ENABLE_VOLATILE=YES `
+                -D SWIFT_NATIVE_SWIFT_TOOLS_PATH=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin `
+                -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE=${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch `
+                -D SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE=${{ github.workspace }}/SourceCache/swift-syntax `
+                -D SWIFT_PATH_TO_STRING_PROCESSING_SOURCE=${{ github.workspace }}/SourceCache/swift-experimental-string-processing
+      - name: Build Swift Standard Library
+        run: |
+          Remove-Item env:\SDKROOT
+          cmake --build ${{ github.workspace }}/BinaryCache/swift
+      - name: Install Swift Standard Library
+        run: |
+          Remove-Item env:\SDKROOT
+          cmake --build ${{ github.workspace }}/BinaryCache/swift --target install
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}-stdlib-${{ matrix.arch }}
+          path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform
+
+      - uses: actions/upload-artifact@v4
+        if: matrix.os == 'Windows'
+        with:
+          name: windows-vfs-overlay-${{ matrix.arch }}
+          path: ${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml
+
+      - name: Upload PDBs to Azure
+        uses: microsoft/action-publish-symbols@v2.1.6
+        if: ${{ needs.context.outputs.debug_info && matrix.os == 'Windows' }}
+        with:
+          accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
+          personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
+          symbolsFolder: ${{ github.workspace }}/BinaryCache
+          searchPattern: '**/*.pdb'
+
+      - name: Upload DLLs to Azure
+        uses: microsoft/action-publish-symbols@v2.1.6
+        if: ${{ needs.context.outputs.debug_info && matrix.os == 'Windows' }}
+        with:
+          accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
+          personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
+          symbolsFolder: ${{ github.workspace }}/BinaryCache
+          searchPattern: '**/*.dll'
+
+  sdk:
+    continue-on-error: ${{ matrix.arch != 'amd64' }}
+    needs: [context, libxml2, curl, zlib, compilers, cmark_gfm, stdlib]
+    runs-on: ${{ needs.context.outputs.windows_build_runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            cpu: 'x86_64'
+            triple: 'x86_64-unknown-windows-msvc'
+            triple_no_api_level: 'x86_64-unknown-windows-msvc'
+            cc: '$CLANG_CL'
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cxx: '$CLANG_CL'
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
+            os: Windows
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            extra_flags:
+
+          - arch: arm64
+            cpu: 'aarch64'
+            triple: 'aarch64-unknown-windows-msvc'
+            triple_no_api_level: 'aarch64-unknown-windows-msvc'
+            cc: '$CLANG_CL'
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cxx: '$CLANG_CL'
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
+            os: Windows
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            extra_flags:
+
+          - arch: x86
+            cpu: 'i686'
+            triple: 'i686-unknown-windows-msvc'
+            triple_no_api_level: 'i686-unknown-windows-msvc'
+            cc: '$CLANG_CL'
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cxx: '$CLANG_CL'
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
+            os: Windows
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            extra_flags:
+
+          - arch: arm64
+            cpu: 'aarch64'
+            triple: 'aarch64-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }}'
+            triple_no_api_level: aarch64-unknown-linux-android
+            cc: clang
+            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cxx: clang++
+            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker aarch64-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
+            os: Android
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
+            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a
+
+          - arch: armv7
+            cpu: armv7
+            triple: 'armv7a-unknown-linux-androideabi${{ needs.context.outputs.ANDROID_API_LEVEL }}'
+            triple_no_api_level: armv7-unknown-linux-androideabi
+            cc: clang
+            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cxx: clang++
+            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker armv7a-unknown-linux-androideabi${{ needs.context.outputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
+            os: Android
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
+            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a
+
+          - arch: i686
+            cpu: i686
+            triple: 'i686-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }}'
+            triple_no_api_level: i686-unknown-linux-android
+            cc: clang
+            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cxx: clang++
+            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker i686-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
+            os: Android
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
+            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86
+
+          - arch: x86_64
+            cpu: 'x86_64'
+            triple: 'x86_64-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }}'
+            triple_no_api_level: x86_64-unknown-linux-android
+            cc: clang
+            cflags: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+            cxx: clang++
+            cxxflags: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+            swiftflags: -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker x86_64-unknown-linux-android${{ needs.context.outputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/17 -L ${{ github.workspace }}/BinaryCache/swift/lib/swift/android -g
+            os: Android
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
+            extra_flags: -DSWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -DLLVM_ENABLE_LIBCXX=YES -DSWIFT_USE_LINKER=lld -DCMAKE_ANDROID_API=${{ needs.context.outputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86_64
+
     name: ${{ matrix.os }} ${{ matrix.arch }} SDK
 
     steps:
@@ -1384,18 +1663,17 @@ jobs:
       - name: cmark-gfm Setup
         run: Copy-Item ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr/bin/*.dll ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/
 
-      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
-          repository: apple/llvm-project
-          ref: ${{ needs.context.outputs.llvm_project_revision }}
-          path: ${{ github.workspace }}/SourceCache/llvm-project
-          show-progress: false
-      - uses: actions/checkout@v4
+          name: ${{ matrix.os }}-stdlib-${{ matrix.arch }}
+          path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform
+
+      - uses: actions/download-artifact@v4
+        if: matrix.os == 'Windows'
         with:
-          repository: apple/swift
-          ref: ${{ needs.context.outputs.swift_revision }}
-          path: ${{ github.workspace }}/SourceCache/swift
-          show-progress: false
+          name: windows-vfs-overlay-${{ matrix.arch }}
+          path: ${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml
+
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-syntax
@@ -1453,6 +1731,10 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/swift-experimental-string-processing
           show-progress: false
 
+      - run: |
+          $RTLPath = cygpath -w ${{ github.workspace }}/BinaryCache/Developer/SDKs/Windows.sdk/usr/bin
+          echo ${RTLPath} | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       # NOTE(compnerd): we execute unconditionally as we use CMake from VSDevEnv
       - uses: compnerd/gha-setup-vsdevenv@main
         with:
@@ -1460,105 +1742,16 @@ jobs:
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
-      - name: Install Swift Toolchain
-        uses: compnerd/gha-setup-swift@main
-        with:
-          github-repo: thebrowsercompany/swift-build
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          release-asset-name: installer-amd64.exe
-          release-tag-name: '20231016.0'
-
-      # FIXME(compnerd): workaround CMake 3.30 issue
+      # FIXME(compnerd): workaround CMake 3.29-3.30 issue
       - uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '3.29'
+          cmake-version: '3.28'
 
       # NOTE(compnerd): we execute unconditionally as we reference outputs
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
           ndk-version: r26b
-
-      - name: Configure LLVM
-        run: |
-          $CLANG_CL = "cl"
-          $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-
-          Remove-Item env:\SDKROOT
-          cmake -B ${{ github.workspace }}/BinaryCache/llvm `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
-                -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
-                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
-                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_MT=mt `
-                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr `
-                -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
-                ${{ matrix.llvm_flags }} `
-                ${{ matrix.extra_flags }} `
-                -D CMAKE_ANDROID_NDK=$NDKPATH `
-                -D SWIFT_ANDROID_NDK_PATH=$NDKPATH `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/llvm-project/llvm `
-                -D LLVM_ENABLE_ASSERTIONS=YES
-
-      - name: Configure Swift Standard Library
-        run: |
-          # Workaround CMake 3.20 issue
-          $CLANG_CL = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
-
-          $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
-          $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-
-          $CMAKE_CPU = if ("${{ matrix.cpu }}" -eq "armv7") { "armv7-a" } else { "${{ matrix.cpu }}" }
-
-          Remove-Item env:\SDKROOT
-          cmake -B ${{ github.workspace }}/BinaryCache/swift `
-                -C ${{ github.workspace }}/SourceCache/swift/cmake/caches/Runtime-${{ matrix.os }}-${{ matrix.cpu }}.cmake `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
-                -D CMAKE_C_FLAGS="${{ matrix.cflags }}"  `
-                -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
-                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_MT=mt `
-                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr `
-                -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
-                -D CMAKE_SYSTEM_PROCESSOR=${CMAKE_CPU} `
-                -D CMAKE_Swift_COMPILER=${SWIFTC} `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple_no_api_level }} `
-                -D CMAKE_Swift_FLAGS="-resource-dir ${{ github.workspace }}/BinaryCache/swift/lib/swift ${{ matrix.swiftflags }}" `
-                -D MSVC_C_ARCHITECTURE_ID=${{ matrix.arch }} `
-                -D MSVC_CXX_ARCHITECTURE_ID=${{ matrix.arch }} `
-                ${{ matrix.linker_flags }} `
-                ${{ matrix.extra_flags }} `
-                -D CMAKE_ANDROID_NDK=$NDKPATH `
-                -D SWIFT_ANDROID_NDK_PATH=$NDKPATH `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift `
-                -D LLVM_DIR=${{ github.workspace }}/BinaryCache/llvm/lib/cmake/llvm `
-                -D SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=YES `
-                -D SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP=YES `
-                -D SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED=YES `
-                -D SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING=YES `
-                -D SWIFT_ENABLE_EXPERIMENTAL_OBSERVATION=YES `
-                -D SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING=YES `
-                -D SWIFT_ENABLE_SYNCHRONIZATION=YES `
-                -D SWIFT_ENABLE_VOLATILE=YES `
-                -D SWIFT_NATIVE_SWIFT_TOOLS_PATH=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin `
-                -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE=${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch `
-                -D SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE=${{ github.workspace }}/SourceCache/swift-syntax `
-                -D SWIFT_PATH_TO_STRING_PROCESSING_SOURCE=${{ github.workspace }}/SourceCache/swift-experimental-string-processing
-      - name: Build Swift Standard Library
-        run: |
-          Remove-Item env:\SDKROOT
-          cmake --build ${{ github.workspace }}/BinaryCache/swift
-      - name: Install Swift Standard Library
-        run: |
-          Remove-Item env:\SDKROOT
-          cmake --build ${{ github.workspace }}/BinaryCache/swift --target install
 
       - name: Configure libdispatch
         run: |
@@ -1773,7 +1966,7 @@ jobs:
           searchPattern: '**/*.dll'
 
   devtools:
-    needs: [context, sqlite, compilers, sdk]
+    needs: [context, sqlite, compilers, stdlib, sdk]
     runs-on: ${{ needs.context.outputs.windows_build_runner }}
 
     strategy:
@@ -2474,7 +2667,7 @@ jobs:
 
   debugging_tools:
     name: Debugging Tools
-    needs: [context, compilers, devtools, sdk]
+    needs: [context, compilers, devtools, stdlib, sdk]
     runs-on: ${{ needs.context.outputs.windows_build_runner }}
 
     strategy:
@@ -2770,7 +2963,7 @@ jobs:
 
   package_sdk_runtime:
     name: Package Windows SDK & Runtime
-    needs: [context, sdk]
+    needs: [context, stdlib, sdk]
     runs-on: ${{ needs.context.outputs.windows_build_runner }}
 
     strategy:
@@ -2870,7 +3063,7 @@ jobs:
 
   package_android_sdk:
     name: Package Android SDK & Runtime
-    needs: [context, sdk]
+    needs: [context, stdlib, sdk]
     runs-on: ${{ needs.context.outputs.windows_build_runner }}
 
     strategy:


### PR DESCRIPTION
Split out the standard library build phase to allow us to build the macros for the correct hosts. This is required to allow us to build the macros for distribution and for the build of the SDK.