### PR TITLE
GHA: wire up Foundation macros to swift-corelibs-foundation

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1918,7 +1918,8 @@ jobs:
                 -D LIBXML2_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/libxml2-2.11.5/usr/include/libxml2 `
                 -D LIBXML2_LIBRARY=${{ github.workspace }}/BuildRoot/Library/libxml2-2.11.5/usr/lib/$LIBXML `
                 -D ZLIB_ROOT=${{ github.workspace }}/BuildRoot/Library/zlib-1.3/usr `
-                -D ZLIB_LIBRARY=${{ github.workspace }}/BuildRoot/Library/zlib-1.3/usr/lib/$LIBZ
+                -D ZLIB_LIBRARY=${{ github.workspace }}/BuildRoot/Library/zlib-1.3/usr/lib/$LIBZ `
+                -D SwiftFoundation_MACRO=${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin
       - name: Build foundation
         run: |
           cmake --build ${{ github.workspace }}/BinaryCache/foundation


### PR DESCRIPTION
We are already building the Foundation macros but did not pass that along to the Foundation build. This is now required and failure to pass it along results in a build failure. Wire it up so that we can build and avoid another build of the macros.