### PR TITLE
Add the workspace hash to ccache key

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -258,7 +258,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
-          key: ${{ matrix.os }}-${{ matrix.arch }}-sqlite
+          key: ${{ inputs.default_build_runner }}-${{ matrix.os }}-${{ matrix.arch }}-sqlite
           variant: sccache
 
       - name: Configure SQLite
@@ -315,7 +315,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 1M
-          key: windows-${{ matrix.arch }}-cmark-gfm
+          key: ${{ inputs.default_build_runner }}-windows-${{ matrix.arch }}-cmark-gfm
           variant: sccache
 
       - name: Configure cmark-gfm
@@ -375,7 +375,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
-          key: windows-amd64-build_tools
+          key: ${{ inputs.default_build_runner }}-windows-amd64-build_tools
           variant: sccache
 
       - name: Configure Tools
@@ -558,7 +558,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 500M
-          key: windows-${{ matrix.arch }}-compilers
+          key: ${{ inputs.compilers_build_runner }}-windows-${{ matrix.arch }}-compilers
           variant: sccache
 
       - name: Configure Compilers
@@ -790,7 +790,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
-          key: ${{ matrix.os }}-${{ matrix.arch }}-zlib
+          key: ${{ inputs.default_build_runner }}-${{ matrix.os }}-${{ matrix.arch }}-zlib
           variant: sccache
 
       - uses: nttld/setup-ndk@v1
@@ -918,7 +918,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
-          key: ${{ matrix.os }}-${{ matrix.arch }}-curl
+          key: ${{ inputs.default_build_runner }}-${{ matrix.os }}-${{ matrix.arch }}-curl
           variant: sccache
 
       - uses: nttld/setup-ndk@v1
@@ -1117,7 +1117,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
-          key: ${{ matrix.os }}-${{ matrix.arch }}-libxml2
+          key: ${{ inputs.default_build_runner }}-${{ matrix.os }}-${{ matrix.arch }}-libxml2
           variant: sccache
 
       - uses: nttld/setup-ndk@v1

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -254,11 +254,23 @@ jobs:
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
+      - name: Compute workspace hash
+        id: workspace_hash
+        shell: pwsh
+        run: |
+          $stringAsStream = [System.IO.MemoryStream]::new()
+          $writer = [System.IO.StreamWriter]::new($stringAsStream)
+          $writer.write("${{ github.workspace }}")
+          $writer.Flush()
+          $stringAsStream.Position = 0
+          $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
+          echo "hash=$hash" >> $env:GITHUB_OUTPUT
+
       - name: Setup sccache
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
-          key: ${{ inputs.default_build_runner }}-${{ matrix.os }}-${{ matrix.arch }}-sqlite
+          key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-sqlite
           variant: sccache
 
       - name: Configure SQLite
@@ -311,11 +323,23 @@ jobs:
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
+      - name: Compute workspace hash
+        id: workspace_hash
+        shell: pwsh
+        run: |
+          $stringAsStream = [System.IO.MemoryStream]::new()
+          $writer = [System.IO.StreamWriter]::new($stringAsStream)
+          $writer.write("${{ github.workspace }}")
+          $writer.Flush()
+          $stringAsStream.Position = 0
+          $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
+          echo "hash=$hash" >> $env:GITHUB_OUTPUT
+
       - name: Setup sccache
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 1M
-          key: ${{ inputs.default_build_runner }}-windows-${{ matrix.arch }}-cmark-gfm
+          key: ${{ steps.workspace_hash.outputs.hash }}-windows-${{ matrix.arch }}-cmark-gfm
           variant: sccache
 
       - name: Configure cmark-gfm
@@ -371,11 +395,23 @@ jobs:
 
       - uses: compnerd/gha-setup-vsdevenv@main
 
+      - name: Compute workspace hash
+        id: workspace_hash
+        shell: pwsh
+        run: |
+          $stringAsStream = [System.IO.MemoryStream]::new()
+          $writer = [System.IO.StreamWriter]::new($stringAsStream)
+          $writer.write("${{ github.workspace }}")
+          $writer.Flush()
+          $stringAsStream.Position = 0
+          $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
+          echo "hash=$hash" >> $env:GITHUB_OUTPUT
+
       - name: Setup sccache
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
-          key: ${{ inputs.default_build_runner }}-windows-amd64-build_tools
+          key: ${{ steps.workspace_hash.outputs.hash }}-windows-amd64-build_tools
           variant: sccache
 
       - name: Configure Tools
@@ -554,11 +590,23 @@ jobs:
         with:
           ndk-version: r26b
 
+      - name: Compute workspace hash
+        id: workspace_hash
+        shell: pwsh
+        run: |
+          $stringAsStream = [System.IO.MemoryStream]::new()
+          $writer = [System.IO.StreamWriter]::new($stringAsStream)
+          $writer.write("${{ github.workspace }}")
+          $writer.Flush()
+          $stringAsStream.Position = 0
+          $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
+          echo "hash=$hash" >> $env:GITHUB_OUTPUT
+
       - name: Setup sccache
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 500M
-          key: ${{ inputs.compilers_build_runner }}-windows-${{ matrix.arch }}-compilers
+          key: ${{ steps.workspace_hash.outputs.hash }}-windows-${{ matrix.arch }}-compilers
           variant: sccache
 
       - name: Configure Compilers
@@ -786,11 +834,23 @@ jobs:
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
+      - name: Compute workspace hash
+        id: workspace_hash
+        shell: pwsh
+        run: |
+          $stringAsStream = [System.IO.MemoryStream]::new()
+          $writer = [System.IO.StreamWriter]::new($stringAsStream)
+          $writer.write("${{ github.workspace }}")
+          $writer.Flush()
+          $stringAsStream.Position = 0
+          $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
+          echo "hash=$hash" >> $env:GITHUB_OUTPUT
+
       - name: Setup sccache
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
-          key: ${{ inputs.default_build_runner }}-${{ matrix.os }}-${{ matrix.arch }}-zlib
+          key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-zlib
           variant: sccache
 
       - uses: nttld/setup-ndk@v1
@@ -914,11 +974,23 @@ jobs:
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
+      - name: Compute workspace hash
+        id: workspace_hash
+        shell: pwsh
+        run: |
+          $stringAsStream = [System.IO.MemoryStream]::new()
+          $writer = [System.IO.StreamWriter]::new($stringAsStream)
+          $writer.write("${{ github.workspace }}")
+          $writer.Flush()
+          $stringAsStream.Position = 0
+          $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
+          echo "hash=$hash" >> $env:GITHUB_OUTPUT
+
       - name: Setup sccache
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
-          key: ${{ inputs.default_build_runner }}-${{ matrix.os }}-${{ matrix.arch }}-curl
+          key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-curl
           variant: sccache
 
       - uses: nttld/setup-ndk@v1
@@ -1113,11 +1185,23 @@ jobs:
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
+      - name: Compute workspace hash
+        id: workspace_hash
+        shell: pwsh
+        run: |
+          $stringAsStream = [System.IO.MemoryStream]::new()
+          $writer = [System.IO.StreamWriter]::new($stringAsStream)
+          $writer.write("${{ github.workspace }}")
+          $writer.Flush()
+          $stringAsStream.Position = 0
+          $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
+          echo "hash=$hash" >> $env:GITHUB_OUTPUT
+
       - name: Setup sccache
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
-          key: ${{ inputs.default_build_runner }}-${{ matrix.os }}-${{ matrix.arch }}-libxml2
+          key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-libxml2
           variant: sccache
 
       - uses: nttld/setup-ndk@v1


### PR DESCRIPTION
Depending on the runner configuration, `github.workspace` might be set up differently, resulting in issues when restoring previous builds from sccache. In order to work around this issue, this adds a hash of `github.workspace` to the sccache key to uniquely identify the build between different runner types.