### PR TITLE
GHA: XCTest now installs a thick module

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2416,9 +2416,9 @@ jobs:
         if: matrix.os != 'Android' || inputs.build_android
         run: |
           $OS = "${{ matrix.os }}".ToLowerInvariant()
-          $Lib = if ("${{ matrix.os }}" -eq "Windows") { "Testing.lib" } else { "libTesting.so" }
+          $LIB = if ("${{ matrix.os }}" -eq "Windows") { "Testing.lib" } else { "libTesting.so" }
           New-Item -ItemType Directory -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/Testing-development/usr/lib/swift/${OS}/${{ matrix.cpu }}" -Force -ErrorAction Ignore | Out-Null
-          Move-Item -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/Testing-development/usr/lib/swift/${OS}/${Lib}" "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/Testing-development/usr/lib/swift/${OS}/${{ matrix.cpu }}/${Lib}"
+          Move-Item -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/Testing-development/usr/lib/swift/${OS}/${LIB}" "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/Testing-development/usr/lib/swift/${OS}/${{ matrix.cpu }}/"
       - name: Install xctest
         if: matrix.os != 'Android' || inputs.build_android
         run: |
@@ -2427,12 +2427,9 @@ jobs:
         if: matrix.os != 'Android' || inputs.build_android
         run: |
           $OS = "${{ matrix.os }}".ToLowerInvariant()
-          $Lib = if ("${{ matrix.os }}" -eq "Windows") { "XCTest.lib" } else { "libXCTest.so" }
+          $LIB = if ("${{ matrix.os }}" -eq "Windows") { "XCTest.lib" } else { "libXCTest.so" }
           New-Item -ItemType Directory -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/${{ matrix.cpu }}" -Force -ErrorAction Ignore | Out-Null
-          New-Item -ItemType Directory -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/XCTest.swiftmodule" -Force -ErrorAction Ignore | Out-Null
-          Move-Item -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/${LIB}" "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/${{ matrix.cpu }}/${Lib}"
-          Move-Item -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/${{ matrix.cpu }}/XCTest.swiftdoc" "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/XCTest.swiftmodule/${{ matrix.triple_no_api_level }}.swiftdoc"
-          Move-Item -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/${{ matrix.cpu }}/XCTest.swiftmodule" "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/XCTest.swiftmodule/${{ matrix.triple_no_api_level }}.swiftmodule"
+          Move-Item -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/${LIB}" "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-development/usr/lib/swift/${OS}/${{ matrix.cpu }}/"
       - name: Install foundation
         if: matrix.os != 'Android' || inputs.build_android
         run: |


### PR DESCRIPTION
Adjust the install fixup to remove the re-organisation as XCTest will install a thick module by default.