### PR TITLE
GHA: wire up swift-build revision tracking

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -147,6 +147,7 @@ jobs:
       swift_argument_parser_revision: ${{ steps.context.outputs.swift_argument_parser_revision }}
       swift_asn1_revision: ${{ steps.context.outputs.swift_asn1_revision }}
       swift_atomics_revision: ${{ steps.context.outputs.swift_atomics_revision }}
+      swift_build_revision: ${{ steps.context.outputs.swift_build_revision }}
       swift_certificates_revision: ${{ steps.context.outputs.swift_certificates_revision }}
       swift_cmark_revision: ${{ steps.context.outputs.swift_cmark_revision }}
       swift_cmark_version: ${{ steps.context.outputs.swift_cmark_version }}
@@ -239,6 +240,7 @@ jobs:
           swift_argument_parser_revision=refs/tags/1.4.0
           swift_asn1_revision=refs/tags/0.7.0
           swift_atomics_revision=refs/tags/1.2.0
+          swift_build_revision=refs/heads/main
           swift_certificates_revision=refs/tags/0.1.0
           swift_cmark_revision=refs/tags/${{ inputs.swift_tag }}
           swift_collections_revision=refs/tags/1.1.2
@@ -663,6 +665,7 @@ jobs:
       swift_argument_parser_revision: ${{ needs.context.outputs.swift_argument_parser_revision }}
       swift_asn1_revision: ${{ needs.context.outputs.swift_asn1_revision }}
       swift_atomics_revision: ${{ needs.context.outputs.swift_atomics_revision }}
+      swift_build_revision: ${{ needs.context.outputs.swift_build_revision }}
       swift_certificates_revision: ${{ needs.context.outputs.swift_certificates_revision }}
       swift_cmark_revision: ${{ needs.context.outputs.swift_cmark_revision }}
       swift_cmark_version: ${{ needs.context.outputs.swift_cmark_version }}
@@ -737,6 +740,7 @@ jobs:
       swift_argument_parser_revision: ${{ needs.context.outputs.swift_argument_parser_revision }}
       swift_asn1_revision: ${{ needs.context.outputs.swift_asn1_revision }}
       swift_atomics_revision: ${{ needs.context.outputs.swift_atomics_revision }}
+      swift_build_revision: ${{ needs.context.outputs.swift_build_revision }}
       swift_certificates_revision: ${{ needs.context.outputs.swift_certificates_revision }}
       swift_cmark_revision: ${{ needs.context.outputs.swift_cmark_revision }}
       swift_cmark_version: ${{ needs.context.outputs.swift_cmark_version }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -71,6 +71,10 @@ on:
         required: true
         type: string
 
+      swift_build_revision:
+        required: true
+        type: string
+
       swift_certificates_revision:
         required: true
         type: string


### PR DESCRIPTION
Track the revision of swift-build. This is not yet wired up into the build, but this is the first step towards integrating swift-build into the toolchain.