### PR TITLE
[matrix] Set cmake_linker_flags for Windows hosts

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -376,6 +376,7 @@ jobs:
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
                   "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
+                  "cmake_linker_flags": "-D CMAKE_EXE_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}\" -D CMAKE_SHARED_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}\"",
                   "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=AMD64 -D CMAKE_MT=mt"
                 },
                 {
@@ -389,6 +390,7 @@ jobs:
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
                   "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
+                  "cmake_linker_flags": "-D CMAKE_EXE_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}\" -D CMAKE_SHARED_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}\"",
                   "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=ARM64 -D CMAKE_MT=mt"
                 }
               ]
@@ -407,6 +409,7 @@ jobs:
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
                   "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
+                  "cmake_linker_flags": "-D CMAKE_EXE_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}\" -D CMAKE_SHARED_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}\"",
                   "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=ARM64 -D CMAKE_MT=mt"
                 }
               ]
@@ -422,7 +425,6 @@ jobs:
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
                   "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
-                  "cmake_linker_flags": "-D CMAKE_EXE_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}\" -D CMAKE_SHARED_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}\"",
                   "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=AMD64 -D CMAKE_MT=mt"
                 }
               ]
@@ -438,7 +440,6 @@ jobs:
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
                   "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
-                  "cmake_linker_flags": "-D CMAKE_EXE_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}\" -D CMAKE_SHARED_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}\"",
                   "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=ARM64 -D CMAKE_MT=mt"
                 }
               ]


### PR DESCRIPTION
These were erroneously set up on the Windows build matrix, when they should have been set for the Windows host matrix.