### PR TITLE
[Mac build] Add target the Mac host matrix

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -594,6 +594,8 @@ jobs:
               "include": [
                 {
                   "arch": "arm64",
+                  "cpu": "aarch64",
+                  "compiler_target": "arm64-apple-macosx15.0",
                   "os": "Darwin",
                   "cc": "clang",
                   "cflags": "${{ steps.context.outputs.DARWIN_CMAKE_C_FLAGS }}",


### PR DESCRIPTION
`compiler_target` and `cpu` are required for the early swift driver build since #878.