### PR TITLE
GHA: adjust the file system layout to accommodate the installer

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2366,6 +2366,13 @@ jobs:
 
           $CMAKE_CPU = if ("${{ matrix.cpu }}" -eq "armv7") { "armv7-a" } else { "${{ matrix.cpu }}" }
 
+          $XCTestBinDir = switch ("${{ matrix.cpu }}") {
+          "armv7" { "bin32a" }
+          "i686" { "bin32" }
+          "x86_64" { "bin64" }
+          "aarch64" { "bin64a" }
+          }
+
           cmake -B ${{ github.workspace }}/BinaryCache/xctest `
                 -D BUILD_SHARED_LIBS=YES `
                 -D CMAKE_BUILD_TYPE=Release `
@@ -2376,6 +2383,7 @@ jobs:
                 -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
+                -D CMAKE_INSTALL_BINDIR=$XCTestBinDir `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple_no_api_level }} `
@@ -2424,6 +2432,13 @@ jobs:
 
           $CMAKE_CPU = if ("${{ matrix.cpu }}" -eq "armv7") { "armv7-a" } else { "${{ matrix.cpu }}" }
 
+          $TestingBinDir = switch ("${{ matrix.cpu }}") {
+          "armv7" { "bin32a" }
+          "i686" { "bin32" }
+          "x86_64" { "bin64" }
+          "aarch64" { "bin64a" }
+          }
+
           cmake -B ${{ github.workspace }}/BinaryCache/testing `
                 -D BUILD_SHARED_LIBS=YES `
                 -D CMAKE_BUILD_TYPE=Release `
@@ -2431,6 +2446,7 @@ jobs:
                 -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
+                -D CMAKE_INSTALL_BINDIR=$TestingBinDir `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/Testing-development/usr `
                 -D CMAKE_Swift_COMPILER=${SWIFTC} `
                 -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple_no_api_level }} `
@@ -2456,10 +2472,25 @@ jobs:
         if: matrix.os != 'Android' || inputs.build_android
         run: |
           cmake --build ${{ github.workspace }}/BinaryCache/testing --target install
+      - name: Testing Install Fixup
+        if: matrix.os != 'Android' || inputs.build_android
+        run: |
+          $OS = "${{ matrix.os }}".ToLowerInvariant()
+          New-Item -ItemType Directory -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/Testing-development/usr/lib/swift/${OS}/${{ matrix.cpu }}" -Force -ErrorAction Ignore | Out-Null
+          Move-Item -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/Testing-development/usr/lib/swift/${OS}/Testing.lib" "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/Testing-development/usr/lib/swift/${OS}/${{ matrix.cpu }}/Testing.lib"
       - name: Install xctest
         if: matrix.os != 'Android' || inputs.build_android
         run: |
           cmake --build ${{ github.workspace }}/BinaryCache/xctest --target install
+      - name: XCTest Install Fixup
+        if: matrix.os != 'Android' || inputs.build_android
+        run: |
+          $OS = "${{ matrix.os }}".ToLowerInvariant()
+          New-Item -ItemType Directory -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/${{ matrix.cpu }}" -Force -ErrorAction Ignore | Out-Null
+          New-Item -ItemType Directory -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/XCTest.swiftmodule" -Force -ErrorAction Ignore | Out-Null
+          Move-Item -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/XCTest.lib" "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/${{ matrix.cpu }}/XCTest.lib"
+          Move-Item -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/${{ matrix.cpu }}/XCTest.swiftdoc" "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/XCTest.swiftmodule/${{ matrix.triple_no_api_level }}.swiftdoc"
+          Move-Item -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/${{ matrix.cpu }}/XCTest.swiftmodule" "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/XCTest.swiftmodule/${{ matrix.triple_no_api_level }}.swiftmodule"
       - name: Install foundation
         if: matrix.os != 'Android' || inputs.build_android
         run: |


### PR DESCRIPTION
This adjusts the installation to shuffle around some of the installed files to match the expected layout post-installation. This is required to accommodate the installer which is beginning to expect the toolchain to be laid out as desired.