### PR TITLE
[build] Use windows_build_arch from context

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -632,7 +632,7 @@ jobs:
     uses: ./.github/workflows/swift-toolchain.yml
     with:
       build_os: Windows
-      build_arch: ${{ inputs.windows_build_arch }}
+      build_arch: ${{ needs.context.outputs.windows_build_arch }}
       build_matrix: ${{ needs.context.outputs[format('windows_{0}_build_matrix', needs.context.outputs.windows_build_cpu)] }}
       host_matrix: ${{ needs.context.outputs[format('windows_{0}_host_matrix', needs.context.outputs.windows_build_cpu)] }}
       target_matrix: ${{ needs.context.outputs[format('windows_{0}_target_matrix', needs.context.outputs.windows_build_cpu)] }}


### PR DESCRIPTION
`inputs.windows_build_arch` is not always populated. `windows_build_arch` from the `context` job always is.