### PR TITLE
Use GHA upload/download tar actions for stdlib

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1738,10 +1738,10 @@ jobs:
           }
           cmake --build ${{ github.workspace }}/BinaryCache/swift --target install
 
-      - uses: actions/upload-artifact@v4
+      - uses: thebrowsercompany/gha-upload-tar-artifact@e18c33b1cd416d0d96a91dc6dce06219f98e4e27 # main
         if: matrix.os != 'Android' || inputs.build_android
         with:
-          name: ${{ matrix.os }}-stdlib-${{ matrix.arch }}
+          name: stdlib-${{ matrix.os }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library
 
       - uses: actions/upload-artifact@v4
@@ -1791,14 +1791,14 @@ jobs:
         with:
           name: swift-syntax-Windows-${{ matrix.arch }}
           path: ${{ github.workspace }}/BinaryCache/swift-syntax
-      - uses: actions/download-artifact@v4
+      - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Windows-stdlib-${{ matrix.arch }}
+          name: stdlib-Windows-${{ matrix.arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
-      - uses: actions/download-artifact@v4
+      - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         if: matrix.arch == 'arm64'
         with:
-          name: Windows-stdlib-${{ inputs.build_arch }}
+          name: stdlib-Windows-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: actions/download-artifact@v4
         with:
@@ -2033,14 +2033,14 @@ jobs:
         with:
           name: compilers-Windows-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
-      - uses: actions/download-artifact@v4
+      - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         if: matrix.os != 'Android' || inputs.build_android
         with:
-          name: ${{ matrix.os }}-stdlib-${{ matrix.arch }}
+          name: stdlib-${{ matrix.os }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
-      - uses: actions/download-artifact@v4
+      - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Windows-stdlib-${{ inputs.build_arch }}
+          name: stdlib-Windows-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: actions/download-artifact@v4
         if: matrix.os == 'Windows'
@@ -2464,9 +2464,9 @@ jobs:
         with:
           name: compilers-Windows-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
-      - uses: actions/download-artifact@v4
+      - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Windows-stdlib-${{ matrix.arch }}
+          name: stdlib-Windows-${{ matrix.arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: actions/download-artifact@v4
         with:
@@ -2613,9 +2613,9 @@ jobs:
           Move-Item ${env:SDKROOT}/usr/lib/swift/windows/FoundationInternationalization.lib ${env:SDKROOT}/usr/lib/swift/windows/${{ matrix.cpu }}/
 
       # Download host libraries for the windows amd64 host, after moving the target libraries to the target-specific directory.
-      - uses: actions/download-artifact@v4
+      - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Windows-stdlib-${{ inputs.build_arch }}
+          name: stdlib-Windows-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: actions/download-artifact@v4
         with:
@@ -3171,9 +3171,9 @@ jobs:
           name: compilers-Windows-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - name: Download stdlib
-        uses: actions/download-artifact@v4
+        uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Windows-stdlib-${{ matrix.arch }}
+          name: stdlib-Windows-${{ matrix.arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - name: Download SDK
         uses: actions/download-artifact@v4
@@ -3219,9 +3219,9 @@ jobs:
           Move-Item ${env:SDKROOT}/usr/lib/swift/windows/FoundationInternationalization.lib ${env:SDKROOT}/usr/lib/swift/windows/${{ matrix.cpu }}/
 
       # Download host SDK on top of the target SDK, so that the runtime DLLs are the host ones.
-      - uses: actions/download-artifact@v4
+      - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Windows-stdlib-${{ inputs.build_arch }}
+          name: stdlib-Windows-${{ inputs.build_arch }}
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: actions/download-artifact@v4
         with:
@@ -3466,9 +3466,9 @@ jobs:
             platform: x86
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Windows-stdlib-${{ matrix.arch }}
+          name: stdlib-Windows-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library
       - uses: actions/download-artifact@v4
         with:
@@ -3577,7 +3577,7 @@ jobs:
         # There is currently no Android NDK for Windows ARM64 so build Android only on Windows X64 host only
         if: inputs.build_android
         with:
-          name: Android-stdlib-${{ matrix.arch }}
+          name: stdlib-Android-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library
       - uses: actions/download-artifact@v4
         if: inputs.build_android


### PR DESCRIPTION
This is required for the Mac build. This also renames the "os-stdlib-arch" artifact to "stdlib-os-arch" for consistency for other artifacts.