### PR TITLE
[compilers] Separate Windows/Mac python versions

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -826,9 +826,9 @@ jobs:
       # This will grab the latest Python 3.9 version available for setup-python. It is necessary to
       # specify in this manner for Mac where actions/setup-python does not have version 3.9.10.
       # Once the Python version is upgraded to 3.12, these should be kept in sync.
-      PYTHON_VERSION: 3.9
+      PYTHON_VERSION_MACOS: 3.9
       # Must be a full version string from https://www.nuget.org/packages/pythonarm64
-      PYTHON_VERSION_ARM64: 3.9.10
+      PYTHON_VERSION_WINDOWS: 3.9.10
 
     strategy:
       fail-fast: false
@@ -885,38 +885,38 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch
           show-progress: false
 
-      - name: Install Python ${{ env.PYTHON_VERSION }} (Host)
+      - name: Install Python ${{ env.PYTHON_VERSION_MACOS }} (Host)
         if: matrix.os == 'Darwin'
         uses: actions/setup-python@v5
         with:
-          python-version: '${{ env.PYTHON_VERSION }}'
+          python-version: '${{ env.PYTHON_VERSION_MACOS }}'
 
-      - name: Install Python ${{ env.PYTHON_VERSION }} (Host)
+      - name: Install Python ${{ env.PYTHON_VERSION_WINDOWS }} (Host)
         if: matrix.os == 'Windows' && (matrix.arch == 'amd64' || inputs.build_arch == 'amd64')
         uses: actions/setup-python@v5
         id: python
         with:
-          python-version: '${{ env.PYTHON_VERSION }}'
+          python-version: '${{ env.PYTHON_VERSION_WINDOWS }}'
           architecture: x64
 
       - uses: nuget/setup-nuget@v2
         if: inputs.build_os == 'Windows' && (matrix.arch == 'arm64' || inputs.build_arch == 'arm64')
 
       # TODO(lxbndr) use actions/cache to improve this step timings
-      - name: Install Python ${{ env.PYTHON_VERSION_ARM64 }} (Windows arm64)
+      - name: Install Python ${{ env.PYTHON_VERSION_WINDOWS }} (Windows arm64)
         if: inputs.build_os == 'Windows' && (matrix.arch == 'arm64' || inputs.build_arch == 'arm64')
         run: |
           $NugetSources=[string](nuget Sources List -Format short)
           if (-Not ($NugetSources.contains("api.nuget.org"))) {
             nuget sources Add -Name api.nuget.org -Source https://api.nuget.org/v3/index.json -NonInteractive
           }
-          nuget install pythonarm64 -Version ${{ env.PYTHON_VERSION_ARM64 }}
+          nuget install pythonarm64 -Version ${{ env.PYTHON_VERSION_WINDOWS }}
 
       - name: Export Python Location (Windows)
         if: inputs.build_os == 'Windows'
         run: |
           echo "PYTHON_LOCATION_amd64=$env:pythonLocation" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "PYTHON_LOCATION_arm64=${{ github.workspace }}\pythonarm64.${{ env.PYTHON_VERSION_ARM64 }}\tools" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "PYTHON_LOCATION_arm64=${{ github.workspace }}\pythonarm64.${{ env.PYTHON_VERSION_WINDOWS }}\tools" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
         with:


### PR DESCRIPTION
Installing the latest Python 3.9 version proved to be an issue on some bot configuration. This reverts to installing 3.9.10 for Windows, which should solve the issue.