### PR TITLE
[installer] Rename condition variables

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3752,13 +3752,13 @@ jobs:
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:BundleFlavor=offline `
-              -p:INCLUDE_AMD64_SDK=true `
-              -p:INCLUDE_X86_SDK=true `
-              -p:INCLUDE_ARM64_SDK=true `
-              -p:ANDROID_INCLUDE_ARM64_SDK=${{ inputs.build_android }} `
-              -p:ANDROID_INCLUDE_x86_64_SDK=${{ inputs.build_android }} `
-              -p:ANDROID_INCLUDE_ARM_SDK=${{ inputs.build_android }} `
-              -p:ANDROID_INCLUDE_X86_SDK=${{ inputs.build_android }} `
+              -p:INCLUDE_WINDOWS_AMD64_SDK=true `
+              -p:INCLUDE_WINDOWS_X86_SDK=true `
+              -p:INCLUDE_WINDOWS_ARM64_SDK=true `
+              -p:INCLUDE_ANDROID_ARM64_SDK=${{ inputs.build_android }} `
+              -p:INCLUDE_ANDROID_x86_64_SDK=${{ inputs.build_android }} `
+              -p:INCLUDE_ANDROID_ARM_SDK=${{ inputs.build_android }} `
+              -p:INCLUDE_ANDROID_X86_SDK=${{ inputs.build_android }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
               -p:ProductVersion=${{ inputs.swift_version }}-${{ inputs.swift_tag }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bundle/installer.wixproj


### PR DESCRIPTION
The condition variable names for the various platform SDKs were renamed upstream. This fixes the installer build by using the proper variable name conditions.