### PR TITLE
Fix the swift-testing branch in release/6.0

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -41,7 +41,7 @@
   <project remote="github" name="apple/swift-protobuf" path="swift-protobuf" groups="notdefault" />
   <project remote="github" name="swiftlang/swift-syntax" path="swift-syntax" />
   <project remote="github" name="apple/swift-system" path="swift-system" revision="refs/tags/1.3.0" />
-  <project remote="github" name="swiftlang/swift-testing" path="swift-testing" revision="main" />
+  <project remote="github" name="swiftlang/swift-testing" path="swift-testing" />
   <project remote="github" name="swiftlang/swift-toolchain-sqlite" path="swift-toolchain-sqlite" />
   <project remote="github" name="swiftlang/swift-tools-support-core" path="swift-tools-support-core" />
   <project remote="github" name="apple/swift-xcode-playground-support" path="swift-xcode-playground-support" groups="notdefault" />


### PR DESCRIPTION
It should be `release/6.0` as opposed to `main` as per https://github.com/swiftlang/swift/blob/555c00a7317764f8fa2e587af4f0f9f68df7a178/utils/update_checkout/update-checkout-config.json#L195 and https://github.com/swiftlang/swift/pull/76026