### PR TITLE
[Mac Build] Add compilers to the Mac Build

### DIFF
--- a/.github/actions/download-directory/action.yml
+++ b/.github/actions/download-directory/action.yml
@@ -1,0 +1,34 @@
+name: Download Directory
+description: Downloads a tar artifact and extracts it to a directory, preserving permissions and symlinks.
+
+inputs:
+  name:
+    description: 'The name of the artifact to download.'
+    required: true
+  path:
+    description: 'The path to extract the artifact to.'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create Temporary Directory
+      shell: pwsh
+      id: create-temp-dir
+      run: |
+        $TempDir = New-TemporaryFile | % { Remove-Item $_; New-Item -ItemType Directory -Path $_ }
+        echo "temp-dir=$TempDir" >> $env:GITHUB_OUTPUT
+
+    - name: Download Artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ steps.create-temp-dir.outputs.temp-dir }}
+
+    - name: Extract Tar Archive
+      shell: pwsh
+      id: extract-tar
+      run: |
+        New-Item -ItemType Directory -Path "${{ inputs.path }}" -Force | Out-Null
+        $TarFile = Join-Path "${{ steps.create-temp-dir.outputs.temp-dir }}" "${{ inputs.name }}.tar.gz"
+        tar -xzf $TarFile -C ${{ inputs.path }}

--- a/.github/actions/upload-directory/action.yml
+++ b/.github/actions/upload-directory/action.yml
@@ -1,0 +1,27 @@
+name: Upload Directory
+description: Uploads a directory as a tar artifact, preserving permissions and symlinks.
+
+inputs:
+  name:
+    description: 'The name of the artifact to create.'
+    required: true
+  path:
+    description: 'The path to the file or directory to upload.'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create Tar Archive
+      shell: pwsh
+      id: create-tar
+      run: |
+        $TempDir = New-TemporaryFile | % { Remove-Item $_; New-Item -ItemType Directory -Path $_ }
+        $TarFile = Join-Path $TempDir "${{ inputs.name }}.tar.gz"
+        echo "tar-file=$TarFile" >> $env:GITHUB_OUTPUT
+        tar -czf $TarFile -C "${{ inputs.path }}" .
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ steps.create-tar.outputs.tar-file }}

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -142,6 +142,8 @@ jobs:
       WINDOWS_CMAKE_SHARED_LINKER_FLAGS: ${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}
       DARWIN_CMAKE_C_FLAGS: ${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}
       DARWIN_CMAKE_CXX_FLAGS: ${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}
+      DARWIN_CMAKE_EXE_LINKER_FLAGS: ${{ steps.context.outputs.DARWIN_CMAKE_EXE_LINKER_FLAGS }}
+      DARWIN_CMAKE_SHARED_LINKER_FLAGS: ${{ steps.context.outputs.DARWIN_CMAKE_SHARED_LINKER_FLAGS }}
       ANDROID_CMAKE_C_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_C_FLAGS }}
       ANDROID_CMAKE_CXX_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
       ANDROID_CMAKE_EXE_LINKER_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}
@@ -244,6 +246,8 @@ jobs:
             echo WINDOWS_CMAKE_CXX_FLAGS="/GS- /Gw /Gy /Oi /Oy /Z7 /Zc:inline /Zc:preprocessor /Zc:__cplusplus /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" >> ${GITHUB_OUTPUT}
             echo DARWIN_CMAKE_C_FLAGS="-g" >> ${GITHUB_OUTPUT}
             echo DARWIN_CMAKE_CXX_FLAGS="-g" >> ${GITHUB_OUTPUT}
+            echo DARWIN_CMAKE_EXE_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
+            echo DARWIN_CMAKE_SHARED_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
             echo ANDROID_CMAKE_C_FLAGS="-ffunction-sections -fdata-sections -g" >> ${GITHUB_OUTPUT}
             echo ANDROID_CMAKE_CXX_FLAGS="-ffunction-sections -fdata-sections -g" >> ${GITHUB_OUTPUT}
             echo WINDOWS_CMAKE_EXE_LINKER_FLAGS="-incremental:no -debug -opt:ref -opt:icf" >> ${GITHUB_OUTPUT}
@@ -256,6 +260,8 @@ jobs:
             echo WINDOWS_CMAKE_CXX_FLAGS="/GS- /Gw /Gy /Oi /Oy /Zc:inline /Zc:preprocessor /Zc:__cplusplus /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" >> ${GITHUB_OUTPUT}
             echo DARWIN_CMAKE_C_FLAGS="" >> ${GITHUB_OUTPUT}
             echo DARWIN_CMAKE_CXX_FLAGS="" >> ${GITHUB_OUTPUT}
+            echo DARWIN_CMAKE_EXE_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
+            echo DARWIN_CMAKE_SHARED_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
             echo ANDROID_CMAKE_C_FLAGS="-ffunction-sections -fdata-sections" >> ${GITHUB_OUTPUT}
             echo ANDROID_CMAKE_CXX_FLAGS="-ffunction-sections -fdata-sections" >> ${GITHUB_OUTPUT}
             echo WINDOWS_CMAKE_EXE_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
@@ -306,24 +312,26 @@ jobs:
               "include": [
                 {
                   "arch": "amd64",
-                  "compiler_target": "x86_64-unknown-windows-msvc",
                   "os": "Windows",
                   "cc": "cl",
                   "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
+                  "ldflags": "${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}",
+                  "shared_ldflags": "${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}",
                   "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
                   "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=AMD64 -D CMAKE_MT=mt"
                 },
                 {
                   "arch": "arm64",
-                  "compiler_target": "aarch64-unknown-windows-msvc",
                   "os": "Windows",
                   "cc": "cl",
                   "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
                   "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
+                  "ldflags": "${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}",
+                  "shared_ldflags": "${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}",
                   "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=ARM64 -D CMAKE_MT=mt"
                 }
               ]
@@ -423,25 +431,27 @@ jobs:
               "include": [
                 {
                   "arch": "x86_64",
-                  "compiler_target": "x86_64-apple-macosx10.15",
                   "os": "Darwin",
                   "cc": "clang",
                   "cflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}",
                   "swiftflags": "${{ steps.context.outputs.DARWIN_CMAKE_Swift_FLAGS }}",
-                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=x86_64 -D CMAKE_OSX_DEPLOYMENT_TARGET=\"10.15\" -D CMAKE_OSX_ARCHITECTURES=x86_64"
+                  "ldflags": "${{ steps.context.outputs.DARWIN_CMAKE_EXE_LINKER_FLAGS }}",
+                  "shared_ldflags": "${{ steps.context.outputs.DARWIN_CMAKE_SHARED_LINKER_FLAGS }}",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=x86_64 -D CMAKE_OSX_DEPLOYMENT_TARGET=10.15 -D CMAKE_OSX_ARCHITECTURES=x86_64"
                 },
                 {
                   "arch": "arm64",
-                  "compiler_target": "arm64-apple-macosx10.15",
                   "os": "Darwin",
                   "cc": "clang",
                   "cflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}",
                   "swiftflags": "${{ steps.context.outputs.DARWIN_CMAKE_Swift_FLAGS }}",
-                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=arm64 -D CMAKE_OSX_DEPLOYMENT_TARGET=\"10.15\" -D CMAKE_OSX_ARCHITECTURES=arm64"
+                  "ldflags": "${{ steps.context.outputs.DARWIN_CMAKE_EXE_LINKER_FLAGS }}",
+                  "shared_ldflags": "${{ steps.context.outputs.DARWIN_CMAKE_SHARED_LINKER_FLAGS }}",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=arm64 -D CMAKE_OSX_DEPLOYMENT_TARGET=10.15 -D CMAKE_OSX_ARCHITECTURES=arm64"
                 }
               ]
             }
@@ -454,9 +464,9 @@ jobs:
                   "cc": "clang",
                   "cflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",
                   "cxx": "clang++",
-                  "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}"
+                  "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}",
                   "swiftflags": "${{ steps.context.outputs.DARWIN_CMAKE_Swift_FLAGS }}",
-                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=arm64 -D CMAKE_OSX_DEPLOYMENT_TARGET=\"10.15\" -D CMAKE_OSX_ARCHITECTURES=arm64"
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=arm64 -D CMAKE_OSX_DEPLOYMENT_TARGET=10.15 -D CMAKE_OSX_ARCHITECTURES=arm64"
                 }
               ]
             }
@@ -471,7 +481,7 @@ jobs:
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}",
                   "swiftflags": "${{ steps.context.outputs.DARWIN_CMAKE_Swift_FLAGS }}",
-                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=x86_64 -D CMAKE_OSX_DEPLOYMENT_TARGET=\"10.15\" -D CMAKE_OSX_ARCHITECTURES=x86_64"
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=x86_64 -D CMAKE_OSX_DEPLOYMENT_TARGET=10.15 -D CMAKE_OSX_ARCHITECTURES=x86_64"
                 },
                 {
                   "arch": "arm64",
@@ -481,7 +491,7 @@ jobs:
                   "cxx": "clang++",
                   "cxxflags": "${{ steps.context.outputs.DARWIN_CMAKE_CXX_FLAGS }}",
                   "swiftflags": "${{ steps.context.outputs.DARWIN_CMAKE_Swift_FLAGS }}",
-                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=arm64 -D CMAKE_OSX_DEPLOYMENT_TARGET=\"10.15\" -D CMAKE_OSX_ARCHITECTURES=arm64"
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=arm64 -D CMAKE_OSX_DEPLOYMENT_TARGET=10.15 -D CMAKE_OSX_ARCHITECTURES=arm64"
                 }
               ]
             }

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -503,6 +503,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          sparse-checkout: '.github/actions'
+      - uses: actions/checkout@v4
+        with:
           repository: swiftlang/swift-cmark
           ref: ${{ inputs.swift_cmark_revision }}
           path: ${{ github.workspace }}/SourceCache/cmark-gfm
@@ -557,7 +560,7 @@ jobs:
         run: cmake --build ${{ github.workspace }}/BinaryCache/cmark-gfm-${{ inputs.swift_cmark_version }}
       - name: Install cmark-gfm
         run: cmake --build ${{ github.workspace }}/BinaryCache/cmark-gfm-${{ inputs.swift_cmark_version }} --target install
-      - uses: actions/upload-artifact@v4
+      - uses: ./.github/actions/upload-directory
         with:
           name: cmark-gfm-${{ matrix.os }}-${{ matrix.arch }}-${{ inputs.swift_cmark_version }}
           path: ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr
@@ -573,7 +576,10 @@ jobs:
     name: ${{ matrix.os }} ${{ matrix.arch }} Compiler Build Tools
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: '.github/actions'
+      - uses: ./.github/actions/download-directory
         with:
           name: cmark-gfm-${{ matrix.os }}-${{ matrix.arch }}-${{ inputs.swift_cmark_version }}
           path: ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr
@@ -670,33 +676,31 @@ jobs:
       - name: Build swift-compatibility-symbols
         run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target swift-compatibility-symbols
 
-      - name: Export binary paths
-        id: export-binary-paths
+      - name: Copy binaries
         run: |
           $Suffix = if ( "${{ matrix.os }}" -eq "Windows" ) { ".exe" } else { "" }
-          echo "llvm_tblgen=${{ github.workspace }}/BinaryCache/0/bin/llvm-tblgen${Suffix}" >> $env:GITHUB_OUTPUT
-          echo "clang_tblgen=${{ github.workspace }}/BinaryCache/0/bin/clang-tblgen${Suffix}" >> $env:GITHUB_OUTPUT
-          echo "lldb_tblgen=${{ github.workspace }}/BinaryCache/0/bin/lldb-tblgen${Suffix}" >> $env:GITHUB_OUTPUT
-          echo "llvm_config=${{ github.workspace }}/BinaryCache/0/bin/llvm-config${Suffix}" >> $env:GITHUB_OUTPUT
-          echo "clang_pseudo_gen=${{ github.workspace }}/BinaryCache/0/bin/clang-pseudo-gen${Suffix}" >> $env:GITHUB_OUTPUT
-          echo "clang_tidy_confusable_chars_gen=${{ github.workspace }}/BinaryCache/0/bin/clang-tidy-confusable-chars-gen${Suffix}" >> $env:GITHUB_OUTPUT
-          echo "swift_def_to_strings_converter=${{ github.workspace }}/BinaryCache/0/bin/swift-def-to-strings-converter${Suffix}" >> $env:GITHUB_OUTPUT
-          echo "swift_serialize_diagnostics=${{ github.workspace }}/BinaryCache/0/bin/swift-serialize-diagnostics${Suffix}" >> $env:GITHUB_OUTPUT
-          echo "swift_compatibility_symbols=${{ github.workspace }}/BinaryCache/0/bin/swift-compatibility-symbols${Suffix}" >> $env:GITHUB_OUTPUT
+          $Binaries = @(
+            "llvm-tblgen${Suffix}",
+            "clang-tblgen${Suffix}",
+            "lldb-tblgen${Suffix}",
+            "llvm-config${Suffix}",
+            "clang-pseudo-gen${Suffix}",
+            "clang-tidy-confusable-chars-gen${Suffix}",
+            "swift-def-to-strings-converter${Suffix}",
+            "swift-serialize-diagnostics${Suffix}",
+            "swift-compatibility-symbols${Suffix}"
+          )
 
-      - uses: actions/upload-artifact@v4
+          # Create the target folder.
+          New-Item -ItemType Directory -Path "${{ github.workspace }}/BuildRoot/bin" -Force | Out-Null
+          foreach ($Binary in $Binaries) {
+            Copy-Item -Path "${{ github.workspace }}/BinaryCache/0/bin/${Binary}" -Destination "${{ github.workspace }}/BuildRoot/bin/${Binary}" -Force
+          }
+
+      - uses: ./.github/actions/upload-directory
         with:
           name: build-tools-${{ matrix.os }}
-          path: |
-            ${{ steps.export-binary-paths.outputs.llvm_tblgen }}
-            ${{ steps.export-binary-paths.outputs.clang_tblgen }}
-            ${{ steps.export-binary-paths.outputs.lldb_tblgen }}
-            ${{ steps.export-binary-paths.outputs.llvm_config }}
-            ${{ steps.export-binary-paths.outputs.clang_pseudo_gen }}
-            ${{ steps.export-binary-paths.outputs.clang_tidy_confusable_chars_gen }}
-            ${{ steps.export-binary-paths.outputs.swift_def_to_strings_converter }}
-            ${{ steps.export-binary-paths.outputs.swift_serialize_diagnostics }}
-            ${{ steps.export-binary-paths.outputs.swift_compatibility_symbols }}
+          path: ${{ github.workspace }}/BuildRoot/bin
 
   early_swift_driver:
     # TODO: Build this on Windows too.
@@ -711,6 +715,10 @@ jobs:
     name: ${{ matrix.os }} ${{ matrix.arch }} Early Swift Driver
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: '.github/actions'
+
       - uses: actions/download-artifact@v4
         with:
           name: sqlite-${{ matrix.os }}-${{ matrix.arch }}-${{ inputs.swift_toolchain_sqlite_version }}
@@ -792,7 +800,7 @@ jobs:
           # The Swift compiler expects a specific folder name for the early swift-driver build.
           # TODO: Make this configurable upstream so we don't have to hardcode it here.
           $InstallFolderName = "earlyswiftdriver-${PlatformName}-${Cpu}"
-          $InstallBinDir = Join-Path "${{ github.workspace }}" "BinaryCache" $InstallFolderName "release" "bin"
+          $InstallBinDir = Join-Path "${{ github.workspace }}" "BuildRoot" $InstallFolderName "release" "bin"
 
           # Create the target folder.
           New-Item -ItemType Directory -Path $InstallBinDir -Force
@@ -805,49 +813,55 @@ jobs:
               Copy-Item -Path "${SourceBinDir}/${binName}" -Destination $binPath -Force
           }
 
-          # Create an archive to preserve permissions.
-          tar -czf "${{ github.workspace }}/BinaryCache/early-swift-driver.tar.gz" `
-              -C "${{ github.workspace }}/BinaryCache" `
-              $InstallFolderName
-
-      - uses: actions/upload-artifact@v4
+      - uses: ./.github/actions/upload-directory
         with:
           name: early-swift-driver-${{ matrix.os }}-${{ matrix.arch }}
-          path: ${{ github.workspace }}/BinaryCache/early-swift-driver.tar.gz
+          path: ${{ github.workspace }}/BuildRoot
 
   compilers:
-    # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.build_os == 'Windows'
-    needs: [build_tools, cmark_gfm]
+    needs: [build_tools, cmark_gfm, early_swift_driver]
+    if: |
+      always() &&
+      needs.build_tools.result == 'success' &&
+      needs.cmark_gfm.result == 'success' &&
+      (needs.early_swift_driver.result == 'success' || needs.early_swift_driver.result == 'skipped')
     runs-on: ${{ inputs.compilers_build_runner }}
 
     env:
+      # This will grab the latest Python 3.9 version available for setup-python. It is necessary to
+      # specify in this manner for Mac where actions/setup-python does not have version 3.9.10.
+      # Once the Python version is upgraded to 3.12, these should be kept in sync.
+      PYTHON_VERSION: 3.9
       # Must be a full version string from https://www.nuget.org/packages/pythonarm64
-      PYTHON_VERSION: 3.9.10
+      PYTHON_VERSION_FULL: 3.9.10
 
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - arch: 'amd64'
-            cpu: 'x86_64'
-            triple: 'x86_64-unknown-windows-msvc'
+      matrix: ${{ fromJSON(inputs.host_matrix) }}
 
-          - arch: 'arm64'
-            cpu: 'aarch64'
-            triple: 'aarch64-unknown-windows-msvc'
+    defaults:
+      run:
+        shell: pwsh
 
-    name: Windows ${{ matrix.arch }} Toolchain
+    name: ${{ matrix.os }} ${{ matrix.arch }} Toolchain
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v4
         with:
-          name: build-tools-Windows
+          sparse-checkout: '.github/actions'
+      - uses: ./.github/actions/download-directory
+        with:
+          name: build-tools-${{ matrix.os }}
           path: ${{ github.workspace }}/BinaryCache/0/bin
-      - uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-directory
         with:
-          name: cmark-gfm-Windows-${{ matrix.arch }}-${{ inputs.swift_cmark_version }}
+          name: cmark-gfm-${{ matrix.os }}-${{ matrix.arch }}-${{ inputs.swift_cmark_version }}
           path: ${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr
+      - uses: ./.github/actions/download-directory
+        if: matrix.os == 'Darwin'
+        with:
+          name: early-swift-driver-${{ matrix.os }}-${{ matrix.arch }}
+          path: ${{ github.workspace }}/BinaryCache
 
       - uses: actions/checkout@v4
         with:
@@ -879,6 +893,10 @@ jobs:
           ref: ${{ inputs.swift_corelibs_libdispatch_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch
           show-progress: false
+      - uses: actions/checkout@v4
+        if: matrix.os == 'Darwin'
+        with:
+          path: ${{ github.workspace }}/SourceCache/swift-build
 
       - name: Install Python ${{ env.PYTHON_VERSION }} (Host)
         uses: actions/setup-python@v5
@@ -887,36 +905,48 @@ jobs:
           python-version: '${{ env.PYTHON_VERSION }}'
 
       - uses: nuget/setup-nuget@v2
-        if: matrix.arch == 'arm64'
+        if: matrix.arch == 'arm64' && inputs.build_os == 'Windows'
 
       # TODO(lxbndr) use actions/cache to improve this step timings
-      - name: Install Python ${{ env.PYTHON_VERSION }} (arm64)
-        if: matrix.arch == 'arm64'
+      - name: Install Python ${{ env.PYTHON_VERSION_FULL }} (Windows arm64)
+        if: matrix.arch == 'arm64' && inputs.build_os == 'Windows'
         run: |
           $NugetSources=[string](nuget Sources List -Format short)
           if (-Not ($NugetSources.contains("api.nuget.org"))) {
             nuget sources Add -Name api.nuget.org -Source https://api.nuget.org/v3/index.json -NonInteractive
           }
-          nuget install pythonarm64 -Version ${{ env.PYTHON_VERSION }}
+          nuget install pythonarm64 -Version ${{ env.PYTHON_VERSION_FULL }}
 
-      - name: Export Python Location
+      - name: Export Python Location (Windows)
+        if: inputs.build_os == 'Windows'
         run: |
           echo "PYTHON_LOCATION_amd64=$env:pythonLocation" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "PYTHON_LOCATION_arm64=${{ github.workspace }}\pythonarm64.${{ env.PYTHON_VERSION }}\tools" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "PYTHON_LOCATION_arm64=${{ github.workspace }}\pythonarm64.${{ env.PYTHON_VERSION_FULL }}\tools" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - uses: compnerd/gha-setup-vsdevenv@main
         with:
-          host_arch: amd64
+          host_arch: ${{ inputs.build_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
-      - name: Install Swift Toolchain
+      - uses: seanmiddleditch/gha-setup-ninja@master
+        if: inputs.build_os == 'Darwin'
+
+      - name: Install Swift Toolchain (Windows)
+        if: inputs.build_os == 'Windows'
         uses: compnerd/gha-setup-swift@main
         with:
           github-repo: thebrowsercompany/swift-build
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          release-asset-name: installer-amd64.exe
+          release-asset-name: installer-${{ inputs.build_arch }}.exe
           release-tag-name: '20240920.2'
+
+      - name: Install Swift Toolchain (Mac)
+        if: inputs.build_os == 'Darwin'
+        uses: compnerd/gha-setup-swift@main
+        with:
+          branch: swift-6.0.1-release
+          tag: 6.0.1-RELEASE
 
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
@@ -939,55 +969,82 @@ jobs:
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 500M
-          key: ${{ steps.workspace_hash.outputs.hash }}-windows-${{ matrix.arch }}-compilers
+          key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-compilers
           variant: sccache
 
       - name: Configure Compilers
         env:
           NDKPATH: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
-          if ( "${{ matrix.arch }}" -eq "arm64" ) {
-            $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
-            $CMAKE_SYSTEM_PROCESSOR="-D CMAKE_SYSTEM_PROCESSOR=ARM64"
-            $CACHE="Windows-aarch64.cmake"
+          if ( "${{ matrix.os }}" -eq "Windows" ) {
+            $SWIFTC = cygpath -m (Get-Command swiftc).Source
+            # Use toolchain clang to avoid broken __prefetch intrinsic on arm64 in Clang 18.
+            $CLANG_LOCATION = Split-Path (Get-Command swiftc).Source
+            $EXTRA_FLAGS = "-D SWIFT_NATIVE_SWIFT_TOOLS_PATH=${{ github.workspace }}/BinaryCache/0/bin"
+            if ( "${{ matrix.arch }}" -eq "arm64" ) {
+              $EXTRA_FLAGS += " ${{ matrix.extra_flags }} -D CMAKE_SYSTEM_NAME=Windows"
+              $CACHE="${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-aarch64.cmake"
 
-            # FIXME(compnerd) re-enable runtimes after we sort out compiler-rt
-            (Get-Content ${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-aarch64.cmake).Replace(' runtimes', '') | Set-Content ${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-aarch64.cmake
-          } else {
-            $CACHE="Windows-x86_64.cmake"
+              # FIXME(compnerd) re-enable runtimes after we sort out compiler-rt
+              (Get-Content ${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-aarch64.cmake).Replace(' runtimes', '') | Set-Content ${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-aarch64.cmake
+            } else {
+              # FIXME(Steelskin) Setting `CMAKE_SYSTEM_PROCESSOR=AMD64` breaks the compiler-rt build.
+              $EXTRA_FLAGS += " -D CMAKE_MT=mt"
+              $CACHE="${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-x86_64.cmake"
+            }
+            $CC = "cl"
+            $CXX = "cl"
+            $SDKROOT = cygpath -m ${env:SDKROOT}
+            $CLANG_LOCATION = cygpath -m $CLANG_LOCATION
+            $LIBPYTHON_PATH = "${env:PYTHON_LOCATION_${{ matrix.arch }}}/libs/python39.lib"
+            $PYTHON_INCLUDE_DIR = "${env:PYTHON_LOCATION_${{ matrix.arch }}}/include"
+            $ExeSuffix = ".exe"
+            Remove-Item env:\SDKROOT
+          } elseif ( "${{ matrix.os }}" -eq "Darwin" ) {
+            # Default swiftc comes from /usr/bin and is not compatible with the toolchain.
+            $CLANG_LOCATION = "${env:HOME}/Library/Developer/Toolchains/swift-6.0.1-RELEASE.xctoolchain/usr/bin"
+            $SWIFTC = Join-Path $CLANG_LOCATION "swiftc"
+            # We need to use llvm-17 to build the compiler on macOS. We get it from the Swift toolchain.
+            $CC = Join-Path $CLANG_LOCATION "clang"
+            $CXX = Join-Path $CLANG_LOCATION "clang++"
+            $CACHE = "${{ github.workspace }}/SourceCache/swift-build/Darwin-${{ matrix.arch }}.cmake"
+            $SDKROOT = xcrun --sdk macosx --show-sdk-path
+            $EXTRA_FLAGS = "${{ matrix.extra_flags }} -D CMAKE_SYSTEM_NAME=Darwin"
+            $LIBPYTHON_PATH = "${env:pythonLocation}/lib/python3.9/config-3.9-darwin/libpython3.9.a"
+            $PYTHON_INCLUDE_DIR = "${env:pythonLocation}/include/python3.9"
+            $ExeSuffix = ""
           }
-          $SWIFTC = cygpath -m (Get-Command swiftc).Source
-          $SDKROOT = cygpath -m ${env:SDKROOT}
-          # Use toolchain clang to avoid broken __prefetch intrinsic on arm64 in Clang 18.
-          $CLANG_LOCATION = cygpath -m (Split-Path (Get-Command swiftc).Source)
-          Remove-Item env:\SDKROOT
+          $ClangTablegen = "${{ github.workspace }}/BinaryCache/0/bin/clang-tblgen${ExeSuffix}"
+          $ClangTidyConfusableCharsGen = "${{ github.workspace }}/BinaryCache/0/bin/clang-tidy-confusable-chars-gen${ExeSuffix}"
+          $LldbTablegen = "${{ github.workspace }}/BinaryCache/0/bin/lldb-tblgen${ExeSuffix}"
+          $LlvmConfig = "${{ github.workspace }}/BinaryCache/0/bin/llvm-config${ExeSuffix}"
+          $LlvmTablegen = "${{ github.workspace }}/BinaryCache/0/bin/llvm-tblgen${ExeSuffix}"
+          $EXTRA_FLAGS = $EXTRA_FLAGS.split()
           cmake -B ${{ github.workspace }}/BinaryCache/1 `
-                -C ${{ github.workspace }}/SourceCache/swift/cmake/caches/${CACHE} `
+                -C "${CACHE}" `
                 -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=cl `
+                -D CMAKE_C_COMPILER="${CC}" `
                 -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
-                -D CMAKE_CXX_COMPILER=cl `
+                -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
+                -D CMAKE_CXX_COMPILER="${CXX}" `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }} -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" `
-                -D CMAKE_MT=mt `
+                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }} -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" `
                 -D CMAKE_Swift_COMPILER="${SWIFTC}" `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk `"${SDKROOT}`" -Xcc -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" `
-                -D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" `
+                -D CMAKE_EXE_LINKER_FLAGS="${{ matrix.ldflags }}" `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
-                -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}" `
-                ${CMAKE_SYSTEM_NAME} `
-                ${CMAKE_SYSTEM_PROCESSOR} `
+                -D CMAKE_SHARED_LINKER_FLAGS="${{ matrix.shared_ldflags }}" `
+                @EXTRA_FLAGS `
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/llvm-project/llvm `
-                -D CLANG_TABLEGEN=${{ github.workspace }}/BinaryCache/0/bin/clang-tblgen.exe `
-                -D CLANG_TIDY_CONFUSABLE_CHARS_GEN=${{ github.workspace }}/BinaryCache/0/bin/clang-tidy-confusable-chars-gen.exe `
-                -D LLDB_TABLEGEN=${{ github.workspace }}/BinaryCache/0/bin/lldb-tblgen.exe `
-                -D LLVM_CONFIG_PATH=${{ github.workspace }}/BinaryCache/0/bin/llvm-config.exe `
+                -D CLANG_TABLEGEN="${ClangTablegen}" `
+                -D CLANG_TIDY_CONFUSABLE_CHARS_GEN="${ClangTidyConfusableCharsGen}" `
+                -D LLDB_TABLEGEN="${LldbTablegen}" `
+                -D LLVM_CONFIG_PATH="${LlvmConfig}" `
                 -D LLVM_EXTERNAL_SWIFT_SOURCE_DIR=${{ github.workspace }}/SourceCache/swift `
                 -D LLVM_NATIVE_TOOL_DIR=${{ github.workspace }}/BinaryCache/0/bin `
-                -D LLVM_TABLEGEN=${{ github.workspace }}/BinaryCache/0/bin/llvm-tblgen.exe `
+                -D LLVM_TABLEGEN="${LlvmTablegen}" `
                 -D LLVM_USE_HOST_TOOLS=NO `
                 -D SWIFT_BUILD_DYNAMIC_SDK_OVERLAY=NO `
                 -D SWIFT_BUILD_DYNAMIC_STDLIB=NO `
@@ -1001,7 +1058,6 @@ jobs:
                 -D SWIFT_ENABLE_EXPERIMENTAL_OBSERVATION=YES `
                 -D SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING=YES `
                 -D SWIFT_ENABLE_SYNCHRONIZATION=YES `
-                -D SWIFT_NATIVE_SWIFT_TOOLS_PATH=${{ github.workspace }}/BinaryCache/0/bin `
                 -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE=${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch `
                 -D SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE=${{ github.workspace }}/SourceCache/swift-syntax `
                 -D SWIFT_PATH_TO_STRING_PROCESSING_SOURCE=${{ github.workspace }}/SourceCache/swift-experimental-string-processing `
@@ -1015,12 +1071,12 @@ jobs:
                 -D SWIFT_PARALLEL_LINK_JOBS=2 `
                 -D LLVM_APPEND_VC_REV=NO `
                 -D LLVM_VERSION_SUFFIX="" `
-                -D LLDB_PYTHON_EXE_RELATIVE_PATH=python.exe `
+                -D LLDB_PYTHON_EXE_RELATIVE_PATH=python3${ExeSuffix} `
                 -D LLDB_PYTHON_EXT_SUFFIX=.pyd `
                 -D LLDB_PYTHON_RELATIVE_PATH=lib/site-packages `
                 -D Python3_EXECUTABLE=${{ steps.python.outputs.python-path }} `
-                -D Python3_INCLUDE_DIR=$env:PYTHON_LOCATION_${{ matrix.arch }}\include `
-                -D Python3_LIBRARY=$env:PYTHON_LOCATION_${{ matrix.arch }}\libs\python39.lib `
+                -D Python3_INCLUDE_DIR=$PYTHON_INCLUDE_DIR `
+                -D Python3_LIBRARY=$LIBPYTHON_PATH `
                 -D Python3_ROOT_DIR=$env:pythonLocation
 
       - name: Build Compiler Distribution
@@ -1031,43 +1087,54 @@ jobs:
 
       - name: Copy cmark-gfm shared libraries
         run: |
-          Copy-Item -Path "${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr/bin/*.dll" -Destination "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin"
+          if ("${{ matrix.os }}" -eq "Windows") {
+            Copy-Item -Path "${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr/bin/*.dll" -Destination "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin"
+          } else {
+            Copy-Item -Path "${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr/lib/*.dylib" -Destination "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/lib/swift/host/compiler"
+          }
 
       - name: Upload Compilers
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload-directory
         with:
-          name: compilers-${{ matrix.arch }}
+          name: compilers-${{ matrix.os }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library
 
       - name: extract swift-syntax
         run: |
+          $bindir = "${{ github.workspace }}/BinaryCache/1"
+          if ("${{ matrix.os }}" -eq "Windows") {
+            $libSuffix = ".lib"
+            $bindir = cygpath -m "${bindir}"
+          } else {
+            $libSuffix = ".dylib"
+          }
+
           $module = "${{ github.workspace }}/BinaryCache/1/cmake/modules/SwiftSyntaxConfig.cmake"
-          $bindir = cygpath -m ${{ github.workspace }}/BinaryCache/1
           (Get-Content $module).Replace("${bindir}", '<BINARY_DIR>') | Set-Content $module
           New-Item -Path ${{ github.workspace }}/BinaryCache/swift-syntax/lib/swift/host -ItemType Directory | Out-Null
-          Copy-Item -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/lib/*.lib" -Destination "${{ github.workspace }}/BinaryCache/swift-syntax/lib"
-          Copy-Item -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/lib/*.lib" -Destination "${{ github.workspace }}/BinaryCache/swift-syntax/lib/swift/host"
+          Copy-Item -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/lib/*${libSuffix}" -Destination "${{ github.workspace }}/BinaryCache/swift-syntax/lib"
+          Copy-Item -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/lib/*${libSuffix}" -Destination "${{ github.workspace }}/BinaryCache/swift-syntax/lib/swift/host"
           Copy-Item -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/lib/swift/host/*.swiftmodule" -Destination "${{ github.workspace }}/BinaryCache/swift-syntax/lib/swift/host" -Recurse
           New-Item -Path ${{ github.workspace }}/BinaryCache/swift-syntax/cmake/modules -ItemType Directory | Out-Null
           Copy-Item -Path $module -Destination "${{ github.workspace }}/BinaryCache/swift-syntax/cmake/modules"
 
       - name: Upload swift-syntax
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload-directory
         with:
-          name: swift-syntax-${{ matrix.arch }}
+          name: swift-syntax-${{matrix.os }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/BinaryCache/swift-syntax
 
       # TODO(compnerd) this takes ~1h due to the size, see if we can compress first
       - uses: actions/upload-artifact@v4
         if: false # ${{ inputs.debug_info }}
         with:
-          name: compilers-${{ matrix.arch }}-debug-info
+          name: compilers-${{ matrix.os }}-${{ matrix.arch }}-debug-info
           path: |
             ${{ github.workspace }}/BinaryCache/1/**/*.pdb
 
       - name: Upload PDBs to Azure
         uses: microsoft/action-publish-symbols@v2.1.6
-        if: ${{ inputs.debug_info }}
+        if: ${{ inputs.debug_info && matrix.os  == 'Windows' }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -1076,7 +1143,7 @@ jobs:
 
       - name: Upload DLLs to Azure
         uses: microsoft/action-publish-symbols@v2.1.6
-        if: ${{ inputs.debug_info }}
+        if: ${{ inputs.debug_info && matrix.os  == 'Windows' }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -1085,7 +1152,7 @@ jobs:
 
       - name: Upload EXEs to Azure
         uses: microsoft/action-publish-symbols@v2.1.6
-        if: ${{ inputs.debug_info }}
+        if: ${{ inputs.debug_info && matrix.os  == 'Windows' }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -1430,7 +1497,7 @@ jobs:
 
   stdlib:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.build_os == 'Windows'
+    if: always() && inputs.build_os == 'Windows' && needs.compilers.result == 'success'
     needs: [compilers, cmark_gfm]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -1539,11 +1606,16 @@ jobs:
     name: ${{ matrix.os }} ${{ matrix.arch }} Standard Library
 
     steps:
-      - name: Download Compilers
-        uses: actions/download-artifact@v4
+      - uses: actions/checkout@v4
         with:
-          name: compilers-amd64
+          sparse-checkout: '.github/actions'
+
+      - name: Download Compilers
+        uses: ./.github/actions/download-directory
+        with:
+          name: compilers-Windows-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BuildRoot/Library
+
       - uses: actions/checkout@v4
         with:
           repository: swiftlang/llvm-project
@@ -1710,8 +1782,8 @@ jobs:
 
   macros:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.build_os == 'Windows'
-    needs: [compilers, cmark_gfm, stdlib]
+    if: always() && inputs.build_os == 'Windows' && needs.stdlib.result == 'success'
+    needs: [stdlib]
     runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
@@ -1729,15 +1801,19 @@ jobs:
     name: Windows ${{ matrix.arch }} Macros
 
     steps:
-      - name: Download Compilers
-        uses: actions/download-artifact@v4
+      - uses: actions/checkout@v4
         with:
-          name: compilers-amd64
+          sparse-checkout: '.github/actions'
+
+      - name: Download Compilers
+        uses: ./.github/actions/download-directory
+        with:
+          name: compilers-Windows-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - name: Download swift-syntax
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download-directory
         with:
-          name: swift-syntax-${{ matrix.arch }}
+          name: swift-syntax-Windows-${{ matrix.arch }}
           path: ${{ github.workspace }}/BinaryCache/swift-syntax
       - uses: actions/download-artifact@v4
         with:
@@ -1752,6 +1828,7 @@ jobs:
         with:
           name: windows-vfs-overlay-${{ matrix.arch }}
           path: ${{ github.workspace }}/BinaryCache/swift/stdlib
+
       - uses: actions/checkout@v4
         with:
           repository: swiftlang/swift
@@ -1858,8 +1935,8 @@ jobs:
 
   sdk:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.build_os == 'Windows'
-    needs: [libxml2, curl, zlib, compilers, cmark_gfm, stdlib, macros]
+    if: always() && inputs.build_os == 'Windows' && needs.macros.result == 'success'
+    needs: [libxml2, curl, zlib, cmark_gfm, stdlib, macros]
     runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
@@ -1960,6 +2037,10 @@ jobs:
     name: ${{ matrix.os }} ${{ matrix.arch }} SDK
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: '.github/actions'
+
       - uses: actions/download-artifact@v4
         with:
           name: libxml2-${{ matrix.os }}-${{ matrix.arch }}-${{ inputs.libxml2_version }}
@@ -1974,9 +2055,9 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr
 
       - name: Download Compilers
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download-directory
         with:
-          name: compilers-amd64
+          name: compilers-Windows-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: actions/download-artifact@v4
         with:
@@ -1995,6 +2076,7 @@ jobs:
         with:
           name: macros-amd64
           path: ${{ github.workspace }}/BinaryCache/Library
+
       - uses: actions/checkout@v4
         with:
           repository: apple/swift-corelibs-libdispatch
@@ -2344,8 +2426,8 @@ jobs:
 
   devtools:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.build_os == 'Windows'
-    needs: [sqlite, compilers, stdlib, sdk]
+    if: always() && inputs.build_os == 'Windows' && needs.sdk.result == 'success'
+    needs: [sqlite, stdlib, sdk]
     runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
@@ -2363,15 +2445,19 @@ jobs:
     name: Windows ${{ matrix.arch }} Developer Tools
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: '.github/actions'
+
       - uses: actions/download-artifact@v4
         with:
           name: sqlite-Windows-${{ matrix.arch }}-${{ inputs.swift_toolchain_sqlite_version }}
           path: ${{ github.workspace }}/BinaryCache/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr
 
       - name: Download Compilers
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download-directory
         with:
-          name: compilers-amd64
+          name: compilers-Windows-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: actions/download-artifact@v4
         with:
@@ -2385,11 +2471,11 @@ jobs:
         with:
           name: macros-amd64
           path: ${{ github.workspace }}/BinaryCache/Library
-      - uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-directory
         with:
-          name: swift-syntax-${{ matrix.arch }}
+          name: swift-syntax-Windows-${{ matrix.arch }}
           path: ${{ github.workspace }}/BinaryCache/swift-syntax
-      - uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-directory
         with:
           name: cmark-gfm-Windows-${{ matrix.arch }}-${{ inputs.swift_cmark_version }}
           path: ${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr
@@ -3055,8 +3141,8 @@ jobs:
 
   debugging_tools:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.build_os == 'Windows'
-    needs: [compilers, devtools, stdlib, sdk]
+    if: always() && inputs.build_os == 'Windows' && needs.devtools.result == 'success'
+    needs: [devtools, stdlib, sdk]
     runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
@@ -3073,10 +3159,14 @@ jobs:
     name: Windows ${{ matrix.arch }} Debugging Tools
 
     steps:
-      - name: Download Compilers
-        uses: actions/download-artifact@v4
+      - uses: actions/checkout@v4
         with:
-          name: compilers-amd64
+          sparse-checkout: '.github/actions'
+
+      - name: Download Compilers
+        uses: ./.github/actions/download-directory
+        with:
+          name: compilers-Windows-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BuildRoot/Library
       - name: Download Devtools
         uses: actions/download-artifact@v4
@@ -3195,9 +3285,9 @@ jobs:
 
   package_tools:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.build_os == 'Windows'
+    if: always() && inputs.build_os == 'Windows' && needs.debugging_tools.result == 'success'
     name: Package Tools
-    needs: [compilers, macros, debugging_tools, devtools]
+    needs: [macros, debugging_tools, devtools]
     runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
@@ -3206,24 +3296,25 @@ jobs:
         arch: ['amd64' , 'arm64']
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: '.github/actions'
+
       - name: Download Debugging Tools
         uses: actions/download-artifact@v4
         with:
           name: debugging_tools-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/DebuggingTools
-
       - name: Download Compilers
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download-directory
         with:
-          name: compilers-${{ matrix.arch }}
+          name: compilers-Windows-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library
-
       - name: Download Developer Tools
         uses: actions/download-artifact@v4
         with:
           name: devtools-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library
-
       - name: Download Macros
         uses: actions/download-artifact@v4
         with:
@@ -3384,7 +3475,7 @@ jobs:
 
   package_windows_sdk_runtime:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.build_os == 'Windows'
+    if: always() && inputs.build_os == 'Windows' && needs.sdk.result == 'success'
     name: Package Windows SDK & Runtime
     needs: [stdlib, sdk]
     runs-on: ${{ inputs.default_build_runner }}
@@ -3490,7 +3581,7 @@ jobs:
 
   package_android_sdk_runtime:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.build_os == 'Windows'
+    if: always() && inputs.build_os == 'Windows' && needs.sdk.result == 'success'
     name: Package Android SDK & Runtime
     needs: [stdlib, ds2, sdk]
     runs-on: ${{ inputs.default_build_runner }}
@@ -3581,7 +3672,12 @@ jobs:
 
   installer:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.build_os == 'Windows'
+    if: |
+      always() && 
+      inputs.build_os == 'Windows' &&
+      needs.package_tools.result == 'success' &&
+      needs.package_windows_sdk_runtime.result == 'success' &&
+      needs.package_android_sdk_runtime.result == 'success'
     needs: [package_tools, package_windows_sdk_runtime, package_android_sdk_runtime]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -3717,7 +3813,7 @@ jobs:
 
   smoke_test:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.build_os == 'Windows'
+    if: always() && inputs.build_os == 'Windows' && needs.installer.result == 'success'
     needs: [installer]
     runs-on: ${{ inputs.default_build_runner }}
 

--- a/Darwin-arm64.cmake
+++ b/Darwin-arm64.cmake
@@ -1,0 +1,199 @@
+# test args
+
+set(LLVM_LIT_ARGS "--xunit-xml-output=testresults.xunit.xml -v" CACHE STRING "")
+
+set(LLVM_ENABLE_PROJECTS
+    clang
+    clang-tools-extra
+    lld
+    lldb
+    CACHE STRING "")
+
+set(LLVM_EXTERNAL_PROJECTS
+    cmark
+    swift
+    CACHE STRING "")
+
+set(LLVM_ENABLE_RUNTIMES
+    compiler-rt
+    CACHE STRING "")
+
+# This forces libc++ to be built so disable it.
+set(LLDB_INCLUDE_TESTS OFF CACHE BOOL "")
+
+# Compiler-RT configuration for macOS. For some reason, enabling `compiler-rt` in
+# `LLVM_ENABLE_RUNTIMES` is not enough.
+set(LLVM_BUILD_EXTERNAL_COMPILER_RT ON CACHE BOOL "Build Compiler-RT with just-built clang")
+set(COMPILER_RT_ENABLE_IOS ON CACHE BOOL "Build iOS Compiler-RT libraries")
+
+# NOTE(compnerd) always enable assertions, the toolchain will not provide enough
+# context to resolve issues otherwise and may silently generate invalid output.
+set(LLVM_ENABLE_ASSERTIONS YES CACHE BOOL "")
+
+set(ENABLE_X86_RELAX_RELOCATIONS YES CACHE BOOL "")
+
+# NOTE(compnerd) we can hardcode the default target triple since the cache files
+# are target dependent.
+set(LLVM_DEFAULT_TARGET_TRIPLE aarch64-apple-darwin CACHE STRING "")
+
+set(LLVM_APPEND_VC_REV NO CACHE BOOL "")
+set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR YES CACHE BOOL "")
+set(LLVM_ENABLE_PYTHON YES CACHE BOOL "")
+
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF CACHE BOOL "")
+
+# Setting any of the stuff below causes issues with configure (?).
+# set(LLVM_BUILTIN_TARGETS
+#     aarch64-apple-darwin x86_64-apple-darwin
+#     CACHE STRING "")
+
+# The runtime targets are used to build the compiler-rt profile library.
+# set(LLVM_RUNTIME_TARGETS
+#       aarch64-apple-darwin x86_64-apple-darwin
+#     CACHE STRING "")
+
+# foreach(target ${LLVM_RUNTIME_TARGETS})
+#   set(BUILTINS_${target}_LLVM_ENABLE_RUNTIMES
+#           compiler-rt
+#       CACHE STRING "")
+#   set(BUILTINS_${target}_CMAKE_SYSTEM_NAME Darwin CACHE STRING "")
+#   set(BUILTINS_${target}_CMAKE_BUILD_TYPE Release CACHE STRING "")
+#   set(RUNTIMES_${target}_COMPILER_RT_BUILD_BUILTINS NO CACHE BOOL "")
+#   set(BUILTINS_${target}_COMPILER_RT_BUILD_CRT NO CACHE BOOL "")
+#   set(BUILTINS_${target}_COMPILER_RT_BUILD_LIBFUZZER NO CACHE BOOL "")
+#   set(BUILTINS_${target}_COMPILER_RT_BUILD_PROFILE YES CACHE BOOL "")
+#   set(BUILTINS_${target}_COMPILER_RT_BUILD_SANITIZERS NO CACHE BOOL "")
+#   set(BUILTINS_${target}_COMPILER_RT_BUILD_XRAY NO CACHE BOOL "")
+# endforeach()
+
+set(CMAKE_MACOSX_RPATH ON CACHE BOOL "")
+set(LLVM_ENABLE_MODULES OFF CACHE BOOL "")
+
+set(LLVM_TARGETS_TO_BUILD AArch64 ARM WebAssembly X86 CACHE STRING "")
+
+# Disable certain targets to reduce the configure time or to avoid configuration
+# differences (and in some cases weird build errors on a complete build).
+set(LLVM_BUILD_LLVM_DYLIB NO CACHE BOOL "")
+set(LLVM_BUILD_LLVM_C_DYLIB NO CACHE BOOL "")
+set(LLVM_ENABLE_LIBEDIT NO CACHE BOOL "")
+set(LLVM_ENABLE_LIBXML2 NO CACHE BOOL "")
+set(LLVM_ENABLE_OCAMLDOC NO CACHE BOOL "")
+set(LLVM_ENABLE_TERMINFO NO CACHE BOOL "")
+set(LLVM_ENABLE_Z3_SOLVER NO CACHE BOOL "")
+set(LLVM_ENABLE_ZLIB NO CACHE BOOL "")
+set(LLVM_ENABLE_ZSTD NO CACHE BOOL "")
+set(LLVM_INCLUDE_BENCHMARKS NO CACHE BOOL "")
+set(LLVM_INCLUDE_DOCS NO CACHE BOOL "")
+set(LLVM_INCLUDE_EXAMPLES NO CACHE BOOL "")
+set(LLVM_INCLUDE_GO_TESTS NO CACHE BOOL "")
+set(LLVM_TOOL_GOLD_BUILD NO CACHE BOOL "")
+set(LLVM_TOOL_LLVM_SHLIB_BUILD NO CACHE BOOL "")
+
+# Avoid swig dependency for lldb
+set(LLDB_ALLOW_STATIC_BINDINGS YES CACHE BOOL "")
+set(LLDB_USE_STATIC_BINDINGS YES CACHE BOOL "")
+set(LLDB_ENABLE_PYTHON YES CACHE BOOL "")
+set(LLDB_EMBED_PYTHON_HOME NO CACHE BOOL "")
+set(LLDB_ENABLE_LIBXML2 NO CACHE BOOL "")
+
+set(SWIFT_INCLUDE_DOCS YES CACHE BOOL "")
+set(SWIFT_BUILD_ENABLE_PARSER_LIB YES CACHE BOOL "")
+set(SWIFT_BUILD_STDLIB_EXTRA_TOOLCHAIN_CONTENT NO CACHE BOOL "")
+set(SWIFT_BUILD_STDLIB_CXX_MODULE NO CACHE BOOL "")
+set(SWIFT_BUILD_STATIC_STDLIB NO CACHE BOOL "")
+set(SWIFT_BUILD_STATIC_SDK_OVERLAY NO CACHE BOOL "")
+
+set(LLVM_INSTALL_BINUTILS_SYMLINKS YES CACHE BOOL "")
+set(LLVM_INSTALL_TOOLCHAIN_ONLY YES CACHE BOOL "")
+set(LLVM_TOOLCHAIN_TOOLS
+    addr2line
+    ar
+    c++filt
+    dsymutil
+    dwp
+    # lipo
+    llvm-ar
+    llvm-cov
+    llvm-cvtres
+    llvm-cxxfilt
+    llvm-dlltool
+    llvm-dwarfdump
+    llvm-dwp
+    llvm-lib
+    llvm-lipo
+    llvm-ml
+    llvm-mt
+    llvm-nm
+    llvm-objcopy
+    llvm-objdump
+    llvm-pdbutil
+    llvm-profdata
+    llvm-ranlib
+    llvm-rc
+    llvm-readelf
+    llvm-readobj
+    llvm-size
+    llvm-strings
+    llvm-strip
+    llvm-symbolizer
+    llvm-undname
+    nm
+    objcopy
+    objdump
+    ranlib
+    readelf
+    size
+    strings
+    CACHE STRING "")
+
+set(CLANG_TOOLS
+    clang
+    clangd
+    clang-deps-launcher
+    clang-features-file
+    clang-format
+    clang-resource-headers
+    clang-scan-deps
+    clang-tidy
+    CACHE STRING "")
+
+set(LLD_TOOLS
+    lld
+    CACHE STRING "")
+
+set(LLDB_TOOLS
+    liblldb
+    lldb
+    lldb-argdumper
+    lldb-python-scripts
+    lldb-server
+    lldb-dap
+    repl_swift
+    CACHE STRING "")
+
+set(SWIFT_INSTALL_COMPONENTS
+    autolink-driver
+    compiler
+    clang-builtin-headers
+    editor-integration
+    tools
+    sourcekit-inproc
+    static-mirror-lib
+    swift-remote-mirror
+    swift-remote-mirror-headers
+    swift-syntax-lib
+    compiler-swift-syntax-lib
+    CACHE STRING "")
+
+set(LLVM_DISTRIBUTION_COMPONENTS
+    IndexStore
+    libclang
+    libclang-headers
+    LTO
+    runtimes
+    ${LLVM_TOOLCHAIN_TOOLS}
+    ${CLANG_TOOLS}
+    ${LLD_TOOLS}
+    ${LLDB_TOOLS}
+    ${SWIFT_INSTALL_COMPONENTS}
+    CACHE STRING "")

--- a/Darwin-x86_64.cmake
+++ b/Darwin-x86_64.cmake
@@ -1,0 +1,199 @@
+# test args
+
+set(LLVM_LIT_ARGS "--xunit-xml-output=testresults.xunit.xml -v" CACHE STRING "")
+
+set(LLVM_ENABLE_PROJECTS
+    clang
+    clang-tools-extra
+    lld
+    lldb
+    CACHE STRING "")
+
+set(LLVM_EXTERNAL_PROJECTS
+    cmark
+    swift
+    CACHE STRING "")
+
+set(LLVM_ENABLE_RUNTIMES
+    compiler-rt
+    CACHE STRING "")
+
+# This forces libc++ to be built so disable it.
+set(LLDB_INCLUDE_TESTS OFF CACHE BOOL "")
+
+# Compiler-RT configuration for macOS. For some reason, enabling `compiler-rt` in
+# `LLVM_ENABLE_RUNTIMES` is not enough.
+set(LLVM_BUILD_EXTERNAL_COMPILER_RT ON CACHE BOOL "Build Compiler-RT with just-built clang")
+set(COMPILER_RT_ENABLE_IOS ON CACHE BOOL "Build iOS Compiler-RT libraries")
+
+# NOTE(compnerd) always enable assertions, the toolchain will not provide enough
+# context to resolve issues otherwise and may silently generate invalid output.
+set(LLVM_ENABLE_ASSERTIONS YES CACHE BOOL "")
+
+set(ENABLE_X86_RELAX_RELOCATIONS YES CACHE BOOL "")
+
+# NOTE(compnerd) we can hardcode the default target triple since the cache files
+# are target dependent.
+set(LLVM_DEFAULT_TARGET_TRIPLE x86_64-apple-darwin CACHE STRING "")
+
+set(LLVM_APPEND_VC_REV NO CACHE BOOL "")
+set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR YES CACHE BOOL "")
+set(LLVM_ENABLE_PYTHON YES CACHE BOOL "")
+
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF CACHE BOOL "")
+
+# Setting any of the stuff below causes issues with configure (?).
+# set(LLVM_BUILTIN_TARGETS
+#     aarch64-apple-darwin x86_64-apple-darwin
+#     CACHE STRING "")
+
+# The runtime targets are used to build the compiler-rt profile library.
+# set(LLVM_RUNTIME_TARGETS
+#       aarch64-apple-darwin x86_64-apple-darwin
+#     CACHE STRING "")
+
+# foreach(target ${LLVM_RUNTIME_TARGETS})
+#   set(BUILTINS_${target}_LLVM_ENABLE_RUNTIMES
+#           compiler-rt
+#       CACHE STRING "")
+#   set(BUILTINS_${target}_CMAKE_SYSTEM_NAME Darwin CACHE STRING "")
+#   set(BUILTINS_${target}_CMAKE_BUILD_TYPE Release CACHE STRING "")
+#   set(RUNTIMES_${target}_COMPILER_RT_BUILD_BUILTINS NO CACHE BOOL "")
+#   set(BUILTINS_${target}_COMPILER_RT_BUILD_CRT NO CACHE BOOL "")
+#   set(BUILTINS_${target}_COMPILER_RT_BUILD_LIBFUZZER NO CACHE BOOL "")
+#   set(BUILTINS_${target}_COMPILER_RT_BUILD_PROFILE YES CACHE BOOL "")
+#   set(BUILTINS_${target}_COMPILER_RT_BUILD_SANITIZERS NO CACHE BOOL "")
+#   set(BUILTINS_${target}_COMPILER_RT_BUILD_XRAY NO CACHE BOOL "")
+# endforeach()
+
+set(CMAKE_MACOSX_RPATH ON CACHE BOOL "")
+set(LLVM_ENABLE_MODULES OFF CACHE BOOL "")
+
+set(LLVM_TARGETS_TO_BUILD AArch64 ARM WebAssembly X86 CACHE STRING "")
+
+# Disable certain targets to reduce the configure time or to avoid configuration
+# differences (and in some cases weird build errors on a complete build).
+set(LLVM_BUILD_LLVM_DYLIB NO CACHE BOOL "")
+set(LLVM_BUILD_LLVM_C_DYLIB NO CACHE BOOL "")
+set(LLVM_ENABLE_LIBEDIT NO CACHE BOOL "")
+set(LLVM_ENABLE_LIBXML2 NO CACHE BOOL "")
+set(LLVM_ENABLE_OCAMLDOC NO CACHE BOOL "")
+set(LLVM_ENABLE_TERMINFO NO CACHE BOOL "")
+set(LLVM_ENABLE_Z3_SOLVER NO CACHE BOOL "")
+set(LLVM_ENABLE_ZLIB NO CACHE BOOL "")
+set(LLVM_ENABLE_ZSTD NO CACHE BOOL "")
+set(LLVM_INCLUDE_BENCHMARKS NO CACHE BOOL "")
+set(LLVM_INCLUDE_DOCS NO CACHE BOOL "")
+set(LLVM_INCLUDE_EXAMPLES NO CACHE BOOL "")
+set(LLVM_INCLUDE_GO_TESTS NO CACHE BOOL "")
+set(LLVM_TOOL_GOLD_BUILD NO CACHE BOOL "")
+set(LLVM_TOOL_LLVM_SHLIB_BUILD NO CACHE BOOL "")
+
+# Avoid swig dependency for lldb
+set(LLDB_ALLOW_STATIC_BINDINGS YES CACHE BOOL "")
+set(LLDB_USE_STATIC_BINDINGS YES CACHE BOOL "")
+set(LLDB_ENABLE_PYTHON YES CACHE BOOL "")
+set(LLDB_EMBED_PYTHON_HOME NO CACHE BOOL "")
+set(LLDB_ENABLE_LIBXML2 NO CACHE BOOL "")
+
+set(SWIFT_INCLUDE_DOCS YES CACHE BOOL "")
+set(SWIFT_BUILD_ENABLE_PARSER_LIB YES CACHE BOOL "")
+set(SWIFT_BUILD_STDLIB_EXTRA_TOOLCHAIN_CONTENT NO CACHE BOOL "")
+set(SWIFT_BUILD_STDLIB_CXX_MODULE NO CACHE BOOL "")
+set(SWIFT_BUILD_STATIC_STDLIB NO CACHE BOOL "")
+set(SWIFT_BUILD_STATIC_SDK_OVERLAY NO CACHE BOOL "")
+
+set(LLVM_INSTALL_BINUTILS_SYMLINKS YES CACHE BOOL "")
+set(LLVM_INSTALL_TOOLCHAIN_ONLY YES CACHE BOOL "")
+set(LLVM_TOOLCHAIN_TOOLS
+    addr2line
+    ar
+    c++filt
+    dsymutil
+    dwp
+    # lipo
+    llvm-ar
+    llvm-cov
+    llvm-cvtres
+    llvm-cxxfilt
+    llvm-dlltool
+    llvm-dwarfdump
+    llvm-dwp
+    llvm-lib
+    llvm-lipo
+    llvm-ml
+    llvm-mt
+    llvm-nm
+    llvm-objcopy
+    llvm-objdump
+    llvm-pdbutil
+    llvm-profdata
+    llvm-ranlib
+    llvm-rc
+    llvm-readelf
+    llvm-readobj
+    llvm-size
+    llvm-strings
+    llvm-strip
+    llvm-symbolizer
+    llvm-undname
+    nm
+    objcopy
+    objdump
+    ranlib
+    readelf
+    size
+    strings
+    CACHE STRING "")
+
+set(CLANG_TOOLS
+    clang
+    clangd
+    clang-deps-launcher
+    clang-features-file
+    clang-format
+    clang-resource-headers
+    clang-scan-deps
+    clang-tidy
+    CACHE STRING "")
+
+set(LLD_TOOLS
+    lld
+    CACHE STRING "")
+
+set(LLDB_TOOLS
+    liblldb
+    lldb
+    lldb-argdumper
+    lldb-python-scripts
+    lldb-server
+    lldb-dap
+    repl_swift
+    CACHE STRING "")
+
+set(SWIFT_INSTALL_COMPONENTS
+    autolink-driver
+    compiler
+    clang-builtin-headers
+    editor-integration
+    tools
+    sourcekit-inproc
+    static-mirror-lib
+    swift-remote-mirror
+    swift-remote-mirror-headers
+    swift-syntax-lib
+    compiler-swift-syntax-lib
+    CACHE STRING "")
+
+set(LLVM_DISTRIBUTION_COMPONENTS
+    IndexStore
+    libclang
+    libclang-headers
+    LTO
+    runtimes
+    ${LLVM_TOOLCHAIN_TOOLS}
+    ${CLANG_TOOLS}
+    ${LLD_TOOLS}
+    ${LLDB_TOOLS}
+    ${SWIFT_INSTALL_COMPONENTS}
+    CACHE STRING "")


### PR DESCRIPTION
* Add custom upload/download actions for tarring artifacts before upload and after download to preserve permissions.
* Add cache files for the Mac compilers build.
* Modify the compilers step to be re-usable between Windows and Mac.