### PR TITLE
[Mac build] Update upload/download actions

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -580,7 +580,7 @@ jobs:
         run: cmake --build ${{ github.workspace }}/BinaryCache/cmark-gfm-${{ inputs.swift_cmark_version }}
       - name: Install cmark-gfm
         run: cmake --build ${{ github.workspace }}/BinaryCache/cmark-gfm-${{ inputs.swift_cmark_version }} --target install
-      - uses: actions/upload-artifact@v4
+      - uses: thebrowsercompany/gha-upload-tar-artifact@e18c33b1cd416d0d96a91dc6dce06219f98e4e27 # main
         with:
           name: cmark-gfm-${{ matrix.os }}-${{ matrix.arch }}-${{ inputs.swift_cmark_version }}
           path: ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr
@@ -596,7 +596,7 @@ jobs:
     name: ${{ matrix.os }} ${{ matrix.arch }} Compiler Build Tools
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
           name: cmark-gfm-${{ matrix.os }}-${{ matrix.arch }}-${{ inputs.swift_cmark_version }}
           path: ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr
@@ -847,7 +847,7 @@ jobs:
         with:
           name: libxml2-Windows-${{ matrix.arch }}-${{ inputs.libxml2_version }}
           path: ${{ github.workspace }}/BinaryCache/Library/libxml2-${{ inputs.libxml2_version }}/usr
-      - uses: actions/download-artifact@v4
+      - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
           name: cmark-gfm-Windows-${{ matrix.arch }}-${{ inputs.swift_cmark_version }}
           path: ${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr
@@ -1053,9 +1053,9 @@ jobs:
           Copy-Item -Path "${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr/bin/*.dll" -Destination "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin"
 
       - name: Upload Compilers
-        uses: actions/upload-artifact@v4
+        uses: thebrowsercompany/gha-upload-tar-artifact@e18c33b1cd416d0d96a91dc6dce06219f98e4e27 # main
         with:
-          name: compilers-${{ matrix.arch }}
+          name: compilers-Windows-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library
 
       - name: extract swift-syntax
@@ -1577,9 +1577,9 @@ jobs:
 
     steps:
       - name: Download Compilers
-        uses: actions/download-artifact@v4
+        uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: compilers-${{ inputs.build_arch }}
+          name: compilers-Windows-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BuildRoot/Library
       - uses: actions/checkout@v4
         with:
@@ -1793,9 +1793,9 @@ jobs:
 
     steps:
       - name: Download Compilers
-        uses: actions/download-artifact@v4
+        uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: compilers-${{ inputs.build_arch }}
+          name: compilers-Windows-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - name: Download swift-syntax
         uses: actions/download-artifact@v4
@@ -2040,9 +2040,9 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr
 
       - name: Download Compilers
-        uses: actions/download-artifact@v4
+        uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: compilers-${{ inputs.build_arch }}
+          name: compilers-Windows-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: actions/download-artifact@v4
         if: matrix.os != 'Android' || inputs.build_android
@@ -2457,9 +2457,9 @@ jobs:
           path: ${{ github.workspace }}/BinaryCache/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr
 
       - name: Download Compilers
-        uses: actions/download-artifact@v4
+        uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: compilers-${{ inputs.build_arch }}
+          name: compilers-Windows-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: actions/download-artifact@v4
         with:
@@ -2477,7 +2477,7 @@ jobs:
         with:
           name: swift-syntax-${{ matrix.arch }}
           path: ${{ github.workspace }}/BinaryCache/swift-syntax
-      - uses: actions/download-artifact@v4
+      - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
           name: cmark-gfm-Windows-${{ matrix.arch }}-${{ inputs.swift_cmark_version }}
           path: ${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr
@@ -3168,9 +3168,9 @@ jobs:
           path: ${{ github.workspace }}/BinaryCache/swift-argument-parser
 
       - name: Download Compilers
-        uses: actions/download-artifact@v4
+        uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: compilers-${{ inputs.build_arch }}
+          name: compilers-Windows-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - name: Download stdlib
         uses: actions/download-artifact@v4
@@ -3279,9 +3279,9 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library
 
       - name: Download Compilers
-        uses: actions/download-artifact@v4
+        uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: compilers-${{ matrix.arch }}
+          name: compilers-Windows-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library
 
       - name: Download Developer Tools


### PR DESCRIPTION
This updates the upload and download actions to use the tar-artifact actions for the compilers and cmark-gfm artifacts, paving the way for the Mac compilers build.