### PR TITLE
GHA: add a description for `build_android` input

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -43,6 +43,7 @@ on:
         required: false
 
       build_android:
+        description: 'Build Android SDK'
         required: false
         default: false
         type: boolean
@@ -114,6 +115,7 @@ on:
         type: string
 
       build_android:
+        description: 'Build Android SDK'
         required: false
         default: false
         type: boolean


### PR DESCRIPTION
This makes the options more similar by providing a description rather than relying on the user to know what the input variable is meant for.