### PR TITLE
GHA: update repositories for swiftlang migration

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -296,7 +296,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift-cmark
+          repository: swiftlang/swift-cmark
           ref: ${{ inputs.swift_cmark_revision }}
           path: ${{ github.workspace }}/SourceCache/cmark-gfm
           show-progress: false
@@ -354,13 +354,13 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: apple/llvm-project
+          repository: swiftlang/llvm-project
           ref: ${{ inputs.llvm_project_revision }}
           path: ${{ github.workspace }}/SourceCache/llvm-project
           show-progress: false
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift
+          repository: swiftlang/swift
           ref: ${{ inputs.swift_revision }}
           path: ${{ github.workspace }}/SourceCache/swift
           show-progress: false
@@ -478,25 +478,25 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: apple/llvm-project
+          repository: swiftlang/llvm-project
           ref: ${{ inputs.llvm_project_revision }}
           path: ${{ github.workspace }}/SourceCache/llvm-project
           show-progress: false
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift
+          repository: swiftlang/swift
           ref: ${{ inputs.swift_revision }}
           path: ${{ github.workspace }}/SourceCache/swift
           show-progress: false
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift-experimental-string-processing
+          repository: swiftlang/swift-experimental-string-processing
           ref: ${{ inputs.swift_experimental_string_processing_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-experimental-string-processing
           show-progress: false
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift-syntax
+          repository: swiftlang/swift-syntax
           ref: ${{ inputs.swift_syntax_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-syntax
           show-progress: false
@@ -1282,13 +1282,13 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: apple/llvm-project
+          repository: swiftlang/llvm-project
           ref: ${{ inputs.llvm_project_revision }}
           path: ${{ github.workspace }}/SourceCache/llvm-project
           show-progress: false
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift
+          repository: swiftlang/swift
           ref: ${{ inputs.swift_revision }}
           path: ${{ github.workspace }}/SourceCache/swift
           show-progress: false
@@ -1300,7 +1300,7 @@ jobs:
           show-progress: false
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift-experimental-string-processing
+          repository: swiftlang/swift-experimental-string-processing
           ref: ${{ inputs.swift_experimental_string_processing_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-experimental-string-processing
           show-progress: false
@@ -1496,7 +1496,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift
+          repository: swiftlang/swift
           ref: ${{ inputs.swift_revision }}
           path: ${{ github.workspace }}/SourceCache/swift
           show-progress: false
@@ -1773,7 +1773,7 @@ jobs:
           show-progress: false
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift-corelibs-xctest
+          repository: swiftlang/swift-corelibs-xctest
           ref: ${{ inputs.swift_corelibs_xctest_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-corelibs-xctest
           show-progress: false
@@ -2081,13 +2081,13 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: apple/indexstore-db
+          repository: swiftlang/indexstore-db
           ref: ${{ inputs.indexstore_db_revision }}
           path: ${{ github.workspace }}/SourceCache/indexstore-db
           show-progress: false
       - uses: actions/checkout@v4
         with:
-          repository: apple/sourcekit-lsp
+          repository: swiftlang/sourcekit-lsp
           ref: ${{ inputs.sourcekit_lsp_revision }}
           path: ${{ github.workspace }}/SourceCache/sourcekit-lsp
           show-progress: false
@@ -2123,31 +2123,31 @@ jobs:
           show-progress: false
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift-driver
+          repository: swiftlang/swift-driver
           ref: ${{ inputs.swift_driver_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-driver
           show-progress: false
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift-format
+          repository: swiftlang/swift-format
           ref: ${{ inputs.swift_format_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-format
           show-progress: false
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift-llbuild
+          repository: swiftlang/swift-llbuild
           ref: ${{ inputs.swift_llbuild_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-llbuild
           show-progress: false
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift-markdown
+          repository: swiftlang/swift-markdown
           ref: ${{ inputs.swift_markdown_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-markdown
           show-progress: false
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift-package-manager
+          repository: swiftlang/swift-package-manager
           ref: ${{ inputs.swift_package_manager_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-package-manager
           show-progress: false
@@ -2159,7 +2159,7 @@ jobs:
           show-progress: false
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift-tools-support-core
+          repository: swiftlang/swift-tools-support-core
           ref: ${{ inputs.swift_tools_support_core_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-tools-support-core
           show-progress: false
@@ -2171,7 +2171,7 @@ jobs:
           show-progress: false
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift
+          repository: swiftlang/swift
           ref: ${{ inputs.swift_revision }}
           path: ${{ github.workspace }}/SourceCache/swift
           show-progress: false
@@ -2831,10 +2831,9 @@ jobs:
           mkdir $RTLPath
           Get-ChildItem -Path ${env:SDKROOT}/usr/bin -Filter "*.dll" | Move-Item -Destination $RTLPath
 
-      - name: Checkout apple/swift
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
-          repository: apple/swift
+          repository: swiftlang/swift
           ref: ${{ inputs.swift_revision }}
           path: ${{ github.workspace }}/SourceCache/swift
           show-progress: false
@@ -2913,7 +2912,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift-installer-scripts
+          repository: swiftlang/swift-installer-scripts
           ref: ${{ inputs.swift_installer_scripts_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
@@ -3051,7 +3050,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift-installer-scripts
+          repository: swiftlang/swift-installer-scripts
           ref: ${{ inputs.swift_installer_scripts_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
@@ -3153,7 +3152,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift-installer-scripts
+          repository: swiftlang/swift-installer-scripts
           ref: ${{ inputs.swift_installer_scripts_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
@@ -3277,7 +3276,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: apple/swift-installer-scripts
+          repository: swiftlang/swift-installer-scripts
           ref: ${{ inputs.swift_installer_scripts_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false


### PR DESCRIPTION
Update the repositories which have migrated to the swiftlang organisation.