### PR TITLE
[wix] Use updated paths for `sdk.wixproj`

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3551,7 +3551,7 @@ jobs:
               -p:SDK_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/sdk/sdk.wixproj
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/sdk/win/sdk.wixproj
 
       - name: Package Runtime
         run: |
@@ -3665,7 +3665,7 @@ jobs:
               -p:SDK_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Android.platform/Developer/SDKs/Android.sdk `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.cpu }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/android_sdk/android_sdk.wixproj
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/sdk/drd/sdk.wixproj
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The `sdk.wixproj` files were moved upstream.