### PR TITLE
GHA: tweak the library naming for static libraries

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -380,7 +380,7 @@ jobs:
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
                   "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
-                  "cmake_linker_flags": "-D CMAKE_EXE_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}\" -D CMAKE_SHARED_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}\"",
+                  "cmake_linker_flags": "-D CMAKE_EXE_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}\" -D CMAKE_SHARED_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}\" -D CMAKE_STATIC_LIBRARY_PREFIX_Swift=lib",
                   "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=AMD64"
                 },
                 {
@@ -394,7 +394,7 @@ jobs:
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
                   "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
-                  "cmake_linker_flags": "-D CMAKE_EXE_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}\" -D CMAKE_SHARED_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}\"",
+                  "cmake_linker_flags": "-D CMAKE_EXE_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}\" -D CMAKE_SHARED_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}\" -D CMAKE_STATIC_LIBRARY_PREFIX_Swift=lib",
                   "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=ARM64"
                 }
               ]
@@ -413,7 +413,7 @@ jobs:
                   "cxx": "cl",
                   "cxxflags": "${{ steps.context.outputs.WINDOWS_CMAKE_CXX_FLAGS }}",
                   "swiftflags": "${{ steps.context.outputs.WINDOWS_CMAKE_Swift_FLAGS }}",
-                  "cmake_linker_flags": "-D CMAKE_EXE_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}\" -D CMAKE_SHARED_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}\"",
+                  "cmake_linker_flags": "-D CMAKE_EXE_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}\" -D CMAKE_SHARED_LINKER_FLAGS=\"${{ steps.context.outputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}\" -D CMAKE_STATIC_LIBRARY_PREFIX_Swift=lib",
                   "extra_flags": "-D CMAKE_SYSTEM_PROCESSOR=ARM64"
                 }
               ]

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1079,6 +1079,7 @@ jobs:
                 -D CMAKE_CXX_COMPILER="${{ steps.setup-context.outputs.cxx }}" `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
                 -D CMAKE_CXX_FLAGS="${{ steps.setup-context.outputs.cxxflags }}" `
+                -D CMAKE_STATIC_LIBRARY_PREFIX_Swift= `
                 -D CMAKE_Swift_COMPILER="${{ steps.setup-context.outputs.swiftc }}" `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="${{ steps.setup-context.outputs.swiftflags }}" `
@@ -1600,7 +1601,7 @@ jobs:
             swiftflags: ${{ inputs.CMAKE_Swift_FLAGS }}
             os: Windows
             llvm_flags:
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}" -D CMAKE_STATIC_LIBRARY_PREFIX_Swift=lib'
             extra_flags:
 
           - arch: arm64
@@ -1614,8 +1615,8 @@ jobs:
             swiftflags: ${{ inputs.CMAKE_Swift_FLAGS }}
             os: Windows
             llvm_flags:
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
-            extra_flags: 
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}" -D CMAKE_STATIC_LIBRARY_PREFIX_Swift=lib'
+            extra_flags:
 
           - arch: x86
             cpu: 'i686'
@@ -2029,7 +2030,7 @@ jobs:
             cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
             swiftflags: ${{ inputs.CMAKE_Swift_FLAGS }}
             os: Windows
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}" -D CMAKE_STATIC_LIBRARY_PREFIX_Swift=lib'
             extra_flags:
 
           - arch: arm64
@@ -2042,7 +2043,7 @@ jobs:
             cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
             swiftflags: ${{ inputs.CMAKE_Swift_FLAGS }}
             os: Windows
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}" -D CMAKE_STATIC_LIBRARY_PREFIX_Swift=lib'
             extra_flags:
 
           - arch: x86
@@ -2055,7 +2056,7 @@ jobs:
             cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
             swiftflags: ${{ inputs.CMAKE_Swift_FLAGS }}
             os: Windows
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
+            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}" -D CMAKE_STATIC_LIBRARY_PREFIX_Swift=lib'
             extra_flags:
 
           - arch: arm64
@@ -2745,6 +2746,7 @@ jobs:
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
@@ -2774,6 +2776,7 @@ jobs:
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
@@ -2802,6 +2805,7 @@ jobs:
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
@@ -2830,6 +2834,7 @@ jobs:
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
@@ -2862,6 +2867,7 @@ jobs:
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
@@ -2891,6 +2897,7 @@ jobs:
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
@@ -2923,6 +2930,7 @@ jobs:
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
@@ -2950,6 +2958,7 @@ jobs:
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
@@ -2971,6 +2980,7 @@ jobs:
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
@@ -3008,6 +3018,7 @@ jobs:
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
@@ -3048,6 +3059,7 @@ jobs:
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
@@ -3075,6 +3087,7 @@ jobs:
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
@@ -3099,6 +3112,7 @@ jobs:
                 -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
@@ -3128,6 +3142,7 @@ jobs:
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
@@ -3158,6 +3173,7 @@ jobs:
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `


### PR DESCRIPTION
This was changed upstream to use `lib` prefix for static libraries on Windows for Swift. Apply the necessary build changes to ensure that the build system is aware of this.