### PR TITLE
GHA: adjust the ds2 prefix for Android ARMv7

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -456,7 +456,7 @@ jobs:
             cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
             os: Android
             extra_flags: -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a
-            module_triple: armv7-unknown-linux-androideabi
+            module_triple: armv7-unknown-linux-android
 
           - arch: i686
             cc: clang


### PR DESCRIPTION
This is now properly normalised to the expected triple (armv7-unknown-linux-android). Account for this in the build so that we don't have to shuffle files for the installer packaging.