### PR TITLE
[GHA] Update GHA upload/download tar actions

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -797,7 +797,7 @@ jobs:
               Copy-Item -Path "${SourceBinDir}/${binName}" -Destination $binPath -Force
           }
 
-      - uses: thebrowsercompany/gha-upload-tar-artifact@d8f9b9d463a319b5b65b273db0a4e12ab0b10e72 # main
+      - uses: thebrowsercompany/gha-upload-tar-artifact@e18c33b1cd416d0d96a91dc6dce06219f98e4e27 # main
         with:
           name: early-swift-driver-${{ matrix.os }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot
@@ -839,7 +839,7 @@ jobs:
         with:
           name: cmark-gfm-Windows-${{ matrix.arch }}-${{ inputs.swift_cmark_version }}
           path: ${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr
-      - uses: thebrowsercompany/gha-download-tar-artifact@717214c9da2a52b3407a5b0a1f31c00b8fde5681 # main
+      - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
           name: early-swift-driver-Windows-amd64
           path: ${{ github.workspace }}/BinaryCache


### PR DESCRIPTION
This fixes an issue where the GHA upload/download tar artifact actions were using the first `tar` command in `PATH`, which may be a GNU tar command on Windows. GNU tar cannot properly parse Windows paths.