### PR TITLE
[Mac build] Rename builder to a generic name

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -119,10 +119,10 @@ jobs:
       yams_revision: ${{ steps.context.outputs.yams_revision }}
       zlib_revision: ${{ steps.context.outputs.zlib_revision }}
       ANDROID_API_LEVEL: ${{ steps.context.outputs.ANDROID_API_LEVEL }}
-      HOST_CMAKE_C_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
-      HOST_CMAKE_CXX_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
-      HOST_CMAKE_EXE_LINKER_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}
-      HOST_CMAKE_SHARED_LINKER_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}
+      WINDOWS_CMAKE_C_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+      WINDOWS_CMAKE_CXX_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+      WINDOWS_CMAKE_EXE_LINKER_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}
+      WINDOWS_CMAKE_SHARED_LINKER_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}
       ANDROID_CMAKE_C_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}
       ANDROID_CMAKE_CXX_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
       ANDROID_CMAKE_EXE_LINKER_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}
@@ -132,7 +132,7 @@ jobs:
       signed: ${{ steps.context.outputs.signed }}
       swift_version: ${{ steps.context.outputs.swift_version }}
       swift_tag: ${{ steps.context.outputs.swift_tag }}
-      main_build_runner: ${{ steps.context.outputs.windows_build_runner }}
+      default_build_runner: ${{ steps.context.outputs.windows_build_runner }}
       compilers_build_runner: ${{ steps.context.outputs.compilers_build_runner }}
     steps:
       - id: context
@@ -255,7 +255,7 @@ jobs:
 
   sqlite:
     needs: [context]
-    runs-on: ${{ needs.context.outputs.main_build_runner }}
+    runs-on: ${{ needs.context.outputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -263,16 +263,16 @@ jobs:
         include:
           - arch: amd64
             cc: cl
-            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
 
           - arch: arm64
             cc: cl
-            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
 
     name: ${{ matrix.os }} ${{ matrix.arch }} SQLite3
@@ -331,7 +331,7 @@ jobs:
 
   cmark_gfm:
     needs: [context]
-    runs-on: ${{ needs.context.outputs.main_build_runner }}
+    runs-on: ${{ needs.context.outputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -367,10 +367,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_COMPILER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_COMPILER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr `
                 -D CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=YES `
@@ -387,7 +387,7 @@ jobs:
 
   build_tools:
     needs: [context, cmark_gfm]
-    runs-on: ${{ needs.context.outputs.main_build_runner }}
+    runs-on: ${{ needs.context.outputs.default_build_runner }}
 
     steps:
       - uses: actions/download-artifact@v4
@@ -423,10 +423,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D cmark-gfm_DIR=${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr/lib/cmake `
                 -G Ninja `
@@ -622,17 +622,17 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }} -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }} -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_Swift_COMPILER="${SWIFTC}" `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk `"${SDKROOT}`" -Xcc -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" `
-                -D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_EXE_LINKER_FLAGS }}" `
+                -D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
-                -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_SHARED_LINKER_FLAGS }}" `
+                -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}" `
                 ${CMAKE_SYSTEM_NAME} `
                 ${CMAKE_SYSTEM_PROCESSOR} `
                 -G Ninja `
@@ -746,7 +746,7 @@ jobs:
 
   zlib:
     needs: [context]
-    runs-on: ${{ needs.context.outputs.main_build_runner }}
+    runs-on: ${{ needs.context.outputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -754,25 +754,25 @@ jobs:
         include:
           - arch: amd64
             cc: cl
-            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: arm64
             cc: cl
-            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: x86
             cc: cl
-            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
@@ -869,7 +869,7 @@ jobs:
 
   curl:
     needs: [context, zlib]
-    runs-on: ${{ needs.context.outputs.main_build_runner }}
+    runs-on: ${{ needs.context.outputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -877,25 +877,25 @@ jobs:
         include:
           - arch: amd64
             cc: cl
-            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: arm64
             cc: cl
-            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: x86
             cc: cl
-            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
@@ -1074,7 +1074,7 @@ jobs:
 
   libxml2:
     needs: [context]
-    runs-on: ${{ needs.context.outputs.main_build_runner }}
+    runs-on: ${{ needs.context.outputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -1082,25 +1082,25 @@ jobs:
         include:
           - arch: amd64
             cc: cl
-            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: arm64
             cc: cl
-            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: x86
             cc: cl
-            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
@@ -1203,7 +1203,7 @@ jobs:
 
   stdlib:
     needs: [context, compilers, cmark_gfm]
-    runs-on: ${{ needs.context.outputs.main_build_runner }}
+    runs-on: ${{ needs.context.outputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -1214,13 +1214,13 @@ jobs:
             triple: 'x86_64-unknown-windows-msvc'
             triple_no_api_level: 'x86_64-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
             swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
             os: Windows
             llvm_flags:
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags:
 
           - arch: arm64
@@ -1228,13 +1228,13 @@ jobs:
             triple: 'aarch64-unknown-windows-msvc'
             triple_no_api_level: 'aarch64-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
             swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
             os: Windows
             llvm_flags:
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags: 
 
           - arch: x86
@@ -1242,13 +1242,13 @@ jobs:
             triple: 'i686-unknown-windows-msvc'
             triple_no_api_level: 'i686-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
             swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
             os: Windows
             llvm_flags:
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags: 
 
           - arch: arm64
@@ -1489,7 +1489,7 @@ jobs:
 
   macros:
     needs: [context, compilers, cmark_gfm, stdlib]
-    runs-on: ${{ needs.context.outputs.libs_build_runner }}
+    runs-on: ${{ needs.context.outputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -1626,7 +1626,7 @@ jobs:
   sdk:
     continue-on-error: ${{ matrix.arch != 'amd64' }}
     needs: [context, libxml2, curl, zlib, compilers, cmark_gfm, stdlib, macros]
-    runs-on: ${{ needs.context.outputs.main_build_runner }}
+    runs-on: ${{ needs.context.outputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -1637,12 +1637,12 @@ jobs:
             triple: 'x86_64-unknown-windows-msvc'
             triple_no_api_level: 'x86_64-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
             swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
             os: Windows
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags:
 
           - arch: arm64
@@ -1650,12 +1650,12 @@ jobs:
             triple: 'aarch64-unknown-windows-msvc'
             triple_no_api_level: 'aarch64-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
             swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
             os: Windows
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags:
 
           - arch: x86
@@ -1663,12 +1663,12 @@ jobs:
             triple: 'i686-unknown-windows-msvc'
             triple_no_api_level: 'i686-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
             swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
             os: Windows
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags:
 
           - arch: arm64
@@ -1914,7 +1914,7 @@ jobs:
                 -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_EXE_LINKER_FLAGS }}" `
+                -D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2045,7 +2045,7 @@ jobs:
 
   devtools:
     needs: [context, sqlite, compilers, stdlib, sdk]
-    runs-on: ${{ needs.context.outputs.main_build_runner }}
+    runs-on: ${{ needs.context.outputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -2235,10 +2235,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2265,10 +2265,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2294,10 +2294,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2323,10 +2323,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2352,10 +2352,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2385,10 +2385,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2415,10 +2415,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2448,10 +2448,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2535,10 +2535,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2578,7 +2578,7 @@ jobs:
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
@@ -2605,7 +2605,7 @@ jobs:
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
@@ -2634,10 +2634,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }} -Xclang -fno-split-cold-code" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }} -Xclang -fno-split-cold-code" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }} -Xclang -fno-split-cold-code -I ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/include -I ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/include/Block" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }} -Xclang -fno-split-cold-code -I ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/include -I ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/include/Block" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2664,10 +2664,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }} -Xclang -fno-split-cold-code" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }} -Xclang -fno-split-cold-code" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }} -Xclang -fno-split-cold-code" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }} -Xclang -fno-split-cold-code" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2746,7 +2746,7 @@ jobs:
   debugging_tools:
     name: Debugging Tools
     needs: [context, compilers, devtools, stdlib, sdk]
-    runs-on: ${{ needs.context.outputs.main_build_runner }}
+    runs-on: ${{ needs.context.outputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -3048,7 +3048,7 @@ jobs:
   package_sdk_runtime:
     name: Package Windows SDK & Runtime
     needs: [context, stdlib, sdk]
-    runs-on: ${{ needs.context.outputs.main_build_runner }}
+    runs-on: ${{ needs.context.outputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -3148,7 +3148,7 @@ jobs:
   package_android_sdk:
     name: Package Android SDK & Runtime
     needs: [context, stdlib, sdk]
-    runs-on: ${{ needs.context.outputs.main_build_runner }}
+    runs-on: ${{ needs.context.outputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -3222,7 +3222,7 @@ jobs:
 
   installer:
     needs: [context, package_tools, package_sdk_runtime, package_android_sdk]
-    runs-on: ${{ needs.context.outputs.main_build_runner }}
+    runs-on: ${{ needs.context.outputs.default_build_runner }}
 
     strategy:
       fail-fast: false
@@ -3356,7 +3356,7 @@ jobs:
 
   smoke_test:
     needs: [context, installer]
-    runs-on: ${{ needs.context.outputs.main_build_runner }}
+    runs-on: ${{ needs.context.outputs.default_build_runner }}
 
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -119,10 +119,10 @@ jobs:
       yams_revision: ${{ steps.context.outputs.yams_revision }}
       zlib_revision: ${{ steps.context.outputs.zlib_revision }}
       ANDROID_API_LEVEL: ${{ steps.context.outputs.ANDROID_API_LEVEL }}
-      WINDOWS_CMAKE_C_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
-      WINDOWS_CMAKE_CXX_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
-      WINDOWS_CMAKE_EXE_LINKER_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}
-      WINDOWS_CMAKE_SHARED_LINKER_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}
+      HOST_CMAKE_C_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+      HOST_CMAKE_CXX_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+      HOST_CMAKE_EXE_LINKER_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}
+      HOST_CMAKE_SHARED_LINKER_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}
       ANDROID_CMAKE_C_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}
       ANDROID_CMAKE_CXX_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
       ANDROID_CMAKE_EXE_LINKER_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}
@@ -132,7 +132,7 @@ jobs:
       signed: ${{ steps.context.outputs.signed }}
       swift_version: ${{ steps.context.outputs.swift_version }}
       swift_tag: ${{ steps.context.outputs.swift_tag }}
-      windows_build_runner: ${{ steps.context.outputs.windows_build_runner }}
+      libs_build_runner: ${{ steps.context.outputs.windows_build_runner }}
       compilers_build_runner: ${{ steps.context.outputs.compilers_build_runner }}
     steps:
       - id: context
@@ -255,7 +255,7 @@ jobs:
 
   sqlite:
     needs: [context]
-    runs-on: ${{ needs.context.outputs.windows_build_runner }}
+    runs-on: ${{ needs.context.outputs.libs_build_runner }}
 
     strategy:
       fail-fast: false
@@ -263,16 +263,16 @@ jobs:
         include:
           - arch: amd64
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
             os: Windows
 
           - arch: arm64
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
             os: Windows
 
     name: ${{ matrix.os }} ${{ matrix.arch }} SQLite3
@@ -331,7 +331,7 @@ jobs:
 
   cmark_gfm:
     needs: [context]
-    runs-on: ${{ needs.context.outputs.windows_build_runner }}
+    runs-on: ${{ needs.context.outputs.libs_build_runner }}
 
     strategy:
       fail-fast: false
@@ -367,10 +367,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_COMPILER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_COMPILER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr `
                 -D CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=YES `
@@ -387,7 +387,7 @@ jobs:
 
   build_tools:
     needs: [context, cmark_gfm]
-    runs-on: ${{ needs.context.outputs.windows_build_runner }}
+    runs-on: ${{ needs.context.outputs.libs_build_runner }}
 
     steps:
       - uses: actions/download-artifact@v4
@@ -423,10 +423,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D cmark-gfm_DIR=${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr/lib/cmake `
                 -G Ninja `
@@ -622,17 +622,17 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }} -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }} -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_Swift_COMPILER="${SWIFTC}" `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk `"${SDKROOT}`" -Xcc -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" `
-                -D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" `
+                -D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_EXE_LINKER_FLAGS }}" `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
-                -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}" `
+                -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_SHARED_LINKER_FLAGS }}" `
                 ${CMAKE_SYSTEM_NAME} `
                 ${CMAKE_SYSTEM_PROCESSOR} `
                 -G Ninja `
@@ -746,7 +746,7 @@ jobs:
 
   zlib:
     needs: [context]
-    runs-on: ${{ needs.context.outputs.windows_build_runner }}
+    runs-on: ${{ needs.context.outputs.libs_build_runner }}
 
     strategy:
       fail-fast: false
@@ -754,25 +754,25 @@ jobs:
         include:
           - arch: amd64
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: arm64
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: x86
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
@@ -869,7 +869,7 @@ jobs:
 
   curl:
     needs: [context, zlib]
-    runs-on: ${{ needs.context.outputs.windows_build_runner }}
+    runs-on: ${{ needs.context.outputs.libs_build_runner }}
 
     strategy:
       fail-fast: false
@@ -877,25 +877,25 @@ jobs:
         include:
           - arch: amd64
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: arm64
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: x86
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
@@ -1074,7 +1074,7 @@ jobs:
 
   libxml2:
     needs: [context]
-    runs-on: ${{ needs.context.outputs.windows_build_runner }}
+    runs-on: ${{ needs.context.outputs.libs_build_runner }}
 
     strategy:
       fail-fast: false
@@ -1082,25 +1082,25 @@ jobs:
         include:
           - arch: amd64
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: arm64
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
           - arch: x86
             cc: cl
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
             cxx: cl
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
             os: Windows
             extra_flags:
 
@@ -1203,7 +1203,7 @@ jobs:
 
   stdlib:
     needs: [context, compilers, cmark_gfm]
-    runs-on: ${{ needs.context.outputs.windows_build_runner }}
+    runs-on: ${{ needs.context.outputs.libs_build_runner }}
 
     strategy:
       fail-fast: false
@@ -1214,13 +1214,13 @@ jobs:
             triple: 'x86_64-unknown-windows-msvc'
             triple_no_api_level: 'x86_64-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
             swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
             os: Windows
             llvm_flags:
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags:
 
           - arch: arm64
@@ -1228,13 +1228,13 @@ jobs:
             triple: 'aarch64-unknown-windows-msvc'
             triple_no_api_level: 'aarch64-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
             swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
             os: Windows
             llvm_flags:
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags: 
 
           - arch: x86
@@ -1242,13 +1242,13 @@ jobs:
             triple: 'i686-unknown-windows-msvc'
             triple_no_api_level: 'i686-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
             swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
             os: Windows
             llvm_flags:
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags: 
 
           - arch: arm64
@@ -1489,7 +1489,7 @@ jobs:
 
   macros:
     needs: [context, compilers, cmark_gfm, stdlib]
-    runs-on: ${{ needs.context.outputs.windows_build_runner }}
+    runs-on: ${{ needs.context.outputs.libs_build_runner }}
 
     strategy:
       fail-fast: false
@@ -1637,12 +1637,12 @@ jobs:
             triple: 'x86_64-unknown-windows-msvc'
             triple_no_api_level: 'x86_64-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
             swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
             os: Windows
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags:
 
           - arch: arm64
@@ -1650,12 +1650,12 @@ jobs:
             triple: 'aarch64-unknown-windows-msvc'
             triple_no_api_level: 'aarch64-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
             swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
             os: Windows
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags:
 
           - arch: x86
@@ -1663,12 +1663,12 @@ jobs:
             triple: 'i686-unknown-windows-msvc'
             triple_no_api_level: 'i686-unknown-windows-msvc'
             cc: '$CLANG_CL'
-            cflags: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+            cflags: ${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}
             cxx: '$CLANG_CL'
-            cxxflags: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+            cxxflags: ${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}
             swiftflags: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
             os: Windows
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_SHARED_LINKER_FLAGS }}"'
             extra_flags:
 
           - arch: arm64
@@ -1914,7 +1914,7 @@ jobs:
                 -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" `
+                -D CMAKE_EXE_LINKER_FLAGS="${{ needs.context.outputs.HOST_CMAKE_EXE_LINKER_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2045,7 +2045,7 @@ jobs:
 
   devtools:
     needs: [context, sqlite, compilers, stdlib, sdk]
-    runs-on: ${{ needs.context.outputs.windows_build_runner }}
+    runs-on: ${{ needs.context.outputs.libs_build_runner }}
 
     strategy:
       fail-fast: false
@@ -2235,10 +2235,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2265,10 +2265,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2294,10 +2294,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2323,10 +2323,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2352,10 +2352,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2385,10 +2385,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2415,10 +2415,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2448,10 +2448,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2535,10 +2535,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2578,7 +2578,7 @@ jobs:
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
@@ -2605,7 +2605,7 @@ jobs:
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }}" `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
@@ -2634,10 +2634,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }} -Xclang -fno-split-cold-code" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }} -Xclang -fno-split-cold-code" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }} -Xclang -fno-split-cold-code -I ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/include -I ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/include/Block" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }} -Xclang -fno-split-cold-code -I ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/include -I ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/include/Block" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2664,10 +2664,10 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }} -Xclang -fno-split-cold-code" `
+                -D CMAKE_C_FLAGS="${{ needs.context.outputs.HOST_CMAKE_C_FLAGS }} -Xclang -fno-split-cold-code" `
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }} -Xclang -fno-split-cold-code" `
+                -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.HOST_CMAKE_CXX_FLAGS }} -Xclang -fno-split-cold-code" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot-DevTools/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
@@ -2746,7 +2746,7 @@ jobs:
   debugging_tools:
     name: Debugging Tools
     needs: [context, compilers, devtools, stdlib, sdk]
-    runs-on: ${{ needs.context.outputs.windows_build_runner }}
+    runs-on: ${{ needs.context.outputs.libs_build_runner }}
 
     strategy:
       fail-fast: false
@@ -2888,7 +2888,7 @@ jobs:
   package_tools:
     name: Package Tools
     needs: [context, compilers, macros, debugging_tools, devtools]
-    runs-on: ${{ needs.context.outputs.windows_build_runner }}
+    runs-on: ${{ needs.context.outputs.libs_build_runner }}
 
     strategy:
       fail-fast: false
@@ -3048,7 +3048,7 @@ jobs:
   package_sdk_runtime:
     name: Package Windows SDK & Runtime
     needs: [context, stdlib, sdk]
-    runs-on: ${{ needs.context.outputs.windows_build_runner }}
+    runs-on: ${{ needs.context.outputs.libs_build_runner }}
 
     strategy:
       fail-fast: false
@@ -3148,7 +3148,7 @@ jobs:
   package_android_sdk:
     name: Package Android SDK & Runtime
     needs: [context, stdlib, sdk]
-    runs-on: ${{ needs.context.outputs.windows_build_runner }}
+    runs-on: ${{ needs.context.outputs.libs_build_runner }}
 
     strategy:
       fail-fast: false
@@ -3222,7 +3222,7 @@ jobs:
 
   installer:
     needs: [context, package_tools, package_sdk_runtime, package_android_sdk]
-    runs-on: ${{ needs.context.outputs.windows_build_runner }}
+    runs-on: ${{ needs.context.outputs.libs_build_runner }}
 
     strategy:
       fail-fast: false
@@ -3356,7 +3356,7 @@ jobs:
 
   smoke_test:
     needs: [context, installer]
-    runs-on: ${{ needs.context.outputs.windows_build_runner }}
+    runs-on: ${{ needs.context.outputs.libs_build_runner }}
 
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -132,7 +132,7 @@ jobs:
       signed: ${{ steps.context.outputs.signed }}
       swift_version: ${{ steps.context.outputs.swift_version }}
       swift_tag: ${{ steps.context.outputs.swift_tag }}
-      libs_build_runner: ${{ steps.context.outputs.windows_build_runner }}
+      main_build_runner: ${{ steps.context.outputs.windows_build_runner }}
       compilers_build_runner: ${{ steps.context.outputs.compilers_build_runner }}
     steps:
       - id: context
@@ -255,7 +255,7 @@ jobs:
 
   sqlite:
     needs: [context]
-    runs-on: ${{ needs.context.outputs.libs_build_runner }}
+    runs-on: ${{ needs.context.outputs.main_build_runner }}
 
     strategy:
       fail-fast: false
@@ -331,7 +331,7 @@ jobs:
 
   cmark_gfm:
     needs: [context]
-    runs-on: ${{ needs.context.outputs.libs_build_runner }}
+    runs-on: ${{ needs.context.outputs.main_build_runner }}
 
     strategy:
       fail-fast: false
@@ -387,7 +387,7 @@ jobs:
 
   build_tools:
     needs: [context, cmark_gfm]
-    runs-on: ${{ needs.context.outputs.libs_build_runner }}
+    runs-on: ${{ needs.context.outputs.main_build_runner }}
 
     steps:
       - uses: actions/download-artifact@v4
@@ -746,7 +746,7 @@ jobs:
 
   zlib:
     needs: [context]
-    runs-on: ${{ needs.context.outputs.libs_build_runner }}
+    runs-on: ${{ needs.context.outputs.main_build_runner }}
 
     strategy:
       fail-fast: false
@@ -869,7 +869,7 @@ jobs:
 
   curl:
     needs: [context, zlib]
-    runs-on: ${{ needs.context.outputs.libs_build_runner }}
+    runs-on: ${{ needs.context.outputs.main_build_runner }}
 
     strategy:
       fail-fast: false
@@ -1074,7 +1074,7 @@ jobs:
 
   libxml2:
     needs: [context]
-    runs-on: ${{ needs.context.outputs.libs_build_runner }}
+    runs-on: ${{ needs.context.outputs.main_build_runner }}
 
     strategy:
       fail-fast: false
@@ -1203,7 +1203,7 @@ jobs:
 
   stdlib:
     needs: [context, compilers, cmark_gfm]
-    runs-on: ${{ needs.context.outputs.libs_build_runner }}
+    runs-on: ${{ needs.context.outputs.main_build_runner }}
 
     strategy:
       fail-fast: false
@@ -1626,7 +1626,7 @@ jobs:
   sdk:
     continue-on-error: ${{ matrix.arch != 'amd64' }}
     needs: [context, libxml2, curl, zlib, compilers, cmark_gfm, stdlib, macros]
-    runs-on: ${{ needs.context.outputs.windows_build_runner }}
+    runs-on: ${{ needs.context.outputs.main_build_runner }}
 
     strategy:
       fail-fast: false
@@ -2045,7 +2045,7 @@ jobs:
 
   devtools:
     needs: [context, sqlite, compilers, stdlib, sdk]
-    runs-on: ${{ needs.context.outputs.libs_build_runner }}
+    runs-on: ${{ needs.context.outputs.main_build_runner }}
 
     strategy:
       fail-fast: false
@@ -2746,7 +2746,7 @@ jobs:
   debugging_tools:
     name: Debugging Tools
     needs: [context, compilers, devtools, stdlib, sdk]
-    runs-on: ${{ needs.context.outputs.libs_build_runner }}
+    runs-on: ${{ needs.context.outputs.main_build_runner }}
 
     strategy:
       fail-fast: false
@@ -2888,7 +2888,7 @@ jobs:
   package_tools:
     name: Package Tools
     needs: [context, compilers, macros, debugging_tools, devtools]
-    runs-on: ${{ needs.context.outputs.libs_build_runner }}
+    runs-on: ${{ needs.context.outputs.main_build_runner }}
 
     strategy:
       fail-fast: false
@@ -3048,7 +3048,7 @@ jobs:
   package_sdk_runtime:
     name: Package Windows SDK & Runtime
     needs: [context, stdlib, sdk]
-    runs-on: ${{ needs.context.outputs.libs_build_runner }}
+    runs-on: ${{ needs.context.outputs.main_build_runner }}
 
     strategy:
       fail-fast: false
@@ -3148,7 +3148,7 @@ jobs:
   package_android_sdk:
     name: Package Android SDK & Runtime
     needs: [context, stdlib, sdk]
-    runs-on: ${{ needs.context.outputs.libs_build_runner }}
+    runs-on: ${{ needs.context.outputs.main_build_runner }}
 
     strategy:
       fail-fast: false
@@ -3222,7 +3222,7 @@ jobs:
 
   installer:
     needs: [context, package_tools, package_sdk_runtime, package_android_sdk]
-    runs-on: ${{ needs.context.outputs.libs_build_runner }}
+    runs-on: ${{ needs.context.outputs.main_build_runner }}
 
     strategy:
       fail-fast: false
@@ -3356,7 +3356,7 @@ jobs:
 
   smoke_test:
     needs: [context, installer]
-    runs-on: ${{ needs.context.outputs.libs_build_runner }}
+    runs-on: ${{ needs.context.outputs.main_build_runner }}
 
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
`windows_build_runner` is too Windows-specific. This renames the variable to `default_build_runner`, to make space for future Darwin builds.

The variable is kept to its original name in the `context` step, since this step will eventually also output Darwin variables.