### PR TITLE
Set cflags matrix variable properly

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -305,7 +305,7 @@ jobs:
                   "arch": "amd64",
                   "os": "Windows",
                   "cc": "cl",
-                  "ccflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
+                  "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}"
                 },
@@ -313,7 +313,7 @@ jobs:
                   "arch": "arm64",
                   "os": "Windows",
                   "cc": "cl",
-                  "ccflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
+                  "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}"
                 }
@@ -326,7 +326,7 @@ jobs:
                   "arch": "amd64",
                   "os": "Windows",
                   "cc": "cl",
-                  "ccflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
+                  "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}"
                 }
@@ -339,7 +339,7 @@ jobs:
                   "arch": "amd64",
                   "os": "Windows",
                   "cc": "cl",
-                  "ccflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
+                  "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
                   "extra_flags": ""
@@ -348,7 +348,7 @@ jobs:
                   "arch": "arm64",
                   "os": "Windows",
                   "cc": "cl",
-                  "ccflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
+                  "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
                   "extra_flags": ""
@@ -357,7 +357,7 @@ jobs:
                   "arch": "x86",
                   "os": "Windows",
                   "cc": "cl",
-                  "ccflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
+                  "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
                   "extra_flags": ""
@@ -366,7 +366,7 @@ jobs:
                   "arch": "arm64",
                   "os": "Android",
                   "cc": "clang",
-                  "ccflags": "${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}",
+                  "cflags": "${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}",
                   "extra_flags": "-DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a"
@@ -375,7 +375,7 @@ jobs:
                   "arch": "armv7",
                   "os": "Android",
                   "cc": "clang",
-                  "ccflags": "${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}",
+                  "cflags": "${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}",
                   "extra_flags": "-DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a"
@@ -384,7 +384,7 @@ jobs:
                   "arch": "i686",
                   "os": "Android",
                   "cc": "clang",
-                  "ccflags": "${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}",
+                  "cflags": "${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}",
                   "extra_flags": "-DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86"
@@ -393,7 +393,7 @@ jobs:
                   "arch": "x86_64",
                   "os": "Android",
                   "cc": "clang",
-                  "ccflags": "${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}",
+                  "cflags": "${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}",
                   "extra_flags": "-DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86_64"
@@ -407,7 +407,7 @@ jobs:
                   "arch": "x86_64",
                   "os": "Darwin",
                   "cc": "clang",
-                  "ccflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
+                  "cflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}"
                 },
@@ -415,7 +415,7 @@ jobs:
                   "arch": "aarch64",
                   "os": "Darwin",
                   "cc": "clang",
-                  "ccflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
+                  "cflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}"
                 }
@@ -428,7 +428,7 @@ jobs:
                   "arch": "aarch64",
                   "os": "Darwin",
                   "cc": "clang",
-                  "ccflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
+                  "cflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}"
                 }
@@ -441,7 +441,7 @@ jobs:
                   "arch": "x86_64",
                   "os": "Darwin",
                   "cc": "clang",
-                  "ccflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
+                  "cflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}",
                   "extra_flags": ""
@@ -450,7 +450,7 @@ jobs:
                   "arch": "aarch64",
                   "os": "Darwin",
                   "cc": "clang",
-                  "ccflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
+                  "cflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}",
                   "extra_flags": ""


### PR DESCRIPTION
The variable had been erroneously names `ccflags`.