### PR TITLE
[workflow] fixes required to build swift 6 branch

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2147,6 +2147,8 @@ jobs:
                 -D SWIFT_ANDROID_NDK_PATH=${NDKPATH} `
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/swift-testing `
+                -D dispatch_DIR=${{ github.workspace }}/BinaryCache/libdispatch/cmake/modules `
+                -D Foundation_DIR=${{ github.workspace }}/BinaryCache/foundation/cmake/modules `
                 -D SwiftTesting_MACRO=${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/TestingMacros.dll
       - name: Build Testing
         run: |


### PR DESCRIPTION
These fixes are
- update to the base Swift toolchain for new MSVC.
- drop misplaced base toolchain install step.
- workaround x86 assertion crash in the SDK build.
- add flag to find swift macros  in the SDK build of swift-testing.
- add WiX 4.0.1 installation step for installer
- add foundation and dispatch paths for swift-testing configuration