### PR TITLE
[android] link Android components with `-g split-dwarf` to reduce size

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -296,8 +296,8 @@ jobs:
             echo DARWIN_CMAKE_CXX_FLAGS="-g" >> ${GITHUB_OUTPUT}
             echo DARWIN_CMAKE_EXE_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
             echo DARWIN_CMAKE_SHARED_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
-            echo ANDROID_CMAKE_C_FLAGS="-ffunction-sections -fdata-sections -g" >> ${GITHUB_OUTPUT}
-            echo ANDROID_CMAKE_CXX_FLAGS="-ffunction-sections -fdata-sections -g" >> ${GITHUB_OUTPUT}
+            echo ANDROID_CMAKE_C_FLAGS="-ffunction-sections -fdata-sections -g -gsplit-dwarf" >> ${GITHUB_OUTPUT}
+            echo ANDROID_CMAKE_CXX_FLAGS="-ffunction-sections -fdata-sections -g -gsplit-dwarf" >> ${GITHUB_OUTPUT}
             echo WINDOWS_CMAKE_EXE_LINKER_FLAGS="-incremental:no -debug -opt:ref -opt:icf" >> ${GITHUB_OUTPUT}
             echo WINDOWS_CMAKE_SHARED_LINKER_FLAGS="-incremental:no -debug -opt:ref -opt:icf" >> ${GITHUB_OUTPUT}
             echo WINDOWS_CMAKE_Swift_FLAGS="-g -debug-info-format=codeview -Xlinker -debug -Xlinker -incremental:no -Xlinker -opt:ref -Xlinker -opt:icf" >> ${GITHUB_OUTPUT}


### PR DESCRIPTION
## Purpose
Reduce the size of the Swift Android SDK by using `-g split-dwarf` when building with debug symbols enabled.

## Validation

Successful CI run with Android & debug symbols: https://github.com/thebrowsercompany/swift-build/actions/runs/13395138729

Observed size reduction of Android installer by 7-8 MB per architecture:
* `sdk-android-arm64-msi`: 52.7 MB -> 46.1 MB
* `sdk-android-armv7-msi`: 53.2 MB -> 46.8 MB
* `sdk-android-i686-msi`: 53.4 MB -> 47.2 MB
* `sdk-android-x86_64-msi`: 53 MB -> 46.4 MB