### PR TITLE
[Macros] Remove upload exe step

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1706,15 +1706,6 @@ jobs:
           symbolsFolder: ${{ github.workspace }}/BinaryCache/swift-foundation-macros
           searchPattern: '**/*.dll'
 
-      - name: Upload EXEs to Azure
-        uses: microsoft/action-publish-symbols@v2.1.6
-        if: ${{ inputs.debug_info }}
-        with:
-          accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
-          personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
-          symbolsFolder: ${{ github.workspace }}/BinaryCache/swift-foundation-macros
-          searchPattern: '**/*.exe'
-
   sdk:
     # TODO: Build this on macOS or make an equivalent Mac-only job
     if: inputs.build_os == 'Windows'


### PR DESCRIPTION
The "macros" jobs are configured to only build shared libraries.