### PR TITLE
[gha] fix the Windows Swift toolchain build

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1084,6 +1084,7 @@ jobs:
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="${{ steps.setup-context.outputs.swiftflags }}" `
                 ${{ matrix.cmake_linker_flags }} `
+                -D CMAKE_STATIC_LIBRARY_PREFIX_Swift= `
                 -D CMAKE_FIND_PACKAGE_PREFER_CONFIG=YES `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 ${{ steps.setup-context.outputs.extra_flags }} `

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2983,6 +2983,7 @@ jobs:
                 -D CMAKE_Swift_FLAGS_RELEASE="-O" `
                 ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_SYSTEM_NAME=Windows `
+                ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/swift-certificates `
@@ -3168,6 +3169,7 @@ jobs:
                 -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1079,7 +1079,6 @@ jobs:
                 -D CMAKE_CXX_COMPILER="${{ steps.setup-context.outputs.cxx }}" `
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
                 -D CMAKE_CXX_FLAGS="${{ steps.setup-context.outputs.cxxflags }}" `
-                -D CMAKE_STATIC_LIBRARY_PREFIX_Swift= `
                 -D CMAKE_Swift_COMPILER="${{ steps.setup-context.outputs.swiftc }}" `
                 -D CMAKE_Swift_COMPILER_WORKS=YES `
                 -D CMAKE_Swift_FLAGS="${{ steps.setup-context.outputs.swiftflags }}" `


### PR DESCRIPTION
## Overview
* Add the global `cmake_linker_flags` when configuring build for `swift-certificates` and `SourceKit-LSP`. This implicitly adds `CMAKE_STATIC_LIBRARY_PREFIX_Swift="lib"` as needed on Windows.
* Move position of `-D CMAKE_STATIC_LIBRARY_PREFIX_Swift=` later in the CMake configure command for `Compilers` so that it overrides the value pulled in by including the global `cmake_linker_flags`.

## Validation
Ran Development Snapshot CI: https://github.com/thebrowsercompany/swift-build/actions/runs/13266881748