### PR TITLE
[mac build] Build early swift-driver

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -147,7 +147,8 @@ jobs:
       ANDROID_CMAKE_EXE_LINKER_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}
       ANDROID_CMAKE_SHARED_LINKER_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}
       ANDROID_NDK_VERSION: ${{ steps.context.outputs.ANDROID_NDK_VERSION }}
-      CMAKE_Swift_FLAGS: ${{ steps.context.outputs.CMAKE_Swift_FLAGS }}
+      WINDOWS_CMAKE_Swift_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}
+      DARWIN_CMAKE_Swift_FLAGS: ${{ steps.context.outputs.DARWIN_CMAKE_Swift_FLAGS }}
       debug_info: ${{ steps.context.outputs.debug_info }}
       signed: ${{ steps.context.outputs.signed }}
       swift_version: ${{ steps.context.outputs.swift_version }}
@@ -247,7 +248,8 @@ jobs:
             echo ANDROID_CMAKE_CXX_FLAGS="-ffunction-sections -fdata-sections -g" >> ${GITHUB_OUTPUT}
             echo WINDOWS_CMAKE_EXE_LINKER_FLAGS="-incremental:no -debug -opt:ref -opt:icf" >> ${GITHUB_OUTPUT}
             echo WINDOWS_CMAKE_SHARED_LINKER_FLAGS="-incremental:no -debug -opt:ref -opt:icf" >> ${GITHUB_OUTPUT}
-            echo CMAKE_Swift_FLAGS="-g -debug-info-format=codeview -Xlinker -debug -Xlinker -incremental:no -Xlinker -opt:ref -Xlinker -opt:icf" >> ${GITHUB_OUTPUT}
+            echo WINDOWS_CMAKE_Swift_FLAGS="-g -debug-info-format=codeview -Xlinker -debug -Xlinker -incremental:no -Xlinker -opt:ref -Xlinker -opt:icf" >> ${GITHUB_OUTPUT}
+            echo DARWIN_CMAKE_Swift_FLAGS="-g" >> ${GITHUB_OUTPUT}
           else
             echo debug_info=false >> ${GITHUB_OUTPUT}
             echo WINDOWS_CMAKE_C_FLAGS="/GS- /Gw /Gy /Oi /Oy /Zc:inline /Zc:preprocessor" >> ${GITHUB_OUTPUT}
@@ -258,7 +260,8 @@ jobs:
             echo ANDROID_CMAKE_CXX_FLAGS="-ffunction-sections -fdata-sections" >> ${GITHUB_OUTPUT}
             echo WINDOWS_CMAKE_EXE_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
             echo WINDOWS_CMAKE_SHARED_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
-            echo CMAKE_Swift_FLAGS="-Xlinker -incremental:no -Xlinker -opt:ref -Xlinker -opt:icf" >> ${GITHUB_OUTPUT}
+            echo WINDOWS_CMAKE_Swift_FLAGS="-Xlinker -incremental:no -Xlinker -opt:ref -Xlinker -opt:icf" >> ${GITHUB_OUTPUT}
+            echo DARWIN_CMAKE_Swift_FLAGS="" >> ${GITHUB_OUTPUT}
           fi
           echo ANDROID_CMAKE_EXE_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
           echo ANDROID_CMAKE_SHARED_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
@@ -303,19 +306,25 @@ jobs:
               "include": [
                 {
                   "arch": "amd64",
+                  "compiler_target": "x86_64-unknown-windows-msvc",
                   "os": "Windows",
                   "cc": "cl",
                   "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
                   "cxx": "cl",
-                  "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}"
+                  "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
+                  "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=AMD64 -D CMAKE_MT=mt"
                 },
                 {
                   "arch": "arm64",
+                  "compiler_target": "aarch64-unknown-windows-msvc",
                   "os": "Windows",
                   "cc": "cl",
                   "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
                   "cxx": "cl",
-                  "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}"
+                  "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
+                  "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=ARM64 -D CMAKE_MT=mt"
                 }
               ]
             }
@@ -328,7 +337,9 @@ jobs:
                   "cc": "cl",
                   "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
                   "cxx": "cl",
-                  "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}"
+                  "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
+                  "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=AMD64 -D CMAKE_MT=mt"
                 }
               ]
             }
@@ -342,7 +353,8 @@ jobs:
                   "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
-                  "extra_flags": ""
+                  "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=AMD64 -D CMAKE_MT=mt"
                 },
                 {
                   "arch": "arm64",
@@ -351,7 +363,8 @@ jobs:
                   "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
-                  "extra_flags": ""
+                  "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=ARM64 -D CMAKE_MT=mt"
                 },
                 {
                   "arch": "x86",
@@ -360,7 +373,8 @@ jobs:
                   "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
-                  "extra_flags": ""
+                  "swiftflags": "",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=X86 -D CMAKE_MT=mt"
                 },
                 {
                   "arch": "arm64",
@@ -369,6 +383,7 @@ jobs:
                   "cflags": "${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}",
+                  "swiftflags": "",
                   "extra_flags": "-DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a"
                 },
                 {
@@ -378,6 +393,7 @@ jobs:
                   "cflags": "${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}",
+                  "swiftflags": "",
                   "extra_flags": "-DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a"
                 },
                 {
@@ -387,6 +403,7 @@ jobs:
                   "cflags": "${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}",
+                  "swiftflags": "",
                   "extra_flags": "-DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86"
                 },
                 {
@@ -396,6 +413,7 @@ jobs:
                   "cflags": "${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}",
+                  "swiftflags": "",
                   "extra_flags": "-DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86_64"
                 }
               ]
@@ -405,19 +423,25 @@ jobs:
               "include": [
                 {
                   "arch": "x86_64",
+                  "compiler_target": "x86_64-apple-macosx10.15",
                   "os": "Darwin",
                   "cc": "clang",
                   "cflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
-                  "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}"
+                  "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}",
+                  "swiftflags": "${{ steps.context.outputs.DARWIN_CMAKE_Swift_FLAGS }}",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=x86_64 -D CMAKE_OSX_DEPLOYMENT_TARGET=\"10.15\" -D CMAKE_OSX_ARCHITECTURES=x86_64"
                 },
                 {
-                  "arch": "aarch64",
+                  "arch": "arm64",
+                  "compiler_target": "arm64-apple-macosx10.15",
                   "os": "Darwin",
                   "cc": "clang",
                   "cflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
-                  "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}"
+                  "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}",
+                  "swiftflags": "${{ steps.context.outputs.DARWIN_CMAKE_Swift_FLAGS }}",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=arm64 -D CMAKE_OSX_DEPLOYMENT_TARGET=\"10.15\" -D CMAKE_OSX_ARCHITECTURES=arm64"
                 }
               ]
             }
@@ -425,12 +449,14 @@ jobs:
             {
               "include": [
                 {
-                  "arch": "aarch64",
+                  "arch": "arm64",
                   "os": "Darwin",
                   "cc": "clang",
                   "cflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}"
+                  "swiftflags": "${{ steps.context.outputs.DARWIN_CMAKE_Swift_FLAGS }}",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=arm64 -D CMAKE_OSX_DEPLOYMENT_TARGET=\"10.15\" -D CMAKE_OSX_ARCHITECTURES=arm64"
                 }
               ]
             }
@@ -444,16 +470,18 @@ jobs:
                   "cflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}",
-                  "extra_flags": ""
+                  "swiftflags": "${{ steps.context.outputs.DARWIN_CMAKE_Swift_FLAGS }}",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=x86_64 -D CMAKE_OSX_DEPLOYMENT_TARGET=\"10.15\" -D CMAKE_OSX_ARCHITECTURES=x86_64"
                 },
                 {
-                  "arch": "aarch64",
+                  "arch": "arm64",
                   "os": "Darwin",
                   "cc": "clang",
                   "cflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}",
-                  "extra_flags": ""
+                  "swiftflags": "${{ steps.context.outputs.DARWIN_CMAKE_Swift_FLAGS }}",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=arm64 -D CMAKE_OSX_DEPLOYMENT_TARGET=\"10.15\" -D CMAKE_OSX_ARCHITECTURES=arm64"
                 }
               ]
             }
@@ -524,7 +552,7 @@ jobs:
       ANDROID_CMAKE_EXE_LINKER_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}
       ANDROID_CMAKE_SHARED_LINKER_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}
       ANDROID_NDK_VERSION: ${{ needs.context.outputs.ANDROID_NDK_VERSION }}
-      CMAKE_Swift_FLAGS: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
+      CMAKE_Swift_FLAGS: ${{ needs.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}
       debug_info: ${{ fromJSON(needs.context.outputs.debug_info) }}
       signed: ${{ fromJSON(needs.context.outputs.signed) }}
       swift_version: ${{ needs.context.outputs.swift_version }}
@@ -597,7 +625,7 @@ jobs:
       ANDROID_CMAKE_EXE_LINKER_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}
       ANDROID_CMAKE_SHARED_LINKER_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}
       ANDROID_NDK_VERSION: ${{ needs.context.outputs.ANDROID_NDK_VERSION }}
-      CMAKE_Swift_FLAGS: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
+      CMAKE_Swift_FLAGS: ${{ needs.context.outputs.DARWIN_CMAKE_Swift_FLAGS }}
       debug_info: ${{ fromJSON(needs.context.outputs.debug_info) }}
       signed: ${{ fromJSON(needs.context.outputs.signed) }}
       swift_version: ${{ needs.context.outputs.swift_version }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -323,10 +323,9 @@ jobs:
                 -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
                 -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr `
                 -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
-                -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} `
+                ${{ matrix.extra_flags }} `
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/swift-toolchain-sqlite
       - name: Build SQLite
@@ -548,11 +547,10 @@ jobs:
                 -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
                 -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr `
                 -D CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=YES `
                 -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
-                -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} `
+                ${{ matrix.extra_flags }} `
                 -S ${{ github.workspace }}/SourceCache/cmark-gfm `
                 -G Ninja
       - name: Build cmark-gfm
@@ -626,7 +624,7 @@ jobs:
                 -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
                 -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_MT=mt `
+                ${{ matrix.extra_flags }} `
                 -D cmark-gfm_DIR=${{ github.workspace }}/BuildRoot/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr/lib/cmake `
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/llvm-project/llvm `
@@ -699,6 +697,320 @@ jobs:
             ${{ steps.export-binary-paths.outputs.swift_def_to_strings_converter }}
             ${{ steps.export-binary-paths.outputs.swift_serialize_diagnostics }}
             ${{ steps.export-binary-paths.outputs.swift_compatibility_symbols }}
+
+  early_swift_driver:
+    # TODO: Build this on Windows too.
+    if: inputs.build_os == 'Darwin'
+    needs: [sqlite]
+    runs-on: ${{ inputs.default_build_runner }}
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(inputs.host_matrix) }}
+
+    name: ${{ matrix.os }} ${{ matrix.arch }} Early Swift Driver
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: sqlite-${{ matrix.os }}-${{ matrix.arch }}-${{ inputs.swift_toolchain_sqlite_version }}
+          path: ${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr
+
+      - uses: actions/checkout@v4
+        with:
+          repository: swiftlang/swift-llbuild
+          ref: ${{ inputs.swift_llbuild_revision }}
+          path: ${{ github.workspace }}/SourceCache/swift-llbuild
+          show-progress: false
+      - uses: actions/checkout@v4
+        with:
+          repository: swiftlang/swift-tools-support-core
+          ref: ${{ inputs.swift_tools_support_core_revision }}
+          path: ${{ github.workspace }}/SourceCache/swift-tools-support-core
+          show-progress: false
+      - uses: actions/checkout@v4
+        with:
+          repository: apple/swift-argument-parser
+          ref: ${{ inputs.swift_argument_parser_revision }}
+          path: ${{ github.workspace }}/SourceCache/swift-argument-parser
+          show-progress: false
+      - uses: actions/checkout@v4
+        with:
+          repository: jpsim/Yams
+          ref: ${{ inputs.yams_revision }}
+          path: ${{ github.workspace }}/SourceCache/Yams
+          show-progress: false
+      - uses: actions/checkout@v4
+        with:
+          repository: swiftlang/swift-driver
+          ref: ${{ inputs.swift_driver_revision }}
+          path: ${{ github.workspace }}/SourceCache/swift-driver
+          show-progress: false
+
+      - uses: compnerd/gha-setup-vsdevenv@main
+        with:
+          host_arch: ${{ inputs.build_arch }}
+          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+          arch: ${{ matrix.arch }}
+
+      - uses: seanmiddleditch/gha-setup-ninja@master
+        if: inputs.build_os == 'Darwin'
+
+      # TODO: Use the TBC builds once we have a Mac toolchain release.
+      - name: Install Swift Toolchain (Mac)
+        if: inputs.build_os == 'Darwin'
+        uses: compnerd/gha-setup-swift@main
+        with:
+          branch: swift-6.0.1-release
+          tag: 6.0.1-RELEASE
+
+      - name: Set up configuration context
+        id: context
+        run: |
+          if ("${{ matrix.os }}" -eq "Windows") {
+            $SDKROOT = "${env:SDKROOT}"
+            $SQLite3_lib = "${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/lib/SQLite3.lib"
+            $PlatformName = "windows"
+          } else {
+            $SDKROOT = xcrun --sdk macosx --show-sdk-path
+            $SQLite3_lib = "${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/lib/libSQLite3.a"
+            $PlatformName = "macosx"
+          }
+
+          # The Swift compiler expects a specific folder name for the early swift-driver build.
+          $InstallFolderName = "earlyswiftdriver-${PlatformName}-${{ matrix.arch }}"
+
+          echo "SDKROOT=$SDKROOT" >> $env:GITHUB_OUTPUT
+          echo "SQLite3_lib=$SQLite3_lib" >> $env:GITHUB_OUTPUT
+          echo "InstallFolderName=$InstallFolderName" >> $env:GITHUB_OUTPUT
+
+      - name: Configure swift-llbuild
+        run: |
+          cmake -B ${{ github.workspace }}/BinaryCache/swift-llbuild `
+                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_TESTING=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
+                -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
+                -D CMAKE_C_COMPILER_TARGET=${{ matrix.compiler_target }} `
+                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
+                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
+                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.compiler_target }} `
+                -D CMAKE_Swift_COMPILER=swiftc `
+                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.compiler_target }} `
+                -D CMAKE_Swift_COMPILER_WORKS=YES `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ steps.context.outputs.SDKROOT }} ${{ matrix.swiftflags }}" `
+                -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
+                ${{ matrix.extra_flags }} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-llbuild `
+                -D LLBUILD_SUPPORT_BINDINGS=Swift `
+                -D SQLite3_LIBRARY=${{ steps.context.outputs.SQLite3_lib }} `
+                -D SQLite3_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/include
+      - name: Build swift-llbuild
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-llbuild
+
+      - name: Configure swift-tools-support-core
+        run: |
+          cmake -B ${{ github.workspace }}/BinaryCache/swift-tools-support-core `
+                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_TESTING=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
+                -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
+                -D CMAKE_C_COMPILER_TARGET=${{ matrix.compiler_target }} `
+                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
+                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
+                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.compiler_target }} `
+                -D CMAKE_Swift_COMPILER=swiftc `
+                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.compiler_target }} `
+                -D CMAKE_Swift_COMPILER_WORKS=YES `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ steps.context.outputs.SDKROOT }} ${{ matrix.swiftflags }}" `
+                -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
+                ${{ matrix.extra_flags }} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-tools-support-core `
+                -D SQLite3_LIBRARY=${{ steps.context.outputs.SQLite3_lib }} `
+                -D SQLite3_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/include
+      - name: Build swift-tools-support-core
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-tools-support-core
+
+      - name: Configure swift-argument-parser
+        run: |
+          cmake -B ${{ github.workspace }}/BinaryCache/swift-argument-parser `
+                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_TESTING=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
+                -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
+                -D CMAKE_C_COMPILER_TARGET=${{ matrix.compiler_target }} `
+                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
+                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
+                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.compiler_target }} `
+                -D CMAKE_Swift_COMPILER=swiftc `
+                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.compiler_target }} `
+                -D CMAKE_Swift_COMPILER_WORKS=YES `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ steps.context.outputs.SDKROOT }} ${{ matrix.swiftflags }}" `
+                -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
+                ${{ matrix.extra_flags }} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-argument-parser
+      - name: Build swift-argument-parser
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-argument-parser
+
+      - name: Configure Yams
+        run: |
+          cmake -B ${{ github.workspace }}/BinaryCache/yams `
+                -D BUILD_SHARED_LIBS=NO `
+                -D BUILD_TESTING=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
+                -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
+                -D CMAKE_C_COMPILER_TARGET=${{ matrix.compiler_target }} `
+                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
+                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
+                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.compiler_target }} `
+                -D CMAKE_Swift_COMPILER=swiftc `
+                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.compiler_target }} `
+                -D CMAKE_Swift_COMPILER_WORKS=YES `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ steps.context.outputs.SDKROOT }} ${{ matrix.swiftflags }}" `
+                -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
+                ${{ matrix.extra_flags }} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/Yams
+      - name: Build Yams
+        run: cmake --build ${{ github.workspace }}/BinaryCache/yams
+
+      - name: Configure swift-driver
+        run: |
+          cmake -B ${{ github.workspace }}/BinaryCache/swift-driver `
+                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_TESTING=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
+                -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
+                -D CMAKE_C_COMPILER_TARGET=${{ matrix.compiler_target }} `
+                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
+                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
+                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.compiler_target }} `
+                -D CMAKE_Swift_COMPILER=swiftc `
+                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.compiler_target }} `
+                -D CMAKE_Swift_COMPILER_WORKS=YES `
+                -D CMAKE_Swift_FLAGS="-sdk ${{ steps.context.outputs.SDKROOT }} ${{ matrix.swiftflags }}" `
+                -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
+                ${{ matrix.extra_flags }} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-driver `
+                -D ArgumentParser_DIR=${{ github.workspace }}/BinaryCache/swift-argument-parser/cmake/modules `
+                -D LLBuild_DIR=${{ github.workspace }}/BinaryCache/swift-llbuild/cmake/modules `
+                -D TSC_DIR=${{ github.workspace }}/BinaryCache/swift-tools-support-core/cmake/modules `
+                -D Yams_DIR=${{ github.workspace }}/BinaryCache/yams/cmake/modules
+      - name: Build swift-driver
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-driver
+
+      - name: Create installable package
+        run: |
+          $EarlySwiftDriverDir = Join-Path "${{ github.workspace }}" "BinaryCache" "${{ steps.context.outputs.InstallFolderName }}" "release"
+          $SourceBinDir = Join-Path "${{ github.workspace }}" "BinaryCache" "swift-driver" "bin"
+          $SwiftDriverSourceLibDir = Join-Path "${{ github.workspace }}" "BinaryCache" "swift-driver" "lib"
+          $SwiftTSCSourceLibDir = Join-Path "${{ github.workspace }}" "BinaryCache" "swift-tools-support-core" "lib"
+          $SwiftllbuildSourceLibDir = Join-Path "${{ github.workspace }}" "BinaryCache" "swift-llbuild" "lib"
+          $SwiftArgumentParserSourceLibDir = Join-Path "${{ github.workspace }}" "BinaryCache" "swift-argument-parser" "lib"
+          $InstallBinDir = Join-Path $EarlySwiftDriverDir "bin"
+          $SwiftBinaries = @("swift-driver", "swift-help")
+          $SwiftDriverSharedLibs = @("SwiftDriverExecution", "SwiftDriver", "SwiftOptions")
+          $SwiftTSCSharedLibs = @("TSCUtility", "TSCBasic")
+          $SwiftllbuildSharedLibs = @("llbuildSwift")
+          $SwiftArgumentParserSharedLibs = @("ArgumentParser")
+
+          if ("${{ matrix.os }}" -eq "Darwin") {
+              $InstallLibDir = Join-Path $EarlySwiftDriverDir "lib" "swift" "macosx"
+              $ExeSuffix = ""
+              $SharedLibsSuffix = ".dylib"
+              $SharedLibsPrefix = "lib"
+
+              # This is where Apple toolchains install the Swift libraries.
+              $rpath = "@executable_path/../lib/swift/macosx"
+          } else {
+              $InstallLibDir = $SourceBinDir
+              $ExeSuffix = ".exe"
+              $SharedLibsSuffix = ".dll"
+              $SharedLibsPrefix = ""
+          }
+
+          # Create folders.
+          New-Item -ItemType Directory -Path $InstallBinDir -Force
+          New-Item -ItemType Directory -Path $InstallLibDir -Force
+
+          # Copy binaries.
+          foreach ($bin in $SwiftBinaries) {
+              $binName = "${bin}${ExeSuffix}"
+              $binPath = Join-Path $InstallBinDir $binName
+              Copy-Item -Path "${SourceBinDir}/${binName}" -Destination $binPath -Force
+
+              if ("${{ matrix.os }}" -eq "Darwin") {
+                  # Fix absolute rpath in the binaries.
+                  install_name_tool -delete_rpath $SwiftDriverSourceLibDir $binPath
+                  install_name_tool -delete_rpath $SwiftTSCSourceLibDir $binPath
+                  if ($bin -eq "swift-help") {
+                      install_name_tool -delete_rpath $SwiftArgumentParserSourceLibDir $binPath
+                  }
+                  install_name_tool -add_rpath $rpath $binPath
+              }
+          }
+
+          # Copy libraries.
+          foreach ($lib in $SwiftDriverSharedLibs) {
+              $libName = "${SharedLibsPrefix}${lib}${SharedLibsSuffix}"
+              $libPath = Join-Path $InstallLibDir $libName
+              Copy-Item -Path "${SwiftDriverSourceLibDir}/${libName}" -Destination $libPath -Force
+
+              if ("${{ matrix.os }}" -eq "Darwin") {
+                  # Fix absolute rpath in the libraries.
+                  install_name_tool -delete_rpath $SwiftTSCSourceLibDir $libPath
+                  if ($lib -ne "SwiftOptions") {
+                      install_name_tool -delete_rpath $SwiftDriverSourceLibDir $libPath
+                  }
+                  if ($lib -eq "SwiftDriverExecution") {
+                      install_name_tool -delete_rpath $SwiftllbuildSourceLibDir $libPath
+                  }
+              }
+          }
+          foreach ($lib in $SwiftTSCSharedLibs) {
+              $libName = "${SharedLibsPrefix}${lib}${SharedLibsSuffix}"
+              $libPath = Join-Path $InstallLibDir $libName
+              Copy-Item -Path "${SwiftTSCSourceLibDir}/${libName}" -Destination $libPath -Force
+
+              if ("${{ matrix.os }}" -eq "Darwin" -and $lib -eq "TSCUtility") {
+                  # Fix absolute rpath in the libraries.
+                  install_name_tool -delete_rpath $SwiftTSCSourceLibDir $libPath
+              }
+          }
+          foreach ($lib in $SwiftllbuildSharedLibs) {
+              $libName = "${SharedLibsPrefix}${lib}${SharedLibsSuffix}"
+              $libPath = Join-Path $InstallLibDir $libName
+              Copy-Item -Path "${SwiftllbuildSourceLibDir}/${libName}" -Destination $libPath -Force
+          }
+          foreach ($lib in $SwiftArgumentParserSharedLibs) {
+              $libName = "${SharedLibsPrefix}${lib}${SharedLibsSuffix}"
+              $libPath = Join-Path $InstallLibDir $libName
+              Copy-Item -Path "${SwiftArgumentParserSourceLibDir}/${libName}" -Destination $libPath -Force
+          }
+
+          # Create an archive to preserve permissions.
+          tar -czf "${{ github.workspace }}/BinaryCache/early-swift-driver.tar.gz" `
+              -C "${{ github.workspace }}/BinaryCache" `
+              ${{ steps.context.outputs.InstallFolderName }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: early-swift-driver-${{ matrix.os }}-${{ matrix.arch }}
+          path: ${{ github.workspace }}/BinaryCache/early-swift-driver.tar.gz
 
   compilers:
     # TODO: Build this on macOS or make an equivalent Mac-only job
@@ -1037,7 +1349,6 @@ jobs:
                 -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
                 -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr `
                 -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
                 -D CMAKE_ANDROID_NDK=$NDKPATH `
@@ -1126,7 +1437,6 @@ jobs:
                 -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
                 -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/curl-${{ inputs.curl_version }}/usr `
                 -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
                 ${{ matrix.extra_flags }} `
@@ -1287,7 +1597,6 @@ jobs:
                 -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
                 -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/libxml2-${{ inputs.libxml2_version }}/usr `
                 -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
                 ${{ matrix.extra_flags }} `

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -763,249 +763,52 @@ jobs:
           branch: swift-6.0.1-release
           tag: 6.0.1-RELEASE
 
-      - name: Set up configuration context
-        id: context
+      - name: Build early swift-driver
         run: |
-          if ("${{ matrix.os }}" -eq "Windows") {
-            $SDKROOT = "${env:SDKROOT}"
-            $SQLite3_lib = "${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/lib/SQLite3.lib"
-            $PlatformName = "windows"
+          swift build `
+                --configuration release `
+                --arch ${{ matrix.arch }} `
+                --package-path ${{ github.workspace }}/SourceCache/swift-driver `
+                --build-path ${{ github.workspace }}/BinaryCache/swift-driver `
+
+      - name: Create installable package
+        run: |
+          if ("${{ matrix.os }}" -eq "Darwin") {
+              $PlatformName = "windows"
+              $ExeSuffix = ""
+              $Cpu = "${{ matrix.arch }}"
+              $SourceBinDir = Join-Path "${{ github.workspace }}" "BinaryCache" "swift-driver" "${Cpu}-apple-macosx" "release"
           } else {
-            $SDKROOT = xcrun --sdk macosx --show-sdk-path
-            $SQLite3_lib = "${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/lib/libSQLite3.a"
-            $PlatformName = "macosx"
+              $PlatformName = "macosx"
+              $ExeSuffix = ".exe"
+              if ("${{ matrix.arch }}" -eq "ARM64") {
+                $Cpu = "aarch64"
+              } else {
+                $Cpu = "x86_64"
+              }
+              $SourceBinDir = Join-Path "${{ github.workspace }}" "BinaryCache" "swift-driver" "${Cpu}-unknown-windows-msvc" "release"
           }
 
           # The Swift compiler expects a specific folder name for the early swift-driver build.
           # TODO: Make this configurable upstream so we don't have to hardcode it here.
-          $InstallFolderName = "earlyswiftdriver-${PlatformName}-${{ matrix.arch }}"
+          $InstallFolderName = "earlyswiftdriver-${PlatformName}-${Cpu}"
+          $InstallBinDir = Join-Path "${{ github.workspace }}" "BinaryCache" $InstallFolderName "release" "bin"
 
-          echo "SDKROOT=$SDKROOT" >> $env:GITHUB_OUTPUT
-          echo "SQLite3_lib=$SQLite3_lib" >> $env:GITHUB_OUTPUT
-          echo "InstallFolderName=$InstallFolderName" >> $env:GITHUB_OUTPUT
-
-      - name: Configure swift-llbuild
-        run: |
-          cmake -B ${{ github.workspace }}/BinaryCache/swift-llbuild `
-                -D BUILD_SHARED_LIBS=YES `
-                -D BUILD_TESTING=NO `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
-                -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
-                -D CMAKE_C_COMPILER_TARGET=${{ matrix.compiler_target }} `
-                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
-                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.compiler_target }} `
-                -D CMAKE_Swift_COMPILER=swiftc `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.compiler_target }} `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ steps.context.outputs.SDKROOT }} ${{ matrix.swiftflags }}" `
-                -D CMAKE_Swift_FLAGS_RELEASE="-O" `
-                -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
-                ${{ matrix.extra_flags }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift-llbuild `
-                -D LLBUILD_SUPPORT_BINDINGS=Swift `
-                -D SQLite3_LIBRARY=${{ steps.context.outputs.SQLite3_lib }} `
-                -D SQLite3_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/include
-      - name: Build swift-llbuild
-        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-llbuild
-
-      - name: Configure swift-tools-support-core
-        run: |
-          cmake -B ${{ github.workspace }}/BinaryCache/swift-tools-support-core `
-                -D BUILD_SHARED_LIBS=YES `
-                -D BUILD_TESTING=NO `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
-                -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
-                -D CMAKE_C_COMPILER_TARGET=${{ matrix.compiler_target }} `
-                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
-                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.compiler_target }} `
-                -D CMAKE_Swift_COMPILER=swiftc `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.compiler_target }} `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ steps.context.outputs.SDKROOT }} ${{ matrix.swiftflags }}" `
-                -D CMAKE_Swift_FLAGS_RELEASE="-O" `
-                -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
-                ${{ matrix.extra_flags }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift-tools-support-core `
-                -D SQLite3_LIBRARY=${{ steps.context.outputs.SQLite3_lib }} `
-                -D SQLite3_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/include
-      - name: Build swift-tools-support-core
-        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-tools-support-core
-
-      - name: Configure swift-argument-parser
-        run: |
-          cmake -B ${{ github.workspace }}/BinaryCache/swift-argument-parser `
-                -D BUILD_SHARED_LIBS=YES `
-                -D BUILD_TESTING=NO `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
-                -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
-                -D CMAKE_C_COMPILER_TARGET=${{ matrix.compiler_target }} `
-                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
-                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.compiler_target }} `
-                -D CMAKE_Swift_COMPILER=swiftc `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.compiler_target }} `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ steps.context.outputs.SDKROOT }} ${{ matrix.swiftflags }}" `
-                -D CMAKE_Swift_FLAGS_RELEASE="-O" `
-                -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
-                ${{ matrix.extra_flags }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift-argument-parser
-      - name: Build swift-argument-parser
-        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-argument-parser
-
-      - name: Configure Yams
-        run: |
-          cmake -B ${{ github.workspace }}/BinaryCache/yams `
-                -D BUILD_SHARED_LIBS=NO `
-                -D BUILD_TESTING=NO `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
-                -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
-                -D CMAKE_C_COMPILER_TARGET=${{ matrix.compiler_target }} `
-                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
-                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.compiler_target }} `
-                -D CMAKE_Swift_COMPILER=swiftc `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.compiler_target }} `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ steps.context.outputs.SDKROOT }} ${{ matrix.swiftflags }}" `
-                -D CMAKE_Swift_FLAGS_RELEASE="-O" `
-                -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
-                ${{ matrix.extra_flags }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/Yams
-      - name: Build Yams
-        run: cmake --build ${{ github.workspace }}/BinaryCache/yams
-
-      - name: Configure swift-driver
-        run: |
-          cmake -B ${{ github.workspace }}/BinaryCache/swift-driver `
-                -D BUILD_SHARED_LIBS=YES `
-                -D BUILD_TESTING=NO `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
-                -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
-                -D CMAKE_C_COMPILER_TARGET=${{ matrix.compiler_target }} `
-                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
-                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.compiler_target }} `
-                -D CMAKE_Swift_COMPILER=swiftc `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.compiler_target }} `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${{ steps.context.outputs.SDKROOT }} ${{ matrix.swiftflags }}" `
-                -D CMAKE_Swift_FLAGS_RELEASE="-O" `
-                -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
-                ${{ matrix.extra_flags }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift-driver `
-                -D ArgumentParser_DIR=${{ github.workspace }}/BinaryCache/swift-argument-parser/cmake/modules `
-                -D LLBuild_DIR=${{ github.workspace }}/BinaryCache/swift-llbuild/cmake/modules `
-                -D TSC_DIR=${{ github.workspace }}/BinaryCache/swift-tools-support-core/cmake/modules `
-                -D Yams_DIR=${{ github.workspace }}/BinaryCache/yams/cmake/modules
-      - name: Build swift-driver
-        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-driver
-
-      - name: Create installable package
-        run: |
-          $EarlySwiftDriverDir = Join-Path "${{ github.workspace }}" "BinaryCache" "${{ steps.context.outputs.InstallFolderName }}" "release"
-          $SourceBinDir = Join-Path "${{ github.workspace }}" "BinaryCache" "swift-driver" "bin"
-          $SwiftDriverSourceLibDir = Join-Path "${{ github.workspace }}" "BinaryCache" "swift-driver" "lib"
-          $SwiftTSCSourceLibDir = Join-Path "${{ github.workspace }}" "BinaryCache" "swift-tools-support-core" "lib"
-          $SwiftllbuildSourceLibDir = Join-Path "${{ github.workspace }}" "BinaryCache" "swift-llbuild" "lib"
-          $SwiftArgumentParserSourceLibDir = Join-Path "${{ github.workspace }}" "BinaryCache" "swift-argument-parser" "lib"
-          $InstallBinDir = Join-Path $EarlySwiftDriverDir "bin"
-          $SwiftBinaries = @("swift-driver", "swift-help")
-          $SwiftDriverSharedLibs = @("SwiftDriverExecution", "SwiftDriver", "SwiftOptions")
-          $SwiftTSCSharedLibs = @("TSCUtility", "TSCBasic")
-          $SwiftllbuildSharedLibs = @("llbuildSwift")
-          $SwiftArgumentParserSharedLibs = @("ArgumentParser")
-
-          if ("${{ matrix.os }}" -eq "Darwin") {
-              $InstallLibDir = Join-Path $EarlySwiftDriverDir "lib" "swift" "macosx"
-              $ExeSuffix = ""
-              $SharedLibsSuffix = ".dylib"
-              $SharedLibsPrefix = "lib"
-
-              # This is where Apple toolchains install the Swift libraries.
-              $rpath = "@executable_path/../lib/swift/macosx"
-          } else {
-              $InstallLibDir = $SourceBinDir
-              $ExeSuffix = ".exe"
-              $SharedLibsSuffix = ".dll"
-              $SharedLibsPrefix = ""
-          }
-
-          # Create folders.
+          # Create the target folder.
           New-Item -ItemType Directory -Path $InstallBinDir -Force
-          New-Item -ItemType Directory -Path $InstallLibDir -Force
 
           # Copy binaries.
+          $SwiftBinaries = @("swift-driver", "swift-help")
           foreach ($bin in $SwiftBinaries) {
               $binName = "${bin}${ExeSuffix}"
               $binPath = Join-Path $InstallBinDir $binName
               Copy-Item -Path "${SourceBinDir}/${binName}" -Destination $binPath -Force
-
-              if ("${{ matrix.os }}" -eq "Darwin") {
-                  # Fix absolute rpath in the binaries.
-                  install_name_tool -delete_rpath $SwiftDriverSourceLibDir $binPath
-                  install_name_tool -delete_rpath $SwiftTSCSourceLibDir $binPath
-                  if ($bin -eq "swift-help") {
-                      install_name_tool -delete_rpath $SwiftArgumentParserSourceLibDir $binPath
-                  }
-                  install_name_tool -add_rpath $rpath $binPath
-              }
-          }
-
-          # Copy libraries.
-          foreach ($lib in $SwiftDriverSharedLibs) {
-              $libName = "${SharedLibsPrefix}${lib}${SharedLibsSuffix}"
-              $libPath = Join-Path $InstallLibDir $libName
-              Copy-Item -Path "${SwiftDriverSourceLibDir}/${libName}" -Destination $libPath -Force
-
-              if ("${{ matrix.os }}" -eq "Darwin") {
-                  # Fix absolute rpath in the libraries.
-                  install_name_tool -delete_rpath $SwiftTSCSourceLibDir $libPath
-                  if ($lib -ne "SwiftOptions") {
-                      install_name_tool -delete_rpath $SwiftDriverSourceLibDir $libPath
-                  }
-                  if ($lib -eq "SwiftDriverExecution") {
-                      install_name_tool -delete_rpath $SwiftllbuildSourceLibDir $libPath
-                  }
-              }
-          }
-          foreach ($lib in $SwiftTSCSharedLibs) {
-              $libName = "${SharedLibsPrefix}${lib}${SharedLibsSuffix}"
-              $libPath = Join-Path $InstallLibDir $libName
-              Copy-Item -Path "${SwiftTSCSourceLibDir}/${libName}" -Destination $libPath -Force
-
-              if ("${{ matrix.os }}" -eq "Darwin" -and $lib -eq "TSCUtility") {
-                  # Fix absolute rpath in the libraries.
-                  install_name_tool -delete_rpath $SwiftTSCSourceLibDir $libPath
-              }
-          }
-          foreach ($lib in $SwiftllbuildSharedLibs) {
-              $libName = "${SharedLibsPrefix}${lib}${SharedLibsSuffix}"
-              $libPath = Join-Path $InstallLibDir $libName
-              Copy-Item -Path "${SwiftllbuildSourceLibDir}/${libName}" -Destination $libPath -Force
-          }
-          foreach ($lib in $SwiftArgumentParserSharedLibs) {
-              $libName = "${SharedLibsPrefix}${lib}${SharedLibsSuffix}"
-              $libPath = Join-Path $InstallLibDir $libName
-              Copy-Item -Path "${SwiftArgumentParserSourceLibDir}/${libName}" -Destination $libPath -Force
           }
 
           # Create an archive to preserve permissions.
           tar -czf "${{ github.workspace }}/BinaryCache/early-swift-driver.tar.gz" `
               -C "${{ github.workspace }}/BinaryCache" `
-              ${{ steps.context.outputs.InstallFolderName }}
+              $InstallFolderName
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -774,12 +774,12 @@ jobs:
       - name: Create installable package
         run: |
           if ("${{ matrix.os }}" -eq "Darwin") {
-              $PlatformName = "windows"
+              $PlatformName = "macosx"
               $ExeSuffix = ""
               $Cpu = "${{ matrix.arch }}"
               $SourceBinDir = Join-Path "${{ github.workspace }}" "BinaryCache" "swift-driver" "${Cpu}-apple-macosx" "release"
           } else {
-              $PlatformName = "macosx"
+              $PlatformName = "windows"
               $ExeSuffix = ".exe"
               if ("${{ matrix.arch }}" -eq "ARM64") {
                 $Cpu = "aarch64"

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -756,7 +756,6 @@ jobs:
       - uses: seanmiddleditch/gha-setup-ninja@master
         if: inputs.build_os == 'Darwin'
 
-      # TODO: Use the TBC builds once we have a Mac toolchain release.
       - name: Install Swift Toolchain (Mac)
         if: inputs.build_os == 'Darwin'
         uses: compnerd/gha-setup-swift@main
@@ -778,6 +777,7 @@ jobs:
           }
 
           # The Swift compiler expects a specific folder name for the early swift-driver build.
+          # TODO: Make this configurable upstream so we don't have to hardcode it here.
           $InstallFolderName = "earlyswiftdriver-${PlatformName}-${{ matrix.arch }}"
 
           echo "SDKROOT=$SDKROOT" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
This is a required preliminary step to build the compiler on macOS.

* Separate Swift flags between Windows and Darwin.
* Move arch-specific and OS-specific flags to matrix.extra_flags.