### PR TITLE
[Packaging] Update the SDK MSI filename

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3535,8 +3535,8 @@ jobs:
         with:
           name: sdk-windows-${{ matrix.arch }}-msi
           path: |
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/sdk.${{ matrix.arch }}.msi
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/sdk.${{ matrix.arch }}.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/sdk.windows.${{ matrix.arch }}.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/sdk.windows.${{ matrix.arch }}.cab
       - uses: actions/upload-artifact@v4
         with:
           name: rtl-windows-${{ matrix.arch }}-msi
@@ -3548,7 +3548,6 @@ jobs:
           name: rtl-windows-${{ matrix.arch }}-msm
           path: |
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/rtl.${{ matrix.arch }}.msm
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/rtl.${{ matrix.arch }}.cab
 
   package_android_sdk_runtime:
     # TODO: Build this on macOS or make an equivalent Mac-only job
@@ -3635,8 +3634,8 @@ jobs:
         with:
           name: sdk-android-${{ matrix.arch }}-msi
           path: |
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.cpu }}/android_sdk.${{ matrix.cpu }}.msi
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.cpu }}/android_sdk.${{ matrix.cpu }}.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.cpu }}/sdk.android.${{ matrix.cpu }}.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.cpu }}/sdk.android.${{ matrix.cpu }}.cab
 
   installer:
     # TODO: Build this on macOS or make an equivalent Mac-only job


### PR DESCRIPTION
The SDK MSI filename for the Windows builds is now
`sdk.windows.${arch}.msi`. Similarly, the SDK MSI filename for
Android is now `sdk.android.${arch}.msi`.

In addition, the `rtl.${arch}.msm` does not have a corresponding
`.cab` file so it has been removed.