### PR TITLE
GHA: simplify the compiler context

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -992,33 +992,23 @@ jobs:
           $ExtraFlags = "${{ matrix.extra_flags }}"
 
           if ( "${{ matrix.os }}" -eq "Windows" ) {
-            $SWIFTC = cygpath -m (Get-Command swiftc).Source
             # Use toolchain clang to avoid broken __prefetch intrinsic on arm64 in Clang 18.
             # TODO: Use llvm-19 when available. See https://github.com/compnerd/swift-build/issues/846
-            $CLANG_LOCATION = Split-Path (Get-Command swiftc).Source
-            if ( "${{ matrix.arch }}" -eq "arm64" ) {
-              $ExtraFlags += " -D CMAKE_SYSTEM_NAME=Windows"
-              $CACHE="${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-aarch64.cmake"
+            $CLANG_LOCATION = cygpath -m $(Split-Path (Get-Command swiftc).Source)
+            $SWIFTC = cygpath -m (Get-Command swiftc).Source
 
-              # FIXME(compnerd) re-enable runtimes after we sort out compiler-rt
-              (Get-Content ${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-aarch64.cmake).Replace(' runtimes', '') | Set-Content ${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-aarch64.cmake
-            } else {
-              # FIXME(steelskin) Setting `CMAKE_SYSTEM_NAME and `CMAKE_SYSTEM_PROCESSOR` breaks the compiler-rt build
-              $ExtraFlags = ""
-              $CACHE="${{ github.workspace }}/SourceCache/swift/cmake/caches/Windows-x86_64.cmake"
-            }
-            $CC = "cl"
-            $CXX = "cl"
+            $CC = "${{ matrix.cc }}"
+            $CXX = "${{ matrix.cxx }}"
+            $SDKROOT = cygpath -m ${env:SDKROOT}
 
             # Workaround for compiler and STL version mismatch on Windows.
             $CxxFlags += " -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
             $SwiftFlags += " -Xcc -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
 
-            $SDKROOT = cygpath -m ${env:SDKROOT}
-            $CLANG_LOCATION = cygpath -m $CLANG_LOCATION
             $LIBPYTHON_PATH = "${env:PYTHON_LOCATION_${{ matrix.arch }}}/libs/python39.lib"
             $PYTHON_INCLUDE_DIR = "${env:PYTHON_LOCATION_${{ matrix.arch }}}/include"
             $PYTHON_BINARY="python.exe"
+
             Remove-Item env:\SDKROOT
           } elseif ( "${{ matrix.os }}" -eq "Darwin" ) {
             # Default swiftc comes from /usr/bin and is not compatible with the toolchain.
@@ -1026,18 +1016,15 @@ jobs:
             $SWIFTC = Join-Path $CLANG_LOCATION "swiftc"
 
             # We need to use llvm-17 to build the compiler on macOS. We get it from the Swift toolchain.
-            $CC = Join-Path $CLANG_LOCATION "clang"
-            $CXX = Join-Path $CLANG_LOCATION "clang++"
-            $CACHE = "${{ github.workspace }}/SourceCache/swift/cmake/caches/Darwin-${{ matrix.arch }}.cmake"
+            $CC = Join-Path $CLANG_LOCATION ${{ matrix.cc }}
+            $CXX = Join-Path $CLANG_LOCATION ${{ matrix.cxx }}
             $SDKROOT = xcrun --sdk macosx --show-sdk-path
 
-            $ExtraFlags += " -D CMAKE_SYSTEM_NAME=Darwin"
             # TODO: Use early-swift-driver on Windows too.
             $ExtraFlags += " -D SWIFT_EARLY_SWIFT_DRIVER_BUILD=${{ github.workspace }}/BinaryCache/swift-driver/bin"
             $LIBPYTHON_PATH = "${env:pythonLocation}/lib/python3.9/config-3.9-darwin/libpython3.9.a"
             $PYTHON_INCLUDE_DIR = "${env:pythonLocation}/include/python3.9"
             $PYTHON_BINARY="python3"
-            $ExeSuffix = ""
           }
 
           $SwiftFlags += " -sdk `"${SDKROOT}`""
@@ -1050,7 +1037,6 @@ jobs:
           cxxflags=${CxxFlags}
           swiftflags=${SwiftFlags}
           extra_flags=${ExtraFlags}
-          cache=${CACHE}
           clang_location=${CLANG_LOCATION}
           libpython_path=${LIBPYTHON_PATH}
           python_include_dir=${PYTHON_INCLUDE_DIR}
@@ -1071,7 +1057,7 @@ jobs:
           }
 
           cmake -B ${{ github.workspace }}/BinaryCache/1 `
-                -C "${{ steps.setup-context.outputs.cache }}" `
+                -C "${{ github.workspace }}/SourceCache/swift/cmake/caches/${{ matrix.os }}-${{ matrix.cpu }}.cmake" `
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER="${{ steps.setup-context.outputs.cc }}" `
                 -D CMAKE_C_COMPILER_LAUNCHER=sccache `
@@ -1086,6 +1072,7 @@ jobs:
                 -D CMAKE_STATIC_LIBRARY_PREFIX_Swift= `
                 -D CMAKE_FIND_PACKAGE_PREFER_CONFIG=YES `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
+                -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
                 ${{ steps.setup-context.outputs.extra_flags }} `
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/llvm-project/llvm `


### PR DESCRIPTION
With the removal of the runtimes build in unified build, we are able to universally inline some of the computation of the flags. Other options are no longer required to be evaluated at build time. Re-order some of the options to similarly order the macOS and Windows builds.