### PR TITLE
[Mac build] Add optional Mac build

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -134,6 +134,8 @@ jobs:
       WINDOWS_CMAKE_CXX_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
       WINDOWS_CMAKE_EXE_LINKER_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}
       WINDOWS_CMAKE_SHARED_LINKER_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}
+      DARWIN_CMAKE_C_FLAGS: ${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}
+      DARWIN_CMAKE_CXX_FLAGS: ${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}
       ANDROID_CMAKE_C_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}
       ANDROID_CMAKE_CXX_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
       ANDROID_CMAKE_EXE_LINKER_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}
@@ -144,7 +146,10 @@ jobs:
       swift_version: ${{ steps.context.outputs.swift_version }}
       swift_tag: ${{ steps.context.outputs.swift_tag }}
       windows_build_runner: ${{ steps.context.outputs.windows_build_runner }}
-      compilers_build_runner: ${{ steps.context.outputs.compilers_build_runner }}
+      windows_compilers_runner: ${{ steps.context.outputs.windows_compilers_runner }}
+      mac_build_runner: ${{ steps.context.outputs.mac_build_runner }}
+      windows_host_matrix: ${{ steps.setup-matrix.outputs.windows_host_matrix }}
+      darwin_host_matrix: ${{ steps.setup-matrix.outputs.darwin_host_matrix }}
     steps:
       - id: context
         name: Generate Build Context
@@ -219,6 +224,8 @@ jobs:
             echo debug_info=true >> ${GITHUB_OUTPUT}
             echo WINDOWS_CMAKE_C_FLAGS="/GS- /Gw /Gy /Oi /Oy /Z7 /Zc:inline /Zc:preprocessor" >> ${GITHUB_OUTPUT}
             echo WINDOWS_CMAKE_CXX_FLAGS="/GS- /Gw /Gy /Oi /Oy /Z7 /Zc:inline /Zc:preprocessor /Zc:__cplusplus /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" >> ${GITHUB_OUTPUT}
+            echo DARWIN_CMAKE_C_FLAGS="-g" >> ${GITHUB_OUTPUT}
+            echo DARWIN_CMAKE_CXX_FLAGS="-g" >> ${GITHUB_OUTPUT}
             echo ANDROID_CMAKE_C_FLAGS="-ffunction-sections -fdata-sections -g" >> ${GITHUB_OUTPUT}
             echo ANDROID_CMAKE_CXX_FLAGS="-ffunction-sections -fdata-sections -g" >> ${GITHUB_OUTPUT}
             echo WINDOWS_CMAKE_EXE_LINKER_FLAGS="-incremental:no -debug -opt:ref -opt:icf" >> ${GITHUB_OUTPUT}
@@ -228,6 +235,8 @@ jobs:
             echo debug_info=false >> ${GITHUB_OUTPUT}
             echo WINDOWS_CMAKE_C_FLAGS="/GS- /Gw /Gy /Oi /Oy /Zc:inline /Zc:preprocessor" >> ${GITHUB_OUTPUT}
             echo WINDOWS_CMAKE_CXX_FLAGS="/GS- /Gw /Gy /Oi /Oy /Zc:inline /Zc:preprocessor /Zc:__cplusplus /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" >> ${GITHUB_OUTPUT}
+            echo DARWIN_CMAKE_C_FLAGS="" >> ${GITHUB_OUTPUT}
+            echo DARWIN_CMAKE_CXX_FLAGS="" >> ${GITHUB_OUTPUT}
             echo ANDROID_CMAKE_C_FLAGS="-ffunction-sections -fdata-sections" >> ${GITHUB_OUTPUT}
             echo ANDROID_CMAKE_CXX_FLAGS="-ffunction-sections -fdata-sections" >> ${GITHUB_OUTPUT}
             echo WINDOWS_CMAKE_EXE_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
@@ -256,7 +265,9 @@ jobs:
           fi
 
           echo windows_build_runner=${{ inputs.windows_default_runner || vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
-          echo compilers_build_runner=${{ inputs.windows_compilers_runner || inputs.windows_default_runner || vars.COMPILERS_BUILD_RUNNER || vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
+          echo windows_compilers_runner=${{ inputs.windows_compilers_runner || inputs.windows_default_runner || vars.COMPILERS_BUILD_RUNNER || vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
+          # TODO: Make the mac runner configurable.
+          echo mac_build_runner=macos-latest >> ${GITHUB_OUTPUT}
 
           echo ANDROID_API_LEVEL=${{ inputs.android_api_level }} >> ${GITHUB_OUTPUT}
 
@@ -266,11 +277,62 @@ jobs:
           path: stable.xml
           if-no-files-found: ignore
 
+      - name: Setup matrix
+        id: setup-matrix
+        env:
+          WINDOWS_HOST_MATRIX: >-
+            {
+              "include": [
+                {
+                  "arch": "amd64",
+                  "os": "Windows",
+                  "cc": "cl",
+                  "ccflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
+                  "cxx": "cl",
+                  "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}"
+                },
+                {
+                  "arch": "arm64",
+                  "os": "Windows",
+                  "cc": "cl",
+                  "ccflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
+                  "cxx": "cl",
+                  "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}"
+                }
+              ]
+            }
+          DARWIN_HOST_MATRIX: >-
+            {
+              "include": [
+                {
+                  "arch": "x86_64",
+                  "os": "Darwin",
+                  "cc": "clang",
+                  "ccflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
+                  "cxx": "clang++",
+                  "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}"
+                },
+                {
+                  "arch": "arm64",
+                  "os": "Darwin",
+                  "cc": "clang",
+                  "ccflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
+                  "cxx": "clang++",
+                  "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}"
+                }
+              ]
+            }
+        run: |
+          echo "windows_host_matrix=$(jq -r -c '.' <<< ${WINDOWS_HOST_MATRIX})" >> ${GITHUB_OUTPUT}
+          echo "darwin_host_matrix=$(jq -r -c '.' <<< ${DARWIN_HOST_MATRIX})" >> ${GITHUB_OUTPUT}
+
   windows-build:
     needs: [context]
     name: Windows Swift Toolchains Build
     uses: ./.github/workflows/swift-toolchain.yml
     with:
+      builder_os: Windows
+      builder_arch: amd64
       curl_revision: ${{ needs.context.outputs.curl_revision }}
       indexstore_db_revision: ${{ needs.context.outputs.indexstore_db_revision }}
       libxml2_revision: ${{ needs.context.outputs.libxml2_revision }}
@@ -305,6 +367,8 @@ jobs:
       yams_revision: ${{ needs.context.outputs.yams_revision }}
       zlib_revision: ${{ needs.context.outputs.zlib_revision }}
       ANDROID_API_LEVEL: ${{ needs.context.outputs.ANDROID_API_LEVEL }}
+      HOST_CMAKE_C_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+      HOST_CMAKE_CXX_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
       WINDOWS_CMAKE_C_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
       WINDOWS_CMAKE_CXX_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
       WINDOWS_CMAKE_EXE_LINKER_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}
@@ -319,7 +383,73 @@ jobs:
       swift_version: ${{ needs.context.outputs.swift_version }}
       swift_tag: ${{ needs.context.outputs.swift_tag }}
       default_build_runner: ${{ needs.context.outputs.windows_build_runner }}
-      compilers_build_runner: ${{ needs.context.outputs.compilers_build_runner }}
+      compilers_build_runner: ${{ needs.context.outputs.windows_compilers_runner }}
+      host_matrix: ${{ needs.context.outputs.windows_host_matrix }}
+    secrets:
+      SYMBOL_SERVER_PAT: ${{ secrets.SYMBOL_SERVER_PAT }}
+      CERTIFICATE: ${{ secrets.CERTIFICATE }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
+
+  mac-build:
+    # TODO: Enable the mac build.
+    if: false
+    needs: [context]
+    name: macOS Swift Toolchains Build
+    uses: ./.github/workflows/swift-toolchain.yml
+    with:
+      builder_os: Darwin
+      builder_arch: aarch64
+      curl_revision: ${{ needs.context.outputs.curl_revision }}
+      indexstore_db_revision: ${{ needs.context.outputs.indexstore_db_revision }}
+      libxml2_revision: ${{ needs.context.outputs.libxml2_revision }}
+      llvm_project_revision: ${{ needs.context.outputs.llvm_project_revision }}
+      sourcekit_lsp_revision: ${{ needs.context.outputs.sourcekit_lsp_revision }}
+      swift_argument_parser_revision: ${{ needs.context.outputs.swift_argument_parser_revision }}
+      swift_asn1_revision: ${{ needs.context.outputs.swift_asn1_revision }}
+      swift_atomics_revision: ${{ needs.context.outputs.swift_atomics_revision }}
+      swift_certificates_revision: ${{ needs.context.outputs.swift_certificates_revision }}
+      swift_cmark_revision: ${{ needs.context.outputs.swift_cmark_revision }}
+      swift_collections_revision: ${{ needs.context.outputs.swift_collections_revision }}
+      swift_corelibs_foundation_revision: ${{ needs.context.outputs.swift_corelibs_foundation_revision }}
+      swift_corelibs_libdispatch_revision: ${{ needs.context.outputs.swift_corelibs_libdispatch_revision }}
+      swift_corelibs_xctest_revision: ${{ needs.context.outputs.swift_corelibs_xctest_revision }}
+      swift_crypto_revision: ${{ needs.context.outputs.swift_crypto_revision }}
+      swift_driver_revision: ${{ needs.context.outputs.swift_driver_revision }}
+      swift_experimental_string_processing_revision: ${{ needs.context.outputs.swift_experimental_string_processing_revision }}
+      swift_format_revision: ${{ needs.context.outputs.swift_format_revision }}
+      swift_foundation_revision: ${{ needs.context.outputs.swift_foundation_revision }}
+      swift_foundation_icu_revision: ${{ needs.context.outputs.swift_foundation_icu_revision }}
+      swift_installer_scripts_revision: ${{ needs.context.outputs.swift_installer_scripts_revision }}
+      swift_llbuild_revision: ${{ needs.context.outputs.swift_llbuild_revision }}
+      swift_markdown_revision: ${{ needs.context.outputs.swift_markdown_revision }}
+      swift_package_manager_revision: ${{ needs.context.outputs.swift_package_manager_revision }}
+      swift_revision: ${{ needs.context.outputs.swift_revision }}
+      swift_syntax_revision: ${{ needs.context.outputs.swift_syntax_revision }}
+      swift_system_revision: ${{ needs.context.outputs.swift_system_revision }}
+      swift_toolchain_sqlite_revision: ${{ needs.context.outputs.swift_toolchain_sqlite_revision }}
+      swift_toolchain_sqlite_version: ${{ needs.context.outputs.swift_toolchain_sqlite_version }}
+      swift_tools_support_core_revision: ${{ needs.context.outputs.swift_tools_support_core_revision }}
+      yams_revision: ${{ needs.context.outputs.yams_revision }}
+      zlib_revision: ${{ needs.context.outputs.zlib_revision }}
+      ANDROID_API_LEVEL: ${{ needs.context.outputs.ANDROID_API_LEVEL }}
+      HOST_CMAKE_C_FLAGS: ${{ needs.context.outputs.DARWIN_CMAKE_C_FLAGS }}
+      HOST_CMAKE_CXX_FLAGS: ${{ needs.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}
+      WINDOWS_CMAKE_C_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
+      WINDOWS_CMAKE_CXX_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
+      WINDOWS_CMAKE_EXE_LINKER_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}
+      WINDOWS_CMAKE_SHARED_LINKER_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}
+      ANDROID_CMAKE_C_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_C_FLAGS }}
+      ANDROID_CMAKE_CXX_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
+      ANDROID_CMAKE_EXE_LINKER_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}
+      ANDROID_CMAKE_SHARED_LINKER_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}
+      CMAKE_Swift_FLAGS: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
+      debug_info: ${{ needs.context.outputs.debug_info }}
+      signed: ${{ needs.context.outputs.signed }}
+      swift_version: ${{ needs.context.outputs.swift_version }}
+      swift_tag: ${{ needs.context.outputs.swift_tag }}
+      default_build_runner: ${{ needs.context.outputs.mac_build_runner }}
+      compilers_build_runner: ${{ needs.context.outputs.mac_build_runner }}
+      host_matrix: ${{ needs.context.outputs.darwin_host_matrix }}
     secrets:
       SYMBOL_SERVER_PAT: ${{ secrets.SYMBOL_SERVER_PAT }}
       CERTIFICATE: ${{ secrets.CERTIFICATE }}

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -313,7 +313,7 @@ jobs:
                   "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}"
                 },
                 {
-                  "arch": "arm64",
+                  "arch": "aarch64",
                   "os": "Darwin",
                   "cc": "clang",
                   "ccflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
@@ -331,8 +331,8 @@ jobs:
     name: Windows Swift Toolchains Build
     uses: ./.github/workflows/swift-toolchain.yml
     with:
-      builder_os: Windows
-      builder_arch: amd64
+      build_os: Windows
+      build_arch: amd64
       curl_revision: ${{ needs.context.outputs.curl_revision }}
       indexstore_db_revision: ${{ needs.context.outputs.indexstore_db_revision }}
       libxml2_revision: ${{ needs.context.outputs.libxml2_revision }}
@@ -367,8 +367,6 @@ jobs:
       yams_revision: ${{ needs.context.outputs.yams_revision }}
       zlib_revision: ${{ needs.context.outputs.zlib_revision }}
       ANDROID_API_LEVEL: ${{ needs.context.outputs.ANDROID_API_LEVEL }}
-      HOST_CMAKE_C_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
-      HOST_CMAKE_CXX_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
       WINDOWS_CMAKE_C_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
       WINDOWS_CMAKE_CXX_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
       WINDOWS_CMAKE_EXE_LINKER_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}
@@ -397,8 +395,8 @@ jobs:
     name: macOS Swift Toolchains Build
     uses: ./.github/workflows/swift-toolchain.yml
     with:
-      builder_os: Darwin
-      builder_arch: aarch64
+      build_os: Darwin
+      build_arch: aarch64
       curl_revision: ${{ needs.context.outputs.curl_revision }}
       indexstore_db_revision: ${{ needs.context.outputs.indexstore_db_revision }}
       libxml2_revision: ${{ needs.context.outputs.libxml2_revision }}
@@ -426,14 +424,13 @@ jobs:
       swift_revision: ${{ needs.context.outputs.swift_revision }}
       swift_syntax_revision: ${{ needs.context.outputs.swift_syntax_revision }}
       swift_system_revision: ${{ needs.context.outputs.swift_system_revision }}
+      swift_testing_revision: ${{ needs.context.outputs.swift_testing_revision }}
       swift_toolchain_sqlite_revision: ${{ needs.context.outputs.swift_toolchain_sqlite_revision }}
       swift_toolchain_sqlite_version: ${{ needs.context.outputs.swift_toolchain_sqlite_version }}
       swift_tools_support_core_revision: ${{ needs.context.outputs.swift_tools_support_core_revision }}
       yams_revision: ${{ needs.context.outputs.yams_revision }}
       zlib_revision: ${{ needs.context.outputs.zlib_revision }}
       ANDROID_API_LEVEL: ${{ needs.context.outputs.ANDROID_API_LEVEL }}
-      HOST_CMAKE_C_FLAGS: ${{ needs.context.outputs.DARWIN_CMAKE_C_FLAGS }}
-      HOST_CMAKE_CXX_FLAGS: ${{ needs.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}
       WINDOWS_CMAKE_C_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_C_FLAGS }}
       WINDOWS_CMAKE_CXX_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}
       WINDOWS_CMAKE_EXE_LINKER_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3,6 +3,18 @@ name: Swift Toolchain Build
 on:
   workflow_call:
     inputs:
+      builder_os:
+        required: true
+        type: string
+
+      builder_arch:
+        required: true
+        type: string
+
+      host_matrix:
+        required: true
+        type: string
+
       curl_revision:
         required: true
         type: string
@@ -139,6 +151,14 @@ on:
         required: true
         type: string
 
+      HOST_CMAKE_C_FLAGS:
+        required: true
+        type: string
+
+      HOST_CMAKE_CXX_FLAGS:
+        required: true
+        type: string
+
       WINDOWS_CMAKE_C_FLAGS:
         required: true
         type: string
@@ -199,7 +219,6 @@ on:
         required: true
         type: string
 
-
     secrets:
       SYMBOL_SERVER_PAT:
         required: true
@@ -209,7 +228,7 @@ on:
         required: true
 
 env:
-  SCCACHE_DIRECT: yes
+  SCCACHE_DIRECT: on
 
 jobs:
   sqlite:
@@ -217,23 +236,9 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-            cc: cl
-            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
-            cxx: cl
-            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
-            os: Windows
+      matrix: ${{ fromJSON(inputs.host_matrix) }}
 
-          - arch: arm64
-            cc: cl
-            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
-            cxx: cl
-            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
-            os: Windows
-
-    name: ${{ matrix.os }} ${{ matrix.arch }} SQLite3
+    name: SQLite3 (${{ matrix.os }} ${{ matrix.arch }})
 
     steps:
       - uses: actions/checkout@v4
@@ -249,10 +254,19 @@ jobs:
           show-progress: false
 
       - uses: compnerd/gha-setup-vsdevenv@main
+        if: inputs.builder_os == 'Windows'
         with:
-          host_arch: amd64
+          host_arch: ${{ inputs.builder_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        if: inputs.builder_os == 'Darwin'
+        with:
+          xcode-version: latest-stable
+
+      - uses: seanmiddleditch/gha-setup-ninja@master
+        if: inputs.builder_os == 'Darwin'
 
       - name: Compute workspace hash
         id: workspace_hash
@@ -274,6 +288,7 @@ jobs:
           variant: sccache
 
       - name: Configure SQLite
+        shell: pwsh
         run: |
           cmake -B ${{ github.workspace }}/BinaryCache/sqlite-${{ inputs.swift_toolchain_sqlite_version }} `
                 -D BUILD_SHARED_LIBS=NO `
@@ -287,6 +302,7 @@ jobs:
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr `
                 -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
+                -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} `
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/swift-toolchain-sqlite
       - name: Build SQLite
@@ -300,6 +316,8 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr
 
   cmark_gfm:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.builder_os == 'Windows'
     runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
@@ -369,6 +387,8 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-0.29.0.gfm.13/usr
 
   build_tools:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.builder_os == 'Windows'
     needs: [cmark_gfm]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -485,6 +505,8 @@ jobs:
             ${{ github.workspace }}/BinaryCache/0/bin/swift-compatibility-symbols.exe
 
   compilers:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.builder_os == 'Windows'
     needs: [build_tools, cmark_gfm]
     runs-on: ${{ inputs.compilers_build_runner }}
 
@@ -756,6 +778,8 @@ jobs:
           searchPattern: '**/*.exe'
 
   zlib:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.builder_os == 'Windows'
     runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
@@ -890,6 +914,8 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library/zlib-1.3/usr
 
   curl:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.builder_os == 'Windows'
     needs: [zlib]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -1107,6 +1133,8 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library/curl-8.9.1/usr
 
   libxml2:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.builder_os == 'Windows'
     runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
@@ -1247,6 +1275,8 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library/libxml2-2.11.5/usr
 
   stdlib:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.builder_os == 'Windows'
     needs: [compilers, cmark_gfm]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -1533,6 +1563,8 @@ jobs:
           searchPattern: '**/*.dll'
 
   macros:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.builder_os == 'Windows'
     needs: [compilers, cmark_gfm, stdlib]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -1696,6 +1728,8 @@ jobs:
           searchPattern: '**/*.exe'
 
   sdk:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.builder_os == 'Windows'
     needs: [libxml2, curl, zlib, compilers, cmark_gfm, stdlib, macros]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -2194,6 +2228,8 @@ jobs:
           searchPattern: '**/*.dll'
 
   devtools:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.builder_os == 'Windows'
     needs: [sqlite, compilers, stdlib, sdk]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -2912,6 +2948,8 @@ jobs:
           searchPattern: '**/*.exe'
 
   debugging_tools:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.builder_os == 'Windows'
     needs: [compilers, devtools, stdlib, sdk]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -3063,6 +3101,8 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot-DebuggingTools
 
   package_tools:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.builder_os == 'Windows'
     name: Package Tools
     needs: [compilers, macros, debugging_tools, devtools]
     runs-on: ${{ inputs.default_build_runner }}
@@ -3223,6 +3263,8 @@ jobs:
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.cab
 
   package_windows_sdk_runtime:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.builder_os == 'Windows'
     name: Package Windows SDK & Runtime
     needs: [stdlib, sdk]
     runs-on: ${{ inputs.default_build_runner }}
@@ -3327,6 +3369,8 @@ jobs:
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/rtl.${{ matrix.arch }}.cab
 
   package_android_sdk_runtime:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.builder_os == 'Windows'
     name: Package Android SDK & Runtime
     needs: [stdlib, sdk]
     runs-on: ${{ inputs.default_build_runner }}
@@ -3406,6 +3450,8 @@ jobs:
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.cpu }}/android_sdk.${{ matrix.cpu }}.cab
 
   installer:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.builder_os == 'Windows'
     needs: [package_tools, package_windows_sdk_runtime, package_android_sdk_runtime]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -3540,6 +3586,8 @@ jobs:
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/installer.exe
 
   smoke_test:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.builder_os == 'Windows'
     needs: [installer]
     runs-on: ${{ inputs.default_build_runner }}
 

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -249,12 +249,14 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/swift-toolchain-sqlite
           show-progress: false
 
-      # TODO: Add a macOS-equivalent to set up ninja.
       - uses: compnerd/gha-setup-vsdevenv@main
         with:
           host_arch: ${{ inputs.build_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
+
+      - uses: seanmiddleditch/gha-setup-ninja@master
+        if: inputs.build_os == 'Darwin'
 
       - name: Compute workspace hash
         id: workspace_hash

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3,11 +3,11 @@ name: Swift Toolchain Build
 on:
   workflow_call:
     inputs:
-      builder_os:
+      build_os:
         required: true
         type: string
 
-      builder_arch:
+      build_arch:
         required: true
         type: string
 
@@ -151,14 +151,6 @@ on:
         required: true
         type: string
 
-      HOST_CMAKE_C_FLAGS:
-        required: true
-        type: string
-
-      HOST_CMAKE_CXX_FLAGS:
-        required: true
-        type: string
-
       WINDOWS_CMAKE_C_FLAGS:
         required: true
         type: string
@@ -238,7 +230,11 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.host_matrix) }}
 
-    name: SQLite3 (${{ matrix.os }} ${{ matrix.arch }})
+    name: ${{ matrix.os }} ${{ matrix.arch }} SQLite3
+
+    defaults:
+      run:
+        shell: pwsh
 
     steps:
       - uses: actions/checkout@v4
@@ -253,24 +249,15 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/swift-toolchain-sqlite
           show-progress: false
 
+      # TODO: Add a macOS-equivalent to set up ninja.
       - uses: compnerd/gha-setup-vsdevenv@main
-        if: inputs.builder_os == 'Windows'
         with:
-          host_arch: ${{ inputs.builder_arch }}
+          host_arch: ${{ inputs.build_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
-      - uses: maxim-lobanov/setup-xcode@v1
-        if: inputs.builder_os == 'Darwin'
-        with:
-          xcode-version: latest-stable
-
-      - uses: seanmiddleditch/gha-setup-ninja@master
-        if: inputs.builder_os == 'Darwin'
-
       - name: Compute workspace hash
         id: workspace_hash
-        shell: pwsh
         run: |
           $stringAsStream = [System.IO.MemoryStream]::new()
           $writer = [System.IO.StreamWriter]::new($stringAsStream)
@@ -288,7 +275,6 @@ jobs:
           variant: sccache
 
       - name: Configure SQLite
-        shell: pwsh
         run: |
           cmake -B ${{ github.workspace }}/BinaryCache/sqlite-${{ inputs.swift_toolchain_sqlite_version }} `
                 -D BUILD_SHARED_LIBS=NO `
@@ -317,7 +303,7 @@ jobs:
 
   cmark_gfm:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.builder_os == 'Windows'
+    if: inputs.build_os == 'Windows'
     runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
@@ -388,7 +374,7 @@ jobs:
 
   build_tools:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.builder_os == 'Windows'
+    if: inputs.build_os == 'Windows'
     needs: [cmark_gfm]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -506,7 +492,7 @@ jobs:
 
   compilers:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.builder_os == 'Windows'
+    if: inputs.build_os == 'Windows'
     needs: [build_tools, cmark_gfm]
     runs-on: ${{ inputs.compilers_build_runner }}
 
@@ -779,7 +765,7 @@ jobs:
 
   zlib:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.builder_os == 'Windows'
+    if: inputs.build_os == 'Windows'
     runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
@@ -915,7 +901,7 @@ jobs:
 
   curl:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.builder_os == 'Windows'
+    if: inputs.build_os == 'Windows'
     needs: [zlib]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -1134,7 +1120,7 @@ jobs:
 
   libxml2:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.builder_os == 'Windows'
+    if: inputs.build_os == 'Windows'
     runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
@@ -1276,7 +1262,7 @@ jobs:
 
   stdlib:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.builder_os == 'Windows'
+    if: inputs.build_os == 'Windows'
     needs: [compilers, cmark_gfm]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -1564,7 +1550,7 @@ jobs:
 
   macros:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.builder_os == 'Windows'
+    if: inputs.build_os == 'Windows'
     needs: [compilers, cmark_gfm, stdlib]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -1729,7 +1715,7 @@ jobs:
 
   sdk:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.builder_os == 'Windows'
+    if: inputs.build_os == 'Windows'
     needs: [libxml2, curl, zlib, compilers, cmark_gfm, stdlib, macros]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -2229,7 +2215,7 @@ jobs:
 
   devtools:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.builder_os == 'Windows'
+    if: inputs.build_os == 'Windows'
     needs: [sqlite, compilers, stdlib, sdk]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -2949,7 +2935,7 @@ jobs:
 
   debugging_tools:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.builder_os == 'Windows'
+    if: inputs.build_os == 'Windows'
     needs: [compilers, devtools, stdlib, sdk]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -3102,7 +3088,7 @@ jobs:
 
   package_tools:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.builder_os == 'Windows'
+    if: inputs.build_os == 'Windows'
     name: Package Tools
     needs: [compilers, macros, debugging_tools, devtools]
     runs-on: ${{ inputs.default_build_runner }}
@@ -3264,7 +3250,7 @@ jobs:
 
   package_windows_sdk_runtime:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.builder_os == 'Windows'
+    if: inputs.build_os == 'Windows'
     name: Package Windows SDK & Runtime
     needs: [stdlib, sdk]
     runs-on: ${{ inputs.default_build_runner }}
@@ -3370,7 +3356,7 @@ jobs:
 
   package_android_sdk_runtime:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.builder_os == 'Windows'
+    if: inputs.build_os == 'Windows'
     name: Package Android SDK & Runtime
     needs: [stdlib, sdk]
     runs-on: ${{ inputs.default_build_runner }}
@@ -3451,7 +3437,7 @@ jobs:
 
   installer:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.builder_os == 'Windows'
+    if: inputs.build_os == 'Windows'
     needs: [package_tools, package_windows_sdk_runtime, package_android_sdk_runtime]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -3587,7 +3573,7 @@ jobs:
 
   smoke_test:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.builder_os == 'Windows'
+    if: inputs.build_os == 'Windows'
     needs: [installer]
     runs-on: ${{ inputs.default_build_runner }}
 


### PR DESCRIPTION
This adds a new Mac workflow, currently disabled by default and adapts the sqlite job to build on Mac. All other jobs are currently only enabled for Windows, they will be adapted in subsequent PRs.