### PR TITLE
Add the native ARM64 toolchain build to the main CI

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -36,6 +36,17 @@ on:
         default: true
         required: false
 
+      create_snapshot:
+        description: 'Create Snapshot'
+        type: boolean
+        default: true
+        required: false
+
+      build_android:
+        required: false
+        default: false
+        type: boolean
+
   workflow_call:
     inputs:
       swift_version:
@@ -71,15 +82,41 @@ on:
         default: true
         required: false
 
-      windows_default_runner:
-        description: 'Build runner'
+      create_snapshot:
+        description: 'Create Snapshot'
+        type: boolean
+        default: true
+        required: false
+
+      windows_x64_default_runner:
+        description: 'X64 Build runner'
         required: false
         type: string
 
-      windows_compilers_runner:
-        description: 'Build runner for `compilers` job'
-        type: string
+      windows_arm64_default_runner:
+        description: 'ARM64 Build runner'
         required: false
+        type: string
+
+      windows_x64_compilers_runner:
+        description: 'X64 Build runner for `compilers` job'
+        required: false
+        type: string
+
+      windows_arm64_compilers_runner:
+        description: 'ARM64 Build runner for `compilers` job'
+        required: false
+        type: string
+
+      windows_build_arch:
+        description: 'Windows build architecture'
+        required: false
+        type: string
+
+      build_android:
+        required: false
+        default: false
+        type: boolean
 
     secrets:
       SYMBOL_SERVER_PAT:
@@ -153,12 +190,19 @@ jobs:
       signed: ${{ steps.context.outputs.signed }}
       swift_version: ${{ steps.context.outputs.swift_version }}
       swift_tag: ${{ steps.context.outputs.swift_tag }}
-      windows_build_runner: ${{ steps.context.outputs.windows_build_runner }}
-      windows_compilers_runner: ${{ steps.context.outputs.windows_compilers_runner }}
+      windows_arm64_build_runner: ${{ steps.context.outputs.windows_arm64_build_runner }}
+      windows_arm64_compilers_runner: ${{ steps.context.outputs.windows_arm64_compilers_runner }}
+      windows_build_arch: ${{ steps.context.outputs.windows_build_arch }}
+      windows_build_cpu: ${{ steps.context.outputs.windows_build_cpu }}
+      windows_x64_build_runner: ${{ steps.context.outputs.windows_x64_build_runner }}
+      windows_x64_compilers_runner: ${{ steps.context.outputs.windows_x64_compilers_runner }}
       mac_build_runner: ${{ steps.context.outputs.mac_build_runner }}
-      windows_host_matrix: ${{ steps.setup-matrix.outputs.windows_host_matrix }}
-      windows_build_matrix: ${{ steps.setup-matrix.outputs.windows_build_matrix }}
-      windows_target_matrix: ${{ steps.setup-matrix.outputs.windows_target_matrix }}
+      windows_arm64_build_matrix: ${{ steps.setup-matrix.outputs.windows_arm64_build_matrix }}
+      windows_arm64_host_matrix: ${{ steps.setup-matrix.outputs.windows_arm64_host_matrix }}
+      windows_arm64_target_matrix: ${{ steps.setup-matrix.outputs.windows_arm64_target_matrix }}
+      windows_x64_build_matrix: ${{ steps.setup-matrix.outputs.windows_x64_build_matrix }}
+      windows_x64_host_matrix: ${{ steps.setup-matrix.outputs.windows_x64_host_matrix }}
+      windows_x64_target_matrix: ${{ steps.setup-matrix.outputs.windows_x64_target_matrix }}
       darwin_host_matrix: ${{ steps.setup-matrix.outputs.darwin_host_matrix }}
       darwin_build_matrix: ${{ steps.setup-matrix.outputs.darwin_build_matrix }}
       darwin_target_matrix: ${{ steps.setup-matrix.outputs.darwin_target_matrix }}
@@ -284,8 +328,18 @@ jobs:
             fi
           fi
 
-          echo windows_build_runner=${{ inputs.windows_default_runner || vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
-          echo windows_compilers_runner=${{ inputs.windows_compilers_runner || inputs.windows_default_runner || vars.COMPILERS_BUILD_RUNNER || vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
+          echo windows_x64_build_runner=${{ inputs.windows_x64_default_runner || vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
+          echo windows_x64_compilers_runner=${{ inputs.windows_x64_compilers_runner || inputs.windows_x64_default_runner || vars.WINDOWS_X64_COMPILERS_BUILD_RUNNER || vars.WINDOWS_X64_DEFAULT_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
+          echo windows_arm64_build_runner=${{ inputs.windows_arm64_default_runner || vars.WINDOWS_ARM64_DEFAULT_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
+          echo windows_arm64_compilers_runner=${{ inputs.windows_arm64_compilers_runner || inputs.windows_arm64_default_runner || vars.WINDOWS_ARM64_COMPILERS_BUILD_RUNNER || vars.WINDOWS_ARM64_DEFAULT_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
+          if [[ "${{ inputs.windows_build_arch }}" == "arm64" ]] ; then
+            echo windows_build_arch=arm64 >> ${GITHUB_OUTPUT}
+            echo windows_build_cpu=arm64 >> ${GITHUB_OUTPUT}
+          else
+            echo windows_build_arch=amd64 >> ${GITHUB_OUTPUT}
+            echo windows_build_cpu=x64 >> ${GITHUB_OUTPUT}
+          fi
+
           # TODO: Make the mac runner configurable.
           echo mac_build_runner=macos-latest >> ${GITHUB_OUTPUT}
 
@@ -293,6 +347,7 @@ jobs:
           echo ANDROID_NDK_VERSION=r26b >> ${GITHUB_OUTPUT}
 
       - uses: actions/upload-artifact@v4
+        if: inputs.create_snapshot == true
         with:
           name: stable.xml
           path: stable.xml
@@ -301,7 +356,56 @@ jobs:
       - name: Setup matrix
         id: setup-matrix
         env:
-          WINDOWS_HOST_MATRIX: >-
+          WINDOWS_X64_HOST_MATRIX: >-
+            {
+              "include": [
+                {
+                  "arch": "amd64",
+                  "cpu": "x86_64",
+                  "triple": "x86_64-unknown-windows-msvc",
+                  "compiler_target": "x86_64-unknown-windows-msvc",
+                  "os": "Windows",
+                  "cc": "cl",
+                  "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
+                  "cxx": "cl",
+                  "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
+                  "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=AMD64 -D CMAKE_MT=mt"
+                },
+                {
+                  "arch": "arm64",
+                  "cpu": "aarch64",
+                  "triple": "aarch64-unknown-windows-msvc",
+                  "compiler_target": "aarch64-unknown-windows-msvc",
+                  "os": "Windows",
+                  "cc": "cl",
+                  "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
+                  "cxx": "cl",
+                  "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
+                  "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=ARM64 -D CMAKE_MT=mt"
+                }
+              ]
+            }
+          WINDOWS_ARM64_HOST_MATRIX: >-
+            {
+              "include": [
+                {
+                  "arch": "arm64",
+                  "cpu": "aarch64",
+                  "triple": "aarch64-unknown-windows-msvc",
+                  "compiler_target": "aarch64-unknown-windows-msvc",
+                  "os": "Windows",
+                  "cc": "cl",
+                  "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
+                  "cxx": "cl",
+                  "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
+                  "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=ARM64 -D CMAKE_MT=mt"
+                }
+              ]
+            }
+          WINDOWS_X64_BUILD_MATRIX: >-
             {
               "include": [
                 {
@@ -314,7 +418,12 @@ jobs:
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
                   "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
                   "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=AMD64 -D CMAKE_MT=mt"
-                },
+                }
+              ]
+            }
+          WINDOWS_ARM64_BUILD_MATRIX: >-
+            {
+              "include": [
                 {
                   "arch": "arm64",
                   "compiler_target": "aarch64-unknown-windows-msvc",
@@ -328,22 +437,7 @@ jobs:
                 }
               ]
             }
-          WINDOWS_BUILD_MATRIX: >-
-            {
-              "include": [
-                {
-                  "arch": "amd64",
-                  "os": "Windows",
-                  "cc": "cl",
-                  "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
-                  "cxx": "cl",
-                  "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
-                  "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
-                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=AMD64 -D CMAKE_MT=mt"
-                }
-              ]
-            }
-          WINDOWS_TARGET_MATRIX: >-
+          WINDOWS_X64_TARGET_MATRIX: >-
             {
               "include": [
                 {
@@ -418,6 +512,41 @@ jobs:
                 }
               ]
             }
+          WINDOWS_ARM64_TARGET_MATRIX: >-
+            {
+              "include": [
+                {
+                  "arch": "amd64",
+                  "os": "Windows",
+                  "cc": "cl",
+                  "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
+                  "cxx": "cl",
+                  "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
+                  "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=AMD64 -D CMAKE_MT=mt"
+                },
+                {
+                  "arch": "arm64",
+                  "os": "Windows",
+                  "cc": "cl",
+                  "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
+                  "cxx": "cl",
+                  "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
+                  "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=ARM64 -D CMAKE_MT=mt"
+                },
+                {
+                  "arch": "x86",
+                  "os": "Windows",
+                  "cc": "cl",
+                  "cflags": "${{ steps.context.outputs.WINDOWS_CMAKE_C_FLAGS }}",
+                  "cxx": "cl",
+                  "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
+                  "swiftflags": "",
+                  "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=X86 -D CMAKE_MT=mt"
+                }
+              ]
+            }
           DARWIN_HOST_MATRIX: >-
             {
               "include": [
@@ -486,9 +615,12 @@ jobs:
               ]
             }
         run: |
-          echo "windows_host_matrix=$(jq -r -c '.' <<< ${WINDOWS_HOST_MATRIX})" >> ${GITHUB_OUTPUT}
-          echo "windows_build_matrix=$(jq -r -c '.' <<< ${WINDOWS_BUILD_MATRIX})" >> ${GITHUB_OUTPUT}
-          echo "windows_target_matrix=$(jq -r -c '.' <<< ${WINDOWS_TARGET_MATRIX})" >> ${GITHUB_OUTPUT}
+          echo "windows_x64_host_matrix=$(jq -r -c '.' <<< ${WINDOWS_X64_HOST_MATRIX})" >> ${GITHUB_OUTPUT}
+          echo "windows_arm64_host_matrix=$(jq -r -c '.' <<< ${WINDOWS_ARM64_HOST_MATRIX})" >> ${GITHUB_OUTPUT}
+          echo "windows_x64_build_matrix=$(jq -r -c '.' <<< ${WINDOWS_X64_BUILD_MATRIX})" >> ${GITHUB_OUTPUT}
+          echo "windows_arm64_build_matrix=$(jq -r -c '.' <<< ${WINDOWS_ARM64_BUILD_MATRIX})" >> ${GITHUB_OUTPUT}
+          echo "windows_x64_target_matrix=$(jq -r -c '.' <<< ${WINDOWS_X64_TARGET_MATRIX})" >> ${GITHUB_OUTPUT}
+          echo "windows_arm64_target_matrix=$(jq -r -c '.' <<< ${WINDOWS_ARM64_TARGET_MATRIX})" >> ${GITHUB_OUTPUT}
           echo "darwin_host_matrix=$(jq -r -c '.' <<< ${DARWIN_HOST_MATRIX})" >> ${GITHUB_OUTPUT}
           echo "darwin_build_matrix=$(jq -r -c '.' <<< ${DARWIN_BUILD_MATRIX})" >> ${GITHUB_OUTPUT}
           echo "darwin_target_matrix=$(jq -r -c '.' <<< ${DARWIN_TARGET_MATRIX})" >> ${GITHUB_OUTPUT}
@@ -496,13 +628,14 @@ jobs:
   windows-build:
     needs: [context]
     name: Windows Swift Toolchains Build
+
     uses: ./.github/workflows/swift-toolchain.yml
     with:
       build_os: Windows
-      build_arch: amd64
-      build_matrix: ${{ needs.context.outputs.windows_build_matrix }}
-      host_matrix: ${{ needs.context.outputs.windows_host_matrix }}
-      target_matrix: ${{ needs.context.outputs.windows_target_matrix }}
+      build_arch: ${{ inputs.windows_build_arch }}
+      build_matrix: ${{ needs.context.outputs[format('windows_{0}_build_matrix', needs.context.outputs.windows_build_cpu)] }}
+      host_matrix: ${{ needs.context.outputs[format('windows_{0}_host_matrix', needs.context.outputs.windows_build_cpu)] }}
+      target_matrix: ${{ needs.context.outputs[format('windows_{0}_target_matrix', needs.context.outputs.windows_build_cpu)] }}
       curl_revision: ${{ needs.context.outputs.curl_revision }}
       curl_version: ${{ needs.context.outputs.curl_version }}
       ds2_revision: ${{ needs.context.outputs.ds2_revision }}
@@ -557,8 +690,9 @@ jobs:
       signed: ${{ fromJSON(needs.context.outputs.signed) }}
       swift_version: ${{ needs.context.outputs.swift_version }}
       swift_tag: ${{ needs.context.outputs.swift_tag }}
-      default_build_runner: ${{ needs.context.outputs.windows_build_runner }}
-      compilers_build_runner: ${{ needs.context.outputs.windows_compilers_runner }}
+      default_build_runner: ${{ needs.context.outputs[format('windows_{0}_build_runner', needs.context.outputs.windows_build_cpu)] }}
+      compilers_build_runner: ${{ needs.context.outputs[format('windows_{0}_compilers_runner', needs.context.outputs.windows_build_cpu)] }}
+      build_android: ${{ inputs.build_android }}
     secrets:
       SYMBOL_SERVER_PAT: ${{ secrets.SYMBOL_SERVER_PAT }}
       CERTIFICATE: ${{ secrets.CERTIFICATE }}
@@ -640,7 +774,7 @@ jobs:
   snapshot:
     runs-on: ubuntu-latest
     needs: [context, windows-build]
-    if: github.event_name == 'schedule'
+    if: inputs.create_snapshot == true && github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -247,6 +247,11 @@ on:
         required: true
         type: string
 
+      build_android:
+        required: false
+        default: false
+        type: boolean
+
     secrets:
       SYMBOL_SERVER_PAT:
         required: true
@@ -262,9 +267,16 @@ env:
   WORKAROUND_MACOS_PINNED_BOOTSTRAP_TOOLCHAIN_BRANCH: swift-6.0.1-release
   WORKAROUND_MACOS_PINNED_BOOTSTRAP_TOOLCHAIN_TAG: 6.0.1-RELEASE
 
-  # Workaround for ... on Windows preventing us from using the 5.10 toolchain release.
+  # Workaround for the `static_assert(false...)` failure in Clang on Windows
+  # preventing us from using the 5.10 toolchain release.
   WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_REPO: thebrowsercompany/swift-build
   WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_RELEASE: 20231016.5
+
+  # The placeholder for the ARM64 version for
+  # WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_* above. These (x64 and arm64) need
+  # to be updated when the ARM64 compiler is fixed and the pinned toolchain is updated.
+  WORKAROUND_WINDOWS_ARM64_PINNED_BOOTSTRAP_TOOLCHAIN_REPO: thebrowsercompany/swift-build
+  WORKAROUND_WINDOWS_ARM64_PINNED_BOOTSTRAP_TOOLCHAIN_RELEASE: "20231016.1"
 
 defaults:
   run:
@@ -348,7 +360,8 @@ jobs:
 
   ds2_tools:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.build_os == 'Windows'
+    # There is currently no Android NDK for Windows ARM64 so build ds2 only on Windows X64 host only
+    if: inputs.build_android
     runs-on: ${{ inputs.default_build_runner }}
 
     name: ds2 Build Tools
@@ -363,7 +376,7 @@ jobs:
 
       - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
         with:
-          host_arch: amd64
+          host_arch: ${{ inputs.build_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: amd64
 
@@ -397,7 +410,8 @@ jobs:
 
   ds2:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.build_os == 'Windows'
+    # There is currently no Android NDK for Windows ARM64 so build ds2 only on Windows X64 host only
+    if: inputs.build_android
     needs: [ds2_tools]
     runs-on: ${{ inputs.default_build_runner }}
 
@@ -449,7 +463,7 @@ jobs:
 
       - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
         with:
-          host_arch: amd64
+          host_arch: ${{ inputs.build_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
@@ -465,6 +479,7 @@ jobs:
           path: ${{ github.workspace }}/BinaryCache/RegsGen2
 
       - uses: nttld/setup-ndk@v1
+        if: matrix.os == 'Android'
         id: setup-ndk
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
@@ -600,6 +615,10 @@ jobs:
           show-progress: false
 
       - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
+        with:
+          host_arch: ${{ inputs.build_arch }}
+          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+          arch: ${{ matrix.arch }}
 
       - uses: seanmiddleditch/gha-setup-ninja@96bed6edff20d1dd61ecff9b75cc519d516e6401 # master
         if: inputs.build_os == 'Darwin'
@@ -756,6 +775,7 @@ jobs:
       - name: Install Swift Toolchain
         uses: compnerd/gha-setup-swift@b6c5fc1ed5b5439ada8e7661985acb09ad8c3ba2 # main
         with:
+          host_arch: ${{ inputs.build_arch }}
           branch: ${{ env.WORKAROUND_MACOS_PINNED_BOOTSTRAP_TOOLCHAIN_BRANCH }}
           tag: ${{ env.WORKAROUND_MACOS_PINNED_BOOTSTRAP_TOOLCHAIN_TAG }}
 
@@ -814,15 +834,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - arch: 'amd64'
-            cpu: 'x86_64'
-            triple: 'x86_64-unknown-windows-msvc'
-
-          - arch: 'arm64'
-            cpu: 'aarch64'
-            triple: 'aarch64-unknown-windows-msvc'
+      matrix: ${{ fromJSON(inputs.host_matrix) }}
 
     name: Windows ${{ matrix.arch }} Toolchain
 
@@ -876,17 +888,19 @@ jobs:
           show-progress: false
 
       - name: Install Python ${{ env.PYTHON_VERSION }} (Host)
+        if: matrix.arch == 'amd64' || inputs.build_arch == 'amd64'
         uses: actions/setup-python@v5
         id: python
         with:
           python-version: '${{ env.PYTHON_VERSION }}'
+          architecture: x64
 
       - uses: nuget/setup-nuget@v2
-        if: matrix.arch == 'arm64'
+        if: matrix.arch == 'arm64' || inputs.build_arch == 'arm64'
 
       # TODO(lxbndr) use actions/cache to improve this step timings
       - name: Install Python ${{ env.PYTHON_VERSION }} (arm64)
-        if: matrix.arch == 'arm64'
+        if: matrix.arch == 'arm64' || inputs.build_arch == 'arm64'
         run: |
           $NugetSources=[string](nuget Sources List -Format short)
           if (-Not ($NugetSources.contains("api.nuget.org"))) {
@@ -901,19 +915,29 @@ jobs:
 
       - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
         with:
-          host_arch: amd64
+          host_arch: ${{ inputs.build_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
       - name: Install Swift Toolchain
+        if: inputs.build_arch == 'amd64'
         uses: compnerd/gha-setup-swift@b6c5fc1ed5b5439ada8e7661985acb09ad8c3ba2 # main
         with:
           github-repo: ${{ env.WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_REPO }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          release-asset-name: installer-amd64.exe
+          release-asset-name: installer-${{ inputs.build_arch }}.exe
           release-tag-name: ${{ env.WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_RELEASE }}
+      - name: Install Swift Toolchain
+        if: inputs.build_arch == 'arm64'
+        uses: compnerd/gha-setup-swift@b6c5fc1ed5b5439ada8e7661985acb09ad8c3ba2 # main
+        with:
+          github-repo: ${{ env.WORKAROUND_WINDOWS_ARM64_PINNED_BOOTSTRAP_TOOLCHAIN_REPO }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          release-asset-name: installer-${{ inputs.build_arch }}.exe
+          release-tag-name: ${{ env.WORKAROUND_WINDOWS_ARM64_PINNED_BOOTSTRAP_TOOLCHAIN_RELEASE }}
 
       - uses: nttld/setup-ndk@v1
+        if: matrix.os == 'Android'
         id: setup-ndk
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
@@ -938,8 +962,6 @@ jobs:
           variant: sccache
 
       - name: Configure Compilers
-        env:
-          NDKPATH: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           if ( "${{ matrix.arch }}" -eq "arm64" ) {
             $CMAKE_SYSTEM_NAME="-D CMAKE_SYSTEM_NAME=Windows"
@@ -1108,7 +1130,7 @@ jobs:
 
       - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
         with:
-          host_arch: amd64
+          host_arch: ${{ inputs.build_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
@@ -1134,15 +1156,21 @@ jobs:
           variant: sccache
 
       - uses: nttld/setup-ndk@v1
+        if: matrix.os == 'Android'
         id: setup-ndk
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
 
       - name: Configure zlib
         run: |
-          $NDKPATH = "${{ steps.setup-ndk.outputs.ndk-path }}"
-          if ( "${{ inputs.build_os }}" -eq "Windows" ) {
-            $NDKPATH = cygpath -m $NDKPATH
+          if ("${{ matrix.os }}" -eq "Android") {
+            $NDKPATH = "${{ steps.setup-ndk.outputs.ndk-path }}"
+            if ( "${{ inputs.build_os }}" -eq "Windows" ) {
+              $NDKPATH = cygpath -m $NDKPATH
+            }
+            # Since win/arm64 doesn't have one, this logic is necessary because
+            # passing an empty CMAKE_ANDROID_NDK value causes a failure.
+            $CMAKE_NDK_FLAG = "-DCMAKE_ANDROID_NDK=$NDKPATH"
           }
           cmake -B ${{ github.workspace }}/BinaryCache/zlib-${{ inputs.zlib_version }} `
                 -D BUILD_SHARED_LIBS=NO `
@@ -1155,7 +1183,7 @@ jobs:
                 -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr `
                 -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
-                -D CMAKE_ANDROID_NDK=$NDKPATH `
+                $CMAKE_NDK_FLAG `
                 -D CMAKE_POSITION_INDEPENDENT_CODE=YES `
                 ${{ matrix.extra_flags }} `
                 -G Ninja `
@@ -1196,7 +1224,7 @@ jobs:
 
       - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
         with:
-          host_arch: amd64
+          host_arch: ${{ inputs.build_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
@@ -1222,15 +1250,21 @@ jobs:
           variant: sccache
 
       - uses: nttld/setup-ndk@v1
+        if: matrix.os == 'Android'
         id: setup-ndk
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
 
       - name: Configure curl
         run: |
-          $NDKPATH = "${{ steps.setup-ndk.outputs.ndk-path }}"
-          if ( "${{ inputs.build_os }}" -eq "Windows" ) {
-            $NDKPATH = cygpath -m $NDKPATH
+          if ("${{ matrix.os }}" -eq "Android") {
+            $NDKPATH = "${{ steps.setup-ndk.outputs.ndk-path }}"
+            if ( "${{ inputs.build_os }}" -eq "Windows" ) {
+              $NDKPATH = cygpath -m $NDKPATH
+            }
+            # Since win/arm64 doesn't have one, this logic is necessary because
+            # passing an empty CMAKE_ANDROID_NDK value causes a failure.
+            $CMAKE_NDK_FLAG = "-DCMAKE_ANDROID_NDK=$NDKPATH"
           }
           cmake -B ${{ github.workspace }}/BinaryCache/curl-${{ inputs.curl_version }} `
                 -D BUILD_SHARED_LIBS=NO `
@@ -1325,7 +1359,7 @@ jobs:
                 -D ZLIB_ROOT=${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr  `
                 -D ZLIB_LIBRARY=${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr/lib/zlibstatic.lib `
                 -D CMAKE_POSITION_INDEPENDENT_CODE=YES `
-                -D CMAKE_ANDROID_NDK=$NDKPATH
+                $CMAKE_NDK_FLAG
       - name: Build curl
         run: cmake --build ${{ github.workspace }}/BinaryCache/curl-${{ inputs.curl_version }}
       - name: Install curl
@@ -1355,7 +1389,7 @@ jobs:
 
       - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
         with:
-          host_arch: amd64
+          host_arch: ${{ inputs.build_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
@@ -1382,15 +1416,21 @@ jobs:
           variant: sccache
 
       - uses: nttld/setup-ndk@v1
+        if: matrix.os == 'Android'
         id: setup-ndk
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
 
       - name: Configure libxml2
         run: |
-          $NDKPATH = "${{ steps.setup-ndk.outputs.ndk-path }}"
-          if ( "${{ inputs.build_os }}" -eq "Windows" ) {
-            $NDKPATH = cygpath -m $NDKPATH
+          if ("${{ matrix.os }}" -eq "Android") {
+            $NDKPATH = "${{ steps.setup-ndk.outputs.ndk-path }}"
+            if ( "${{ inputs.build_os }}" -eq "Windows" ) {
+              $NDKPATH = cygpath -m $NDKPATH
+            }
+            # Since win/arm64 doesn't have one, this logic is necessary because
+            # passing an empty CMAKE_ANDROID_NDK value causes a failure.
+            $CMAKE_NDK_FLAG = "-DCMAKE_ANDROID_NDK=$NDKPATH"
           }
           cmake -B ${{ github.workspace }}/BinaryCache/libxml2-${{ inputs.libxml2_version }} `
                 -D BUILD_SHARED_LIBS=NO `
@@ -1414,7 +1454,7 @@ jobs:
                 -D LIBXML2_WITH_THREADS=YES `
                 -D LIBXML2_WITH_ZLIB=NO `
                 -D CMAKE_POSITION_INDEPENDENT_CODE=YES `
-                -D CMAKE_ANDROID_NDK=$NDKPATH
+                $CMAKE_NDK_FLAG
       - name: Build libxml2
         run: cmake --build ${{ github.workspace }}/BinaryCache/libxml2-${{ inputs.libxml2_version }}
       - name: Install libxml2
@@ -1539,7 +1579,7 @@ jobs:
       - name: Download Compilers
         uses: actions/download-artifact@v4
         with:
-          name: compilers-amd64
+          name: compilers-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BuildRoot/Library
       - uses: actions/checkout@v4
         with:
@@ -1571,32 +1611,48 @@ jobs:
       # we have not yet built the runtime, this requires that we use the runtime
       # from the previous build.
       - name: Install Swift Toolchain
+        if: inputs.build_arch == 'amd64'
         uses: compnerd/gha-setup-swift@b6c5fc1ed5b5439ada8e7661985acb09ad8c3ba2 # main
         with:
           github-repo: ${{ env.WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_REPO }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          release-asset-name: installer-amd64.exe
+          release-asset-name: installer-${{ inputs.build_arch }}.exe
           release-tag-name: ${{ env.WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_RELEASE }}
+      - name: Install Swift Toolchain
+        if: inputs.build_arch == 'arm64'
+        uses: compnerd/gha-setup-swift@b6c5fc1ed5b5439ada8e7661985acb09ad8c3ba2 # main
+        with:
+          github-repo: ${{ env.WORKAROUND_WINDOWS_ARM64_PINNED_BOOTSTRAP_TOOLCHAIN_REPO }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          release-asset-name: installer-${{ inputs.build_arch }}.exe
+          release-tag-name: ${{ env.WORKAROUND_WINDOWS_ARM64_PINNED_BOOTSTRAP_TOOLCHAIN_RELEASE }}
 
       # NOTE(compnerd): we execute unconditionally as we use CMake from VSDevEnv
       - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
         with:
-          host_arch: amd64
+          host_arch: ${{ inputs.build_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
       # NOTE(compnerd): we execute unconditionally as we reference outputs
       - uses: nttld/setup-ndk@v1
+        if: matrix.os == 'Android'
         id: setup-ndk
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
 
       - name: Configure LLVM
+        if: matrix.os != 'Android' || inputs.build_android
         run: |
           # NOTE: used by `matrix.cc`
           $CLANG_CL = "cl"
-          $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-
+          if ("${{ matrix.os }}" -eq "Android") {
+            $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
+            # Since win/arm64 doesn't have one, this logic is necessary because
+            # passing an empty CMAKE_ANDROID_NDK value causes a failure.
+            $CMAKE_NDK_FLAG = "-DCMAKE_ANDROID_NDK=$NDKPATH"
+            $SWIFT_NDK_FLAG = "-DSWIFT_ANDROID_NDK_PATH=$NDKPATH"
+          }
           cmake -B ${{ github.workspace }}/BinaryCache/llvm `
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${{ matrix.cc }} `
@@ -1608,19 +1664,26 @@ jobs:
                 -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
                 ${{ matrix.llvm_flags }} `
                 ${{ matrix.extra_flags }} `
-                -D CMAKE_ANDROID_NDK=${NDKPATH} `
-                -D SWIFT_ANDROID_NDK_PATH=${NDKPATH} `
+                $CMAKE_NDK_FLAG `
+                $SWIFT_NDK_FLAG `
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/llvm-project/llvm `
                 -D LLVM_ENABLE_ASSERTIONS=YES
 
       - name: Configure Swift Standard Library
+        if: matrix.os != 'Android' || inputs.build_android
         run: |
           # NOTE: used by `matrix.cc`
           $CLANG_CL = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
 
           $SWIFTC = cygpath -m ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
-          $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
+          if ("${{ matrix.os }}" -eq "Android") {
+            $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
+            # Since win/arm64 doesn't have one, this logic is necessary because
+            # passing an empty CMAKE_ANDROID_NDK value causes a failure.
+            $CMAKE_NDK_FLAG = "-DCMAKE_ANDROID_NDK=$NDKPATH"
+            $SWIFT_NDK_FLAG = "-DSWIFT_ANDROID_NDK_PATH=$NDKPATH"
+          }
 
           $CMAKE_CPU = if ("${{ matrix.cpu }}" -eq "armv7") {
             "armv7-a"
@@ -1650,8 +1713,8 @@ jobs:
                 -D MSVC_CXX_ARCHITECTURE_ID=${{ matrix.arch }} `
                 ${{ matrix.linker_flags }} `
                 ${{ matrix.extra_flags }} `
-                -D CMAKE_ANDROID_NDK=${NDKPATH} `
-                -D SWIFT_ANDROID_NDK_PATH=${NDKPATH} `
+                $CMAKE_NDK_FLAG `
+                $SWIFT_NDK_FLAG `
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/swift `
                 -D LLVM_DIR=${{ github.workspace }}/BinaryCache/llvm/lib/cmake/llvm `
@@ -1668,15 +1731,18 @@ jobs:
                 -D SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE=${{ github.workspace }}/SourceCache/swift-syntax `
                 -D SWIFT_PATH_TO_STRING_PROCESSING_SOURCE=${{ github.workspace }}/SourceCache/swift-experimental-string-processing
       - name: Build Swift Standard Library
+        if: matrix.os != 'Android' || inputs.build_android
         run: |
           Remove-Item env:\SDKROOT
           cmake --build ${{ github.workspace }}/BinaryCache/swift
       - name: Install Swift Standard Library
+        if: matrix.os != 'Android' || inputs.build_android
         run: |
           Remove-Item env:\SDKROOT
           cmake --build ${{ github.workspace }}/BinaryCache/swift --target install
 
       - uses: actions/upload-artifact@v4
+        if: matrix.os != 'Android' || inputs.build_android
         with:
           name: ${{ matrix.os }}-stdlib-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform
@@ -1729,7 +1795,7 @@ jobs:
       - name: Download Compilers
         uses: actions/download-artifact@v4
         with:
-          name: compilers-amd64
+          name: compilers-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - name: Download swift-syntax
         uses: actions/download-artifact@v4
@@ -1743,7 +1809,7 @@ jobs:
       - uses: actions/download-artifact@v4
         if: matrix.arch == 'arm64'
         with:
-          name: Windows-stdlib-amd64
+          name: Windows-stdlib-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform
       - uses: actions/download-artifact@v4
         with:
@@ -1771,7 +1837,7 @@ jobs:
       # NOTE(compnerd): we execute unconditionally as we use CMake from VSDevEnv
       - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
         with:
-          host_arch: amd64
+          host_arch: ${{ inputs.build_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
@@ -1958,14 +2024,17 @@ jobs:
 
     steps:
       - uses: actions/download-artifact@v4
+        if: matrix.os != 'Android' || inputs.build_android
         with:
           name: libxml2-${{ matrix.os }}-${{ matrix.arch }}-${{ inputs.libxml2_version }}
           path: ${{ github.workspace }}/BuildRoot/Library/libxml2-${{ inputs.libxml2_version }}/usr
       - uses: actions/download-artifact@v4
+        if: matrix.os != 'Android' || inputs.build_android
         with:
           name: curl-${{ matrix.os }}-${{ matrix.arch }}-${{ inputs.curl_version }}
           path: ${{ github.workspace }}/BuildRoot/Library/curl-${{ inputs.curl_version }}/usr
       - uses: actions/download-artifact@v4
+        if: matrix.os != 'Android' || inputs.build_android
         with:
           name: zlib-${{ matrix.os }}-${{ matrix.arch }}-${{ inputs.zlib_version }}
           path: ${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr
@@ -1973,15 +2042,16 @@ jobs:
       - name: Download Compilers
         uses: actions/download-artifact@v4
         with:
-          name: compilers-amd64
+          name: compilers-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: actions/download-artifact@v4
+        if: matrix.os != 'Android' || inputs.build_android
         with:
           name: ${{ matrix.os }}-stdlib-${{ matrix.arch }}
           path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform
       - uses: actions/download-artifact@v4
         with:
-          name: Windows-stdlib-amd64
+          name: Windows-stdlib-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform
       - uses: actions/download-artifact@v4
         if: matrix.os == 'Windows'
@@ -1990,7 +2060,7 @@ jobs:
           path: ${{ github.workspace }}/BinaryCache/swift/stdlib
       - uses: actions/download-artifact@v4
         with:
-          name: macros-amd64
+          name: macros-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: actions/checkout@v4
         with:
@@ -2053,7 +2123,7 @@ jobs:
       # NOTE(compnerd): we execute unconditionally as we use CMake from VSDevEnv
       - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
         with:
-          host_arch: amd64
+          host_arch: ${{ inputs.build_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
@@ -2064,17 +2134,25 @@ jobs:
 
       # NOTE(compnerd): we execute unconditionally as we reference outputs
       - uses: nttld/setup-ndk@v1
+        if: matrix.os == 'Android'
         id: setup-ndk
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
 
       - name: Configure libdispatch
+        if: matrix.os != 'Android' || inputs.build_android
         run: |
           # Workaround CMake 3.20 issue
           $CLANG_CL = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
           $SWIFTC = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
 
-          $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
+          if ("${{ matrix.os }}" -eq "Android") {
+            $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
+            # Since win/arm64 doesn't have one, this logic is necessary because
+            # passing an empty CMAKE_ANDROID_NDK value causes a failure.
+            $CMAKE_NDK_FLAG = "-DCMAKE_ANDROID_NDK=$NDKPATH"
+            $SWIFT_NDK_FLAG = "-DSWIFT_ANDROID_NDK_PATH=$NDKPATH"
+          }
 
           $WINDOWS_VFS_OVERLAY = cygpath -m ${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml
           $OVERLAY_FLAGS = if ("${{ matrix.os }}" -eq "Windows") {
@@ -2106,23 +2184,31 @@ jobs:
                 -D MSVC_CXX_ARCHITECTURE_ID=${{ matrix.arch }} `
                 ${{ matrix.linker_flags }} `
                 ${{ matrix.extra_flags }} `
-                -D CMAKE_ANDROID_NDK=$NDKPATH `
-                -D SWIFT_ANDROID_NDK_PATH=$NDKPATH `
+                $CMAKE_NDK_FLAG `
+                $SWIFT_NDK_FLAG `
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch `
                 -D BUILD_TESTING=NO `
                 -D ENABLE_SWIFT=YES
       - name: Build libdispatch
+        if: matrix.os != 'Android' || inputs.build_android
         run: |
           cmake --build ${{ github.workspace }}/BinaryCache/libdispatch
 
       - name: Configure Foundation
+        if: matrix.os != 'Android' || inputs.build_android
         run: |
           # Workaround CMake 3.20 issue
           $CLANG_CL = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
           $SWIFTC = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
 
-          $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
+          if ("${{ matrix.os }}" -eq "Android") {
+            $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
+            # Since win/arm64 doesn't have one, this logic is necessary because
+            # passing an empty CMAKE_ANDROID_NDK value causes a failure.
+            $CMAKE_NDK_FLAG = "-DCMAKE_ANDROID_NDK=$NDKPATH"
+            $SWIFT_NDK_FLAG = "-DSWIFT_ANDROID_NDK_PATH=$NDKPATH"
+          }
 
           $WINDOWS_VFS_OVERLAY = cygpath -m ${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml
           $OVERLAY_FLAGS = if ("${{ matrix.os }}" -eq "Windows") {
@@ -2168,8 +2254,8 @@ jobs:
                 -D MSVC_CXX_ARCHITECTURE_ID=${{ matrix.arch }} `
                 ${{ matrix.linker_flags }} `
                 ${{ matrix.extra_flags }} `
-                -D CMAKE_ANDROID_NDK=$NDKPATH `
-                -D SWIFT_ANDROID_NDK_PATH=$NDKPATH `
+                $CMAKE_NDK_FLAG `
+                $SWIFT_NDK_FLAG `
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/swift-corelibs-foundation `
                 -D dispatch_DIR=${{ github.workspace }}/BinaryCache/libdispatch/cmake/modules `
@@ -2185,17 +2271,25 @@ jobs:
                 -D ZLIB_LIBRARY=${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr/lib/$LIBZ `
                 -D SwiftFoundation_MACRO=${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin
       - name: Build foundation
+        if: ${{ !(matrix.os == 'Android' && inputs.build_os == 'Windows' && inputs.build_arch == 'arm64') }}
         run: |
           cmake --build ${{ github.workspace }}/BinaryCache/foundation
 
       # TODO(compnerd) correctly version XCTest
       - name: Configure xctest
+        if: matrix.os != 'Android' || inputs.build_android
         run: |
           # Workaround CMake 3.20 issue
           $CLANG_CL = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
           $SWIFTC = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
 
-          $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
+          if ("${{ matrix.os }}" -eq "Android") {
+            $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
+            # Since win/arm64 doesn't have one, this logic is necessary because
+            # passing an empty CMAKE_ANDROID_NDK value causes a failure.
+            $CMAKE_NDK_FLAG = "-DCMAKE_ANDROID_NDK=$NDKPATH"
+            $SWIFT_NDK_FLAG = "-DSWIFT_ANDROID_NDK_PATH=$NDKPATH"
+          }
 
           $WINDOWS_VFS_OVERLAY = cygpath -m ${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml
           $OVERLAY_FLAGS = if ("${{ matrix.os }}" -eq "Windows") {
@@ -2226,24 +2320,32 @@ jobs:
                 -D CMAKE_SYSTEM_PROCESSOR=${CMAKE_CPU} `
                 ${{ matrix.linker_flags }} `
                 ${{ matrix.extra_flags }} `
-                -D CMAKE_ANDROID_NDK=$NDKPATH `
-                -D SWIFT_ANDROID_NDK_PATH=$NDKPATH `
+                $CMAKE_NDK_FLAG `
+                $SWIFT_NDK_FLAG `
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/swift-corelibs-xctest `
                 -D dispatch_DIR=${{ github.workspace }}/BinaryCache/libdispatch/cmake/modules `
                 -D Foundation_DIR=${{ github.workspace }}/BinaryCache/foundation/cmake/modules `
                 -D ENABLE_TESTING=NO
       - name: Build xctest
+        if: matrix.os != 'Android' || inputs.build_android
         run: |
           cmake --build ${{ github.workspace }}/BinaryCache/xctest
 
       - name: Configure Testing
+        if: matrix.os != 'Android' || inputs.build_android
         run: |
           # Workaround CMake 3.20 issue
           $CLANG_CL = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/clang-cl.exe
           $SWIFTC = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
 
-          $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
+          if ("${{ matrix.os }}" -eq "Android") {
+            $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
+            # Since win/arm64 doesn't have one, this logic is necessary because
+            # passing an empty CMAKE_ANDROID_NDK value causes a failure.
+            $CMAKE_NDK_FLAG = "-DCMAKE_ANDROID_NDK=$NDKPATH"
+            $SWIFT_NDK_FLAG = "-DSWIFT_ANDROID_NDK_PATH=$NDKPATH"
+          }
 
           $WINDOWS_VFS_OVERLAY = cygpath -m ${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml
           $OVERLAY_FLAGS = if ("${{ matrix.os }}" -eq "Windows") {
@@ -2273,32 +2375,38 @@ jobs:
                 -D CMAKE_SYSTEM_PROCESSOR=${CMAKE_CPU} `
                 ${{ matrix.linker_flags }} `
                 ${{ matrix.extra_flags }} `
-                -D CMAKE_ANDROID_NDK=${NDKPATH} `
-                -D SWIFT_ANDROID_NDK_PATH=${NDKPATH} `
+                $CMAKE_NDK_FLAG `
+                $SWIFT_NDK_FLAG `
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/swift-testing `
                 -D dispatch_DIR=${{ github.workspace }}/BinaryCache/libdispatch/cmake/modules `
                 -D Foundation_DIR=${{ github.workspace }}/BinaryCache/foundation/cmake/modules `
                 -D SwiftTesting_MACRO=${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/TestingMacros.dll
       - name: Build Testing
+        if: matrix.os != 'Android' || inputs.build_android
         run: |
           cmake --build ${{ github.workspace }}/BinaryCache/testing
 
       - name: Install Testing
+        if: matrix.os != 'Android' || inputs.build_android
         run: |
           cmake --build ${{ github.workspace }}/BinaryCache/testing --target install
       - name: Install xctest
+        if: matrix.os != 'Android' || inputs.build_android
         run: |
           cmake --build ${{ github.workspace }}/BinaryCache/xctest --target install
       - name: Install foundation
+        if: matrix.os != 'Android' || inputs.build_android
         run: |
           cmake --build ${{ github.workspace }}/BinaryCache/foundation --target install
       - name: Install libdispatch
+        if: matrix.os != 'Android' || inputs.build_android
         run: |
           cmake --build ${{ github.workspace }}/BinaryCache/libdispatch --target install
 
       - uses: actions/setup-python@v5
       - uses: jannekem/run-python-script-action@v1
+        if: matrix.os != 'Android' || inputs.build_android
         with:
           script: |
             import os
@@ -2316,6 +2424,7 @@ jobs:
               plistlib.dump({ 'DefaultProperties': { 'DEFAULT_USE_RUNTIME': 'MD' } }, plist)
 
       - uses: actions/upload-artifact@v4
+        if: matrix.os != 'Android' || inputs.build_android
         with:
           name: ${{ matrix.os }}-sdk-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform
@@ -2346,15 +2455,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - arch: 'amd64'
-            cpu: 'x86_64'
-            triple: 'x86_64-unknown-windows-msvc'
-
-          - arch: 'arm64'
-            cpu: 'aarch64'
-            triple: 'aarch64-unknown-windows-msvc'
+      matrix: ${{ fromJSON(inputs.host_matrix) }}
 
     name: Windows ${{ matrix.arch }} Developer Tools
 
@@ -2367,7 +2468,7 @@ jobs:
       - name: Download Compilers
         uses: actions/download-artifact@v4
         with:
-          name: compilers-amd64
+          name: compilers-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: actions/download-artifact@v4
         with:
@@ -2379,7 +2480,7 @@ jobs:
           path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform
       - uses: actions/download-artifact@v4
         with:
-          name: macros-amd64
+          name: macros-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: actions/download-artifact@v4
         with:
@@ -2496,7 +2597,7 @@ jobs:
 
       - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
         with:
-          host_arch: amd64
+          host_arch: ${{ inputs.build_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
@@ -2520,11 +2621,11 @@ jobs:
       # Download host libraries for the windows amd64 host, after moving the target libraries to the target-specific directory.
       - uses: actions/download-artifact@v4
         with:
-          name: Windows-stdlib-amd64
+          name: Windows-stdlib-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform
       - uses: actions/download-artifact@v4
         with:
-          name: Windows-sdk-amd64
+          name: Windows-sdk-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform
 
       - name: Configure swift-argument-parser
@@ -3064,15 +3165,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-            cpu: x86_64
-            triple: x86_64-unknown-windows-msvc
-
-          - arch: arm64
-            cpu: aarch64
-            triple: aarch64-unknown-windows-msvc
+      matrix: ${{ fromJSON(inputs.host_matrix) }}
 
     name: Windows ${{ matrix.arch }} Debugging Tools
 
@@ -3086,7 +3179,7 @@ jobs:
       - name: Download Compilers
         uses: actions/download-artifact@v4
         with:
-          name: compilers-amd64
+          name: compilers-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - name: Download stdlib
         uses: actions/download-artifact@v4
@@ -3139,11 +3232,11 @@ jobs:
       # Download host SDK on top of the target SDK, so that the runtime DLLs are the host ones.
       - uses: actions/download-artifact@v4
         with:
-          name: Windows-stdlib-amd64
+          name: Windows-stdlib-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform
       - uses: actions/download-artifact@v4
         with:
-          name: Windows-sdk-amd64
+          name: Windows-sdk-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform
 
       - name: Configure swift-inspect
@@ -3184,8 +3277,8 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        arch: ['amd64' , 'arm64']
+
+      matrix: ${{ fromJSON(inputs.host_matrix) }}
 
     steps:
       - name: Download Debugging Tools
@@ -3221,7 +3314,7 @@ jobs:
 
       - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
         with:
-          host_arch: amd64
+          host_arch: ${{ inputs.build_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
@@ -3392,7 +3485,7 @@ jobs:
 
       - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
         with:
-          host_arch: amd64
+          host_arch: ${{ inputs.build_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
@@ -3460,7 +3553,7 @@ jobs:
 
   package_android_sdk_runtime:
     # TODO: Build this on macOS or make an equivalent Mac-only job
-    if: inputs.build_os == 'Windows'
+    if: inputs.build_android
     name: Package Android SDK & Runtime
     needs: [stdlib, ds2, sdk]
     runs-on: ${{ inputs.default_build_runner }}
@@ -3506,7 +3599,7 @@ jobs:
 
       - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
         with:
-          host_arch: amd64
+          host_arch: ${{ inputs.build_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
@@ -3530,7 +3623,7 @@ jobs:
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
               -p:Configuration=Release `
               -p:SignOutput=${{ inputs.signed }} `
-              -p:ANDROID_INCLUDE_DS2=true `
+              -p:ANDROID_INCLUDE_DS2=${{ inputs.build_android }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:PLATFORM_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Android.platform `
@@ -3554,8 +3647,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        arch: ['amd64' , 'arm64']
+      matrix: ${{ fromJSON(inputs.host_matrix) }}
 
     steps:
       - uses: actions/download-artifact@v4
@@ -3605,18 +3697,22 @@ jobs:
           name: sdk-windows-arm64-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/arm64
       - uses: actions/download-artifact@v4
+        if: inputs.build_android
         with:
           name: sdk-android-arm64-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/aarch64
       - uses: actions/download-artifact@v4
+        if: inputs.build_android
         with:
           name: sdk-android-x86_64-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/x86_64
       - uses: actions/download-artifact@v4
+        if: inputs.build_android
         with:
           name: sdk-android-armv7-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/armv7
       - uses: actions/download-artifact@v4
+        if: inputs.build_android
         with:
           name: sdk-android-i686-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/i686
@@ -3630,7 +3726,7 @@ jobs:
 
       - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
         with:
-          host_arch: amd64
+          host_arch: ${{ inputs.build_arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
@@ -3669,10 +3765,10 @@ jobs:
               -p:INCLUDE_AMD64_SDK=true `
               -p:INCLUDE_X86_SDK=true `
               -p:INCLUDE_ARM64_SDK=true `
-              -p:ANDROID_INCLUDE_ARM64_SDK=true `
-              -p:ANDROID_INCLUDE_x86_64_SDK=true `
-              -p:ANDROID_INCLUDE_ARM_SDK=true `
-              -p:ANDROID_INCLUDE_X86_SDK=true `
+              -p:ANDROID_INCLUDE_ARM64_SDK=${{ inputs.build_android }} `
+              -p:ANDROID_INCLUDE_x86_64_SDK=${{ inputs.build_android }} `
+              -p:ANDROID_INCLUDE_ARM_SDK=${{ inputs.build_android }} `
+              -p:ANDROID_INCLUDE_X86_SDK=${{ inputs.build_android }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
               -p:ProductVersion=${{ inputs.swift_version }}-${{ inputs.swift_tag }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bundle/installer.wixproj
@@ -3691,7 +3787,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: installer-amd64
+          name: installer-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/tmp
 
       # TODO(compnerd): migrate this to compnerd/gha-setup-swift after the work that @mangini is doing is completed


### PR DESCRIPTION
- Introduce the concept of ARM64 CI runners. Use the cirun ARM64 machines as the ARM64 runners.
- Split the windows_build job into X64 and ARM64.
- Add the Win/ARM64 build on the Win/ARM64 runner (but no Win/X64 build on Win/ARM64 runner) while retaining the existing Win/X64 and Win/ARM64 builds on the Win/X64 runner.
- Split some of strategy matrices between X64 and ARM64.
- Append the "... (building on <os> <arch>)" to the job names to clarify what's building on what runner.
- Do not release the natively-released Win/ARM64 installer.exe while retaining the existing cross-compiled Win/ARM64 and Win/X64 installer.exe as the published release.
- Exclude the Android-related components including ds2 in the native Win/ARM64 build due to the non-existence of the native Windows/ARM64 Android NDK.
- Other misc changes to get the jobs to be able to run natively on Win/ARM64 (e.g., overriding the build/host arch to arm64 for the vsdevenv or the swift toolchain setup actions).
- The native Win/ARM64 build should currently fail in the compilers job due to the static_assert issue in the pinned toolchain but the whole main CI run should succeed and produce builds as the `release` job depends only on `windows-build-x64`.