### PR TITLE
[android] include ds2 binary in the Android installer

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3422,7 +3422,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: ds2-Android-${{ matrix.arch }}
-          path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Android.platform/Developer/Library/Android/${{ matrix.triple_no_api_level }}
+          path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Android.platform/Developer/Library/${{ matrix.triple_no_api_level }}
 
       - uses: actions/checkout@v4
         with:
@@ -3460,6 +3460,7 @@ jobs:
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
               -p:Configuration=Release `
               -p:SignOutput=${{ inputs.signed }} `
+              -p:ANDROID_INCLUDE_DS2=true `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:PLATFORM_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Android.platform `


### PR DESCRIPTION
## Purpose
Include the Android ds2 binaries in the Swift toolchain Windows installer.

## Overview
* Explicitly sets `ANDROID_INCLUDE_DS2=true` when building the installer so the ds2 Android binaries get included in the installer.
* Remove an extra "Android" from the download path to match the expected file location in the .wxs file.

## Validation
Successful swift-toolchain build with this change [here](https://github.com/thebrowsercompany/swift-build/actions/runs/10744313759).

Downloaded the Android SDK installer artifacts `sdk-android-armv7-msi`, `sdk-android-x86_64-msi`, `sdk-android-arm64-msi`, and `sdk-android-i686-msi` and verified the `ds2` binary is present using Windows MSI viewer.