### PR TITLE
Partial cherry-pick: Fixes to get main working downstream again (#841)

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3145,9 +3145,6 @@ jobs:
       - name: Install WixToolset.Sdk
         run: |
           if ((Get-Package -Name WixToolset.Sdk -ErrorAction SilentlyContinue) -eq $null) {
-            if ([string]::IsNullOrEmpty((Get-PackageSource | %{ $_.Location } | Select-String -Pattern api.nuget.org))) {
-              Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
-            }
             Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
           }
 
@@ -3287,9 +3284,6 @@ jobs:
       - name: Install WixToolset.Sdk
         run: |
           if ((Get-Package -Name WixToolset.Sdk -ErrorAction SilentlyContinue) -eq $null) {
-            if ([string]::IsNullOrEmpty((Get-PackageSource | %{ $_.Location } | Select-String -Pattern api.nuget.org))) {
-              Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
-            }
             Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
           }
 
@@ -3393,9 +3387,6 @@ jobs:
       - name: Install WixToolset.Sdk
         run: |
           if ((Get-Package -Name WixToolset.Sdk -ErrorAction SilentlyContinue) -eq $null) {
-            if ([string]::IsNullOrEmpty((Get-PackageSource | %{ $_.Location } | Select-String -Pattern api.nuget.org))) {
-              Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
-            }
             Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
           }
 
@@ -3509,9 +3500,6 @@ jobs:
       - name: Install WixToolset.Sdk
         run: |
           if ((Get-Package -Name WixToolset.Sdk -ErrorAction SilentlyContinue) -eq $null) {
-            if ([string]::IsNullOrEmpty((Get-PackageSource | %{ $_.Location } | Select-String -Pattern api.nuget.org))) {
-              Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
-            }
             Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
           }
 


### PR DESCRIPTION
* Do not attempt NuGet registration

This is now failing as NuGet is registered:

```
Register-PackageSource: D:\r\_work\_temp\c04a7ca5-aa41-491b-b9ad-0e09fb799d0c.ps1:4
Line |
   4 |      Register-PackageSource -Name NuGet -Location https://www.nuget.or …
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Package Source 'NuGet' exists.
```

https://github.com/thebrowsercompany/swift-build/actions/runs/11656344808/job/32454421580 (cherry picked from commit e2e1a79848ae6287244431e613d9121ed16a28a4)