### PR TITLE
[sdk] Skip Foundation build if Android is skipped

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2270,7 +2270,7 @@ jobs:
                 -D ZLIB_LIBRARY=${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr/lib/$LIBZ `
                 -D SwiftFoundation_MACRO=${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin
       - name: Build foundation
-        if: ${{ !(matrix.os == 'Android' && inputs.build_os == 'Windows' && inputs.build_arch == 'arm64') }}
+        if: matrix.os != 'Android' || inputs.build_android
         run: |
           cmake --build ${{ github.workspace }}/BinaryCache/foundation
 


### PR DESCRIPTION
The condition for building Foundation in the SDK job was erroneously set to build when the Android build was disabled.