### PR TITLE
Update and pin the sccache version following main and release/6.0

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -232,7 +232,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
           key: windows-${{ matrix.arch }}-sqlite
@@ -293,7 +293,7 @@ jobs:
           arch: amd64
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
           key: windows-amd64-icu_tools
@@ -379,7 +379,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
           key: windows-${{ matrix.arch }}-icu
@@ -453,7 +453,7 @@ jobs:
       - uses: compnerd/gha-setup-vsdevenv@main
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
           key: windows-amd64-build_tools
@@ -639,7 +639,7 @@ jobs:
           release-tag-name: '20231016.0'
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 500M
           key: windows-${{ matrix.arch }}-compilers
@@ -793,7 +793,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
           key: windows-${{ matrix.arch }}-zlib
@@ -855,7 +855,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
           key: windows-${{ matrix.arch }}-curl
@@ -989,7 +989,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
           key: windows-${{ matrix.arch }}-libxml2


### PR DESCRIPTION
This an attempt to fix the sccache error

```
sccache: error: failed to execute compile
sccache: caused by: cannot find binary path
```
https://github.com/thebrowsercompany/swift-build/actions/runs/12226735048/job/34102700092