### PR TITLE
variants: Build Asserts and NoAsserts compilers.

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -223,11 +223,14 @@ jobs:
       mac_build_runner: ${{ steps.context.outputs.mac_build_runner }}
       windows_arm64_build_matrix: ${{ steps.setup-matrix.outputs.windows_arm64_build_matrix }}
       windows_arm64_host_matrix: ${{ steps.setup-matrix.outputs.windows_arm64_host_matrix }}
+      windows_arm64_compilers_matrix: ${{ steps.setup-matrix.outputs.windows_arm64_compilers_matrix }}
       windows_arm64_target_matrix: ${{ steps.setup-matrix.outputs.windows_arm64_target_matrix }}
       windows_x64_build_matrix: ${{ steps.setup-matrix.outputs.windows_x64_build_matrix }}
       windows_x64_host_matrix: ${{ steps.setup-matrix.outputs.windows_x64_host_matrix }}
+      windows_x64_compilers_matrix: ${{ steps.setup-matrix.outputs.windows_x64_compilers_matrix }}
       windows_x64_target_matrix: ${{ steps.setup-matrix.outputs.windows_x64_target_matrix }}
       darwin_host_matrix: ${{ steps.setup-matrix.outputs.darwin_host_matrix }}
+      darwin_compilers_matrix: ${{ steps.setup-matrix.outputs.darwin_compilers_matrix }}
       darwin_build_matrix: ${{ steps.setup-matrix.outputs.darwin_build_matrix }}
       darwin_target_matrix: ${{ steps.setup-matrix.outputs.darwin_target_matrix }}
     steps:
@@ -754,14 +757,32 @@ jobs:
               ]
             }
         run: |
+          create_compilers_matrix() {
+            local host_matrix=$1
+            jq -n --argjson host_matrix "${host_matrix}" '
+              {
+                "include": [
+                  ($host_matrix.include[] | . + {"variant": "Asserts"}),
+                  ($host_matrix.include[] | . + {"variant": "NoAsserts"})
+                ]
+              }
+            '
+          }
+          WINDOWS_X64_COMPILERS_MATRIX=$(create_compilers_matrix "${WINDOWS_X64_HOST_MATRIX}")
+          WINDOWS_ARM64_COMPILERS_MATRIX=$(create_compilers_matrix "${WINDOWS_ARM64_HOST_MATRIX}")
+          DARWIN_COMPILERS_MATRIX=$(create_compilers_matrix "${DARWIN_HOST_MATRIX}")
+
           echo "windows_x64_host_matrix=$(jq -r -c '.' <<< ${WINDOWS_X64_HOST_MATRIX})" >> ${GITHUB_OUTPUT}
           echo "windows_arm64_host_matrix=$(jq -r -c '.' <<< ${WINDOWS_ARM64_HOST_MATRIX})" >> ${GITHUB_OUTPUT}
+          echo "windows_x64_compilers_matrix=$(jq -r -c '.' <<< ${WINDOWS_X64_COMPILERS_MATRIX})" >> ${GITHUB_OUTPUT}
+          echo "windows_arm64_compilers_matrix=$(jq -r -c '.' <<< ${WINDOWS_ARM64_COMPILERS_MATRIX})" >> ${GITHUB_OUTPUT}
           echo "windows_x64_build_matrix=$(jq -r -c '.' <<< ${WINDOWS_X64_BUILD_MATRIX})" >> ${GITHUB_OUTPUT}
           echo "windows_arm64_build_matrix=$(jq -r -c '.' <<< ${WINDOWS_ARM64_BUILD_MATRIX})" >> ${GITHUB_OUTPUT}
           echo "windows_x64_target_matrix=$(jq -r -c '.' <<< ${WINDOWS_X64_TARGET_MATRIX})" >> ${GITHUB_OUTPUT}
           echo "windows_arm64_target_matrix=$(jq -r -c '.' <<< ${WINDOWS_ARM64_TARGET_MATRIX})" >> ${GITHUB_OUTPUT}
           echo "darwin_host_matrix=$(jq -r -c '.' <<< ${DARWIN_HOST_MATRIX})" >> ${GITHUB_OUTPUT}
           echo "darwin_build_matrix=$(jq -r -c '.' <<< ${DARWIN_BUILD_MATRIX})" >> ${GITHUB_OUTPUT}
+          echo "darwin_compilers_matrix=$(jq -r -c '.' <<< ${DARWIN_COMPILERS_MATRIX})" >> ${GITHUB_OUTPUT}
           echo "darwin_target_matrix=$(jq -r -c '.' <<< ${DARWIN_TARGET_MATRIX})" >> ${GITHUB_OUTPUT}
 
   windows-build:
@@ -775,6 +796,7 @@ jobs:
       build_matrix: ${{ needs.context.outputs[format('windows_{0}_build_matrix', needs.context.outputs.windows_build_cpu)] }}
       host_matrix: ${{ needs.context.outputs[format('windows_{0}_host_matrix', needs.context.outputs.windows_build_cpu)] }}
       target_matrix: ${{ needs.context.outputs[format('windows_{0}_target_matrix', needs.context.outputs.windows_build_cpu)] }}
+      compilers_matrix: ${{ needs.context.outputs[format('windows_{0}_compilers_matrix', needs.context.outputs.windows_build_cpu)] }}
       curl_revision: ${{ needs.context.outputs.curl_revision }}
       curl_version: ${{ needs.context.outputs.curl_version }}
       ds2_revision: ${{ needs.context.outputs.ds2_revision }}
@@ -850,6 +872,7 @@ jobs:
       build_arch: arm64
       build_matrix: ${{ needs.context.outputs.darwin_build_matrix }}
       host_matrix: ${{ needs.context.outputs.darwin_host_matrix }}
+      compilers_matrix: ${{ needs.context.outputs.darwin_compilers_matrix }}
       target_matrix: ${{ needs.context.outputs.darwin_target_matrix }}
       curl_revision: ${{ needs.context.outputs.curl_revision }}
       curl_version: ${{ needs.context.outputs.curl_version }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -864,7 +864,7 @@ jobs:
       matrix: ${{ fromJSON(inputs.compilers_matrix) }}
 
 
-    name: ${{ matrix.variant }} ${{ matrix.os }} ${{ matrix.arch }} Toolchain
+    name: ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.variant }} Toolchain
 
     steps:
       - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
@@ -995,7 +995,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 500M
-          key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.variant }}-${{ matrix.os }}-${{ matrix.arch }}-compilers
+          key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.variant }}-compilers
           variant: sccache
 
       - name: Setup context
@@ -1164,7 +1164,7 @@ jobs:
       - name: Upload Compilers
         uses: thebrowsercompany/gha-upload-tar-artifact@e18c33b1cd416d0d96a91dc6dce06219f98e4e27 # main
         with:
-          name: ${{ matrix.variant }}-${{ matrix.os }}-${{ matrix.arch }}-compilers
+          name: ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.variant }}-compilers
           path: ${{ github.workspace }}/BuildRoot/Library
 
       - name: Extract swift-syntax
@@ -1190,14 +1190,14 @@ jobs:
       - name: Upload swift-syntax
         uses: thebrowsercompany/gha-upload-tar-artifact@e18c33b1cd416d0d96a91dc6dce06219f98e4e27 # main
         with:
-          name: ${{ matrix.variant }}-${{matrix.os }}-${{ matrix.arch }}-swift-syntax
+          name: ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.variant }}-swift-syntax
           path: ${{ github.workspace }}/BinaryCache/swift-syntax
 
       # TODO(compnerd) this takes ~1h due to the size, see if we can compress first
       - uses: actions/upload-artifact@v4
         if: false # ${{ inputs.debug_info }}
         with:
-          name: ${{ matrix.variant }}-${{ matrix.os }}-${{ matrix.arch }}-compilers-debug-info
+          name: ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.variant }}-compilers-debug-info
           path: |
             ${{ github.workspace }}/BinaryCache/1/**/*.pdb
 
@@ -1597,7 +1597,7 @@ jobs:
         if: matrix.os != 'Android' || inputs.build_android
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Asserts-${{ inputs.build_os }}-${{ inputs.build_arch }}-compilers
+          name: ${{ inputs.build_os }}-${{ inputs.build_arch }}-Asserts-compilers
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: actions/checkout@v4
         if: matrix.os != 'Android' || inputs.build_android
@@ -1805,12 +1805,12 @@ jobs:
       - name: Download Compilers
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Asserts-Windows-${{ inputs.build_arch }}-compilers
+          name: Windows-${{ inputs.build_arch }}-Asserts-compilers
           path: ${{ github.workspace }}/BinaryCache/Library
       - name: Download swift-syntax
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Asserts-Windows-${{ matrix.arch }}-swift-syntax
+          name: Windows-${{ matrix.arch }}-Asserts-swift-syntax
           path: ${{ github.workspace }}/BinaryCache/swift-syntax
       - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
@@ -2053,7 +2053,7 @@ jobs:
         if: matrix.os != 'Android' || inputs.build_android
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Asserts-Windows-${{ inputs.build_arch }}-compilers
+          name: Windows-${{ inputs.build_arch }}-Asserts-compilers
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         if: matrix.os != 'Android' || inputs.build_android
@@ -2517,7 +2517,7 @@ jobs:
       - name: Download Compilers
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Asserts-Windows-${{ inputs.build_arch }}-compilers
+          name: Windows-${{ inputs.build_arch }}-Asserts-compilers
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
@@ -2533,7 +2533,7 @@ jobs:
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Asserts-Windows-${{ matrix.arch }}-swift-syntax
+          name: Windows-${{ matrix.arch }}-Asserts-swift-syntax
           path: ${{ github.workspace }}/BinaryCache/swift-syntax
       - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
@@ -3223,7 +3223,7 @@ jobs:
       - name: Download Compilers
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Asserts-Windows-${{ inputs.build_arch }}-compilers
+          name: Windows-${{ inputs.build_arch }}-Asserts-compilers
           path: ${{ github.workspace }}/BinaryCache/Library
       - name: Download stdlib
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
@@ -3333,7 +3333,7 @@ jobs:
       - name: Download Compilers
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Asserts-Windows-${{ matrix.arch }}-compilers
+          name: Windows-${{ matrix.arch }}-Asserts-compilers
           path: ${{ github.workspace }}/BuildRoot/Library
 
       - name: Download Developer Tools

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1164,7 +1164,7 @@ jobs:
       - name: Upload Compilers
         uses: thebrowsercompany/gha-upload-tar-artifact@e18c33b1cd416d0d96a91dc6dce06219f98e4e27 # main
         with:
-          name: ${{ matrix.variant}}-${{ matrix.os }}-${{ matrix.arch }}-compilers
+          name: ${{ matrix.variant }}-${{ matrix.os }}-${{ matrix.arch }}-compilers
           path: ${{ github.workspace }}/BuildRoot/Library
 
       - name: Extract swift-syntax
@@ -1197,7 +1197,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: false # ${{ inputs.debug_info }}
         with:
-          name: ${{ matrix.variant}}-${{ matrix.os }}-${{ matrix.arch }}-compilers-debug-info
+          name: ${{ matrix.variant }}-${{ matrix.os }}-${{ matrix.arch }}-compilers-debug-info
           path: |
             ${{ github.workspace }}/BinaryCache/1/**/*.pdb
 

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -19,6 +19,10 @@ on:
         required: true
         type: string
 
+      compilers_matrix:
+        required: true
+        type: string
+
       target_matrix:
         required: true
         type: string
@@ -857,9 +861,10 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(inputs.host_matrix) }}
+      matrix: ${{ fromJSON(inputs.compilers_matrix) }}
 
-    name: ${{ matrix.os }} ${{ matrix.arch }} Toolchain
+
+    name: ${{ matrix.variant }} ${{ matrix.os }} ${{ matrix.arch }} Toolchain
 
     steps:
       - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
@@ -990,7 +995,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 500M
-          key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-compilers
+          key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.variant }}-${{ matrix.os }}-${{ matrix.arch }}-compilers
           variant: sccache
 
       - name: Setup context
@@ -1089,6 +1094,7 @@ jobs:
                 -D CLANG_TIDY_CONFUSABLE_CHARS_GEN="${{ github.workspace }}/BinaryCache/0/bin/clang-tidy-confusable-chars-gen${ExeSuffix}" `
                 -D LLDB_TABLEGEN="${{ github.workspace }}/BinaryCache/0/bin/lldb-tblgen${ExeSuffix}" `
                 -D LLVM_CONFIG_PATH="${{ github.workspace }}/BinaryCache/0/bin/llvm-config${ExeSuffix}" `
+                -D LLVM_ENABLE_ASSERTIONS=${{ matrix.variant == 'Asserts' && 'YES' || 'NO' }} `
                 -D LLVM_EXTERNAL_SWIFT_SOURCE_DIR=${{ github.workspace }}/SourceCache/swift `
                 -D LLVM_NATIVE_TOOL_DIR=${{ github.workspace }}/BinaryCache/0/bin `
                 -D LLVM_TABLEGEN="${{ github.workspace }}/BinaryCache/0/bin/llvm-tblgen${ExeSuffix}" `
@@ -1158,7 +1164,7 @@ jobs:
       - name: Upload Compilers
         uses: thebrowsercompany/gha-upload-tar-artifact@e18c33b1cd416d0d96a91dc6dce06219f98e4e27 # main
         with:
-          name: ${{ matrix.os }}-${{ matrix.arch }}-compilers
+          name: ${{ matrix.variant}}-${{ matrix.os }}-${{ matrix.arch }}-compilers
           path: ${{ github.workspace }}/BuildRoot/Library
 
       - name: Extract swift-syntax
@@ -1184,14 +1190,14 @@ jobs:
       - name: Upload swift-syntax
         uses: thebrowsercompany/gha-upload-tar-artifact@e18c33b1cd416d0d96a91dc6dce06219f98e4e27 # main
         with:
-          name: ${{matrix.os }}-${{ matrix.arch }}-swift-syntax
+          name: ${{ matrix.variant }}-${{matrix.os }}-${{ matrix.arch }}-swift-syntax
           path: ${{ github.workspace }}/BinaryCache/swift-syntax
 
       # TODO(compnerd) this takes ~1h due to the size, see if we can compress first
       - uses: actions/upload-artifact@v4
         if: false # ${{ inputs.debug_info }}
         with:
-          name: ${{ matrix.os }}-${{ matrix.arch }}-compilers-debug-info
+          name: ${{ matrix.variant}}-${{ matrix.os }}-${{ matrix.arch }}-compilers-debug-info
           path: |
             ${{ github.workspace }}/BinaryCache/1/**/*.pdb
 
@@ -1591,7 +1597,7 @@ jobs:
         if: matrix.os != 'Android' || inputs.build_android
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: ${{ inputs.build_os }}-${{ inputs.build_arch }}-compilers
+          name: Asserts-${{ inputs.build_os }}-${{ inputs.build_arch }}-compilers
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: actions/checkout@v4
         if: matrix.os != 'Android' || inputs.build_android
@@ -1799,12 +1805,12 @@ jobs:
       - name: Download Compilers
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Windows-${{ inputs.build_arch }}-compilers
+          name: Asserts-Windows-${{ inputs.build_arch }}-compilers
           path: ${{ github.workspace }}/BinaryCache/Library
       - name: Download swift-syntax
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Windows-${{ matrix.arch }}-swift-syntax
+          name: Asserts-Windows-${{ matrix.arch }}-swift-syntax
           path: ${{ github.workspace }}/BinaryCache/swift-syntax
       - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
@@ -2047,7 +2053,7 @@ jobs:
         if: matrix.os != 'Android' || inputs.build_android
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Windows-${{ inputs.build_arch }}-compilers
+          name: Asserts-Windows-${{ inputs.build_arch }}-compilers
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         if: matrix.os != 'Android' || inputs.build_android
@@ -2511,7 +2517,7 @@ jobs:
       - name: Download Compilers
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Windows-${{ inputs.build_arch }}-compilers
+          name: Asserts-Windows-${{ inputs.build_arch }}-compilers
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
@@ -2527,7 +2533,7 @@ jobs:
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Windows-${{ matrix.arch }}-swift-syntax
+          name: Asserts-Windows-${{ matrix.arch }}-swift-syntax
           path: ${{ github.workspace }}/BinaryCache/swift-syntax
       - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
@@ -3217,7 +3223,7 @@ jobs:
       - name: Download Compilers
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Windows-${{ inputs.build_arch }}-compilers
+          name: Asserts-Windows-${{ inputs.build_arch }}-compilers
           path: ${{ github.workspace }}/BinaryCache/Library
       - name: Download stdlib
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
@@ -3327,7 +3333,7 @@ jobs:
       - name: Download Compilers
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
-          name: Windows-${{ matrix.arch }}-compilers
+          name: Asserts-Windows-${{ matrix.arch }}-compilers
           path: ${{ github.workspace }}/BuildRoot/Library
 
       - name: Download Developer Tools


### PR DESCRIPTION
Add `variant` to the compilers matrix and update downstream steps.