### PR TITLE
GHA: remove Yams from the build

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -172,7 +172,6 @@ jobs:
       swift_toolchain_sqlite_revision: ${{ steps.context.outputs.swift_toolchain_sqlite_revision }}
       swift_toolchain_sqlite_version: ${{ steps.context.outputs.swift_toolchain_sqlite_version }}
       swift_tools_support_core_revision: ${{ steps.context.outputs.swift_tools_support_core_revision }}
-      yams_revision: ${{ steps.context.outputs.yams_revision }}
       zlib_revision: ${{ steps.context.outputs.zlib_revision }}
       zlib_version: ${{ steps.context.outputs.zlib_version }}
       ANDROID_API_LEVEL: ${{ steps.context.outputs.ANDROID_API_LEVEL }}
@@ -265,7 +264,6 @@ jobs:
           curl_revision=refs/tags/curl-8_5_0
           ds2_revision=refs/tags/nightly-2024-11-07
           libxml2_revision=refs/tags/v2.11.5
-          yams_revision=refs/tags/5.0.6
           zlib_revision=refs/tags/v1.3.1
           EOF
           else
@@ -690,7 +688,6 @@ jobs:
       swift_toolchain_sqlite_revision: ${{ needs.context.outputs.swift_toolchain_sqlite_revision }}
       swift_toolchain_sqlite_version: ${{ needs.context.outputs.swift_toolchain_sqlite_version }}
       swift_tools_support_core_revision: ${{ needs.context.outputs.swift_tools_support_core_revision }}
-      yams_revision: ${{ needs.context.outputs.yams_revision }}
       zlib_revision: ${{ needs.context.outputs.zlib_revision }}
       zlib_version: ${{ needs.context.outputs.zlib_version }}
       ANDROID_API_LEVEL: ${{ needs.context.outputs.ANDROID_API_LEVEL }}
@@ -765,7 +762,6 @@ jobs:
       swift_toolchain_sqlite_revision: ${{ needs.context.outputs.swift_toolchain_sqlite_revision }}
       swift_toolchain_sqlite_version: ${{ needs.context.outputs.swift_toolchain_sqlite_version }}
       swift_tools_support_core_revision: ${{ needs.context.outputs.swift_tools_support_core_revision }}
-      yams_revision: ${{ needs.context.outputs.yams_revision }}
       zlib_revision: ${{ needs.context.outputs.zlib_revision }}
       zlib_version: ${{ needs.context.outputs.zlib_version }}
       ANDROID_API_LEVEL: ${{ needs.context.outputs.ANDROID_API_LEVEL }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -171,10 +171,6 @@ on:
         required: true
         type: string
 
-      yams_revision:
-        required: true
-        type: string
-
       zlib_revision:
         required: true
         type: string
@@ -766,12 +762,6 @@ jobs:
           repository: apple/swift-argument-parser
           ref: ${{ inputs.swift_argument_parser_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-argument-parser
-          show-progress: false
-      - uses: actions/checkout@v4
-        with:
-          repository: jpsim/Yams
-          ref: ${{ inputs.yams_revision }}
-          path: ${{ github.workspace }}/SourceCache/Yams
           show-progress: false
       - uses: actions/checkout@v4
         with:
@@ -2666,12 +2656,6 @@ jobs:
           show-progress: false
       - uses: actions/checkout@v4
         with:
-          repository: jpsim/Yams
-          ref: ${{ inputs.yams_revision }}
-          path: ${{ github.workspace }}/SourceCache/Yams
-          show-progress: false
-      - uses: actions/checkout@v4
-        with:
           repository: swiftlang/swift
           ref: ${{ inputs.swift_revision }}
           path: ${{ github.workspace }}/SourceCache/swift
@@ -2803,34 +2787,6 @@ jobs:
       - name: Build swift-crypto
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-crypto
 
-      - name: Configure Yams
-        run: |
-          # Workaround CMake 3.20 issue
-          $SWIFTC = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe
-
-          cmake -B ${{ github.workspace }}/BinaryCache/yams `
-                -D BUILD_SHARED_LIBS=NO `
-                -D BUILD_TESTING=NO `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=cl `
-                -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
-                -D CMAKE_CXX_COMPILER=cl `
-                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
-                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
-                -D CMAKE_Swift_COMPILER=${SWIFTC} `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
-                -D CMAKE_Swift_FLAGS_RELEASE="-O" `
-                -D CMAKE_SYSTEM_NAME=Windows `
-                -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/Yams
-      - name: Build Yams
-        run: cmake --build ${{ github.workspace }}/BinaryCache/yams
-
       - name: Configure swift-llbuild
         run: |
           # Workaround CMake 3.20 issue
@@ -2954,8 +2910,7 @@ jobs:
                 -D SwiftSystem_DIR=${{ github.workspace }}/BinaryCache/swift-system/cmake/modules `
                 -D SQLite3_LIBRARY=${{ github.workspace }}/BinaryCache/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/lib/SQLite3.lib `
                 -D SQLite3_INCLUDE_DIR=${{ github.workspace }}/BinaryCache/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/include `
-                -D TSC_DIR=${{ github.workspace }}/BinaryCache/swift-tools-support-core/cmake/modules `
-                -D Yams_DIR=${{ github.workspace }}/BinaryCache/yams/cmake/modules
+                -D TSC_DIR=${{ github.workspace }}/BinaryCache/swift-tools-support-core/cmake/modules
       - name: Build swift-driver
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-driver
 
@@ -3046,8 +3001,7 @@ jobs:
                 -D SwiftDriver_DIR=${{ github.workspace }}/BinaryCache/swift-driver/cmake/modules `
                 -D SwiftSyntax_DIR=${{ github.workspace }}/BinaryCache/swift-syntax/cmake/modules `
                 -D SwiftSystem_DIR=${{ github.workspace }}/BinaryCache/swift-system/cmake/modules `
-                -D TSC_DIR=${{ github.workspace }}/BinaryCache/swift-tools-support-core/cmake/modules `
-                -D Yams_DIR=${{ github.workspace }}/BinaryCache/yams/cmake/modules
+                -D TSC_DIR=${{ github.workspace }}/BinaryCache/swift-tools-support-core/cmake/modules
       - name: Build swift-package-manager
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-package-manager
 


### PR DESCRIPTION
This is no longer used as a dependency for swift-driver, remove the unnecessary build.