### PR TITLE
Add custom sccache setup action

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -30,7 +30,8 @@ runs:
     - name: Configure caching enviornment
       shell: pwsh
       run: |
-        if (${{ inputs.s3-arn }} -ne '') {
+        $AWSArn = '${{ inputs.aws-arn }}'
+        if ($AWSArn -ne '') {
           $requiredParams = @{
               's3-bucket' = '${{ inputs.s3-bucket }}'
               's3-bucket-encryption' = '${{ inputs.s3-bucket-encryption }}'
@@ -44,12 +45,12 @@ runs:
           }
 
           Write-Host "Using S3 bucket ${{ inputs.s3-bucket }} for cache storage."
-          $env:SCCACHE_BUCKET = ${{ inputs.s3-bucket }}
-          $env:SCCACHE_REGION = ${{ inputs.aws-region }}
-          $env:SCCACHE_S3_SERVER_SIDE_ENCRYPTION = ${{ inputs.s3-bucket-encryption }}
+          "SCCACHE_BUCKET=${{ inputs.s3-bucket }}" >> $env:GITHUB_ENV
+          "SCCACHE_REGION=${{ inputs.aws-region }}" >> $env:GITHUB_ENV
+          "SCCACHE_S3_SERVER_SIDE_ENCRYPTION=${{ inputs.s3-bucket-encryption }}" >> $env:GITHUB_ENV
         } else {
           Write-Host "Using local disk cache."
-          $env:SCCACHE_DIRECT = 'on'
+          "SCCACHE_DIRECT='on'" >> $env:GITHUB_ENV
         }
 
     - name: Authenticate to AWS

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -11,7 +11,6 @@ inputs:
   s3-bucket:
     description: "The s3 bucket to use for cache storage."
     required: false
-    default: "toolchain-sccache-swift-build"
   s3-bucket-encryption:
     description: "Whether to enable server-side encryption for the S3 bucket."
     required: false
@@ -22,7 +21,6 @@ inputs:
   aws-region:
     description: "The region of the S3 bucket to use for the cache"
     required: false
-    default: "us-east-2"
 
 runs:
   using: composite
@@ -62,7 +60,7 @@ runs:
         aws-region: ${{ inputs.aws-region }}
 
     - name: Setup sccache
-      uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
+      uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.17
       with:
         max-size: ${{ inputs.disk-max-size }}
         key: ${{ inputs.disk-cache-key }}

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -29,7 +29,7 @@ runs:
       shell: pwsh
       run: |
         $AWSArn = '${{ inputs.aws-arn }}'
-        if ($AWSArn -ne '') {
+        if ($AWSArn) {
           $requiredParams = @{
               's3-bucket' = '${{ inputs.s3-bucket }}'
               's3-bucket-encryption' = '${{ inputs.s3-bucket-encryption }}'
@@ -43,12 +43,12 @@ runs:
           }
 
           Write-Host "Using S3 bucket ${{ inputs.s3-bucket }} for cache storage."
-          "SCCACHE_BUCKET=${{ inputs.s3-bucket }}" >> $env:GITHUB_ENV
-          "SCCACHE_REGION=${{ inputs.aws-region }}" >> $env:GITHUB_ENV
-          "SCCACHE_S3_SERVER_SIDE_ENCRYPTION=${{ inputs.s3-bucket-encryption }}" >> $env:GITHUB_ENV
+          Write-Host SCCACHE_BUCKET=${{ inputs.s3-bucket }} | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host SCCACHE_REGION=${{ inputs.aws-region }} | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host SCCACHE_S3_SERVER_SIDE_ENCRYPTION=${{ inputs.s3-bucket-encryption }} | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         } else {
           Write-Host "Using local disk cache."
-          "SCCACHE_DIRECT='on'" >> $env:GITHUB_ENV
+          Write-Host SCCACHE_DIRECT='on' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         }
 
     - name: Authenticate to AWS

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -31,6 +31,18 @@ runs:
       shell: pwsh
       run: |
         if (${{ inputs.s3-arn }} -ne '') {
+          $requiredParams = @{
+              's3-bucket' = '${{ inputs.s3-bucket }}'
+              's3-bucket-encryption' = '${{ inputs.s3-bucket-encryption }}'
+              'aws-region' = '${{ inputs.aws-region }}'
+          }
+
+          foreach ($param in $requiredParams.GetEnumerator()) {
+              if ([string]::IsNullOrEmpty($param.Value)) {
+                  Write-Error -Message "$($param.Key) input cannot be empty when aws-arn is provided" -ErrorAction Stop
+              }
+          }
+
           Write-Host "Using S3 bucket ${{ inputs.s3-bucket }} for cache storage."
           $env:SCCACHE_BUCKET = ${{ inputs.s3-bucket }}
           $env:SCCACHE_REGION = ${{ inputs.aws-region }}

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -1,0 +1,56 @@
+name: "Setup sccache"
+description: "Sets up sccache with S3 or local disk configuration"
+
+inputs:
+  disk-max-size:
+    description: "The maximum size of the local disk cache in MB if S3 is unavailable."
+    required: true
+  disk-cache-key:
+    description: "The key to use for the local disk cache."
+    required: true
+  s3-bucket:
+    description: "The s3 bucket to use for cache storage."
+    required: false
+    default: "toolchain-sccache-swift-build"
+  s3-bucket-encryption:
+    description: "Whether to enable server-side encryption for the S3 bucket."
+    required: false
+    default: "true"
+  aws-arn:
+    description: "The ARN of the AWS role to assume which has read/write access to the S3 bucket."
+    required: false
+  aws-region:
+    description: "The region of the S3 bucket to use for the cache"
+    required: false
+    default: "us-east-2"
+
+runs:
+  using: composite
+  steps:
+    - name: Configure caching enviornment
+      shell: pwsh
+      run: |
+        if (${{ inputs.s3-arn }} -ne '') {
+          Write-Host "Using S3 bucket ${{ inputs.s3-bucket }} for cache storage."
+          $env:SCCACHE_BUCKET = ${{ inputs.s3-bucket }}
+          $env:SCCACHE_REGION = ${{ inputs.aws-region }}
+          $env:SCCACHE_S3_SERVER_SIDE_ENCRYPTION = ${{ inputs.s3-bucket-encryption }}
+        } else {
+          Write-Host "Using local disk cache."
+          $env:SCCACHE_DIRECT = 'on'
+        }
+
+    - name: Authenticate to AWS
+      uses: aws-actions/configure-aws-credentials@v3
+      if: inputs.aws-arn != ''
+      with:
+        role-to-assume: ${{ inputs.aws-arn }}
+        role-session-name: ToolchainCISccacheAccess
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Setup sccache
+      uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
+      with:
+        max-size: ${{ inputs.disk-max-size }}
+        key: ${{ inputs.disk-cache-key }}
+        variant: sccache

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -343,7 +343,7 @@ jobs:
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
 
       - name: Setup sccache
-        uses: ./.github/actions/setup-sccache
+        uses: ./SourceCache/swift-build/.github/actions/setup-sccache
         with:
           disk-max-size: 100M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-sqlite

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -343,11 +343,10 @@ jobs:
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
 
       - name: Setup sccache
-        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
+        uses: ./.github/actions/setup-sccache
         with:
-          max-size: 100M
-          key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-sqlite
-          variant: sccache
+          disk-max-size: 100M
+          disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-sqlite
 
       - name: Configure SQLite
         run: |
@@ -589,11 +588,10 @@ jobs:
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
 
       - name: Setup sccache
-        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
+        uses: ./.github/actions/setup-sccache
         with:
-          max-size: 1M
-          key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-cmark-gfm
-          variant: sccache
+          disk-max-size: 1M
+          disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-cmark-gfm
 
       - name: Configure cmark-gfm
         run: >
@@ -673,11 +671,10 @@ jobs:
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
 
       - name: Setup sccache
-        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
+        uses: ./.github/actions/setup-sccache
         with:
-          max-size: 100M
-          key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-build_tools
-          variant: sccache
+          disk-max-size: 100M
+          disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-build_tools
 
       - name: Configure Tools
         run: |
@@ -1070,11 +1067,10 @@ jobs:
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
 
       - name: Setup sccache
-        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
+        uses: ./.github/actions/setup-sccache
         with:
-          max-size: 500M
-          key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.variant }}-compilers
-          variant: sccache
+          disk-max-size: 500M
+          disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.variant }}-compilers
 
       - name: Setup context
         id: setup-context
@@ -1345,11 +1341,10 @@ jobs:
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
 
       - name: Setup sccache
-        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
+        uses: ./.github/actions/setup-sccache
         with:
-          max-size: 100M
-          key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-zlib
-          variant: sccache
+          disk-max-size: 100M
+          disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-zlib
 
       - uses: nttld/setup-ndk@v1
         if: matrix.os == 'Android'
@@ -1440,11 +1435,10 @@ jobs:
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
 
       - name: Setup sccache
-        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
+        uses: ./.github/actions/setup-sccache
         with:
-          max-size: 100M
-          key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-curl
-          variant: sccache
+          disk-max-size: 100M
+          disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-curl
 
       - uses: nttld/setup-ndk@v1
         if: matrix.os == 'Android'
@@ -1607,11 +1601,10 @@ jobs:
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
 
       - name: Setup sccache
-        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
+        uses: ./.github/actions/setup-sccache
         with:
-          max-size: 100M
-          key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-libxml2
-          variant: sccache
+          disk-max-size: 100M
+          disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-libxml2
 
       - uses: nttld/setup-ndk@v1
         if: matrix.os == 'Android'

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -564,7 +564,7 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/swift-build
           show-progress: false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           repository: swiftlang/swift-cmark
           ref: ${{ inputs.swift_cmark_revision }}
@@ -636,7 +636,7 @@ jobs:
     name: ${{ matrix.os }} ${{ matrix.arch }} Compiler Build Tools
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           path: ${{ github.workspace }}/SourceCache/swift-build
           show-progress: false
@@ -922,7 +922,7 @@ jobs:
     name: ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.variant }} Toolchain
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           path: ${{ github.workspace }}/SourceCache/swift-build
           show-progress: false
@@ -1332,7 +1332,7 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/swift-build
           show-progress: false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           repository: madler/zlib
           ref: ${{ inputs.zlib_revision }}
@@ -1426,7 +1426,7 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/swift-build
           show-progress: false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           repository: curl/curl
           ref: ${{ inputs.curl_revision }}
@@ -1601,7 +1601,7 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/swift-build
           show-progress: false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           repository: gnome/libxml2
           ref: ${{ inputs.libxml2_revision }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -561,6 +561,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
+          path: ${{ github.workspace }}/SourceCache/swift-build
+          show-progress: false
+
+      - uses: actions/checkout@v4
+        with:
           repository: swiftlang/swift-cmark
           ref: ${{ inputs.swift_cmark_revision }}
           path: ${{ github.workspace }}/SourceCache/cmark-gfm
@@ -588,7 +593,7 @@ jobs:
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
 
       - name: Setup sccache
-        uses: ./.github/actions/setup-sccache
+        uses: ./SourceCache/swift-build/.github/actions/setup-sccache
         with:
           disk-max-size: 1M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-cmark-gfm
@@ -631,6 +636,11 @@ jobs:
     name: ${{ matrix.os }} ${{ matrix.arch }} Compiler Build Tools
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          path: ${{ github.workspace }}/SourceCache/swift-build
+          show-progress: false
+
       - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
           name: ${{ matrix.os }}-${{ matrix.arch }}-cmark-gfm-${{ inputs.swift_cmark_version }}
@@ -671,7 +681,7 @@ jobs:
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
 
       - name: Setup sccache
-        uses: ./.github/actions/setup-sccache
+        uses: ./SourceCache/swift-build/.github/actions/setup-sccache
         with:
           disk-max-size: 100M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-build_tools
@@ -912,6 +922,11 @@ jobs:
     name: ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.variant }} Toolchain
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          path: ${{ github.workspace }}/SourceCache/swift-build
+          show-progress: false
+
       - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
           name: ${{ inputs.build_os }}-${{ inputs.build_arch }}-build-tools
@@ -1067,7 +1082,7 @@ jobs:
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
 
       - name: Setup sccache
-        uses: ./.github/actions/setup-sccache
+        uses: ./SourceCache/swift-build/.github/actions/setup-sccache
         with:
           disk-max-size: 500M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.variant }}-compilers
@@ -1314,6 +1329,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
+          path: ${{ github.workspace }}/SourceCache/swift-build
+          show-progress: false
+
+      - uses: actions/checkout@v4
+        with:
           repository: madler/zlib
           ref: ${{ inputs.zlib_revision }}
           path: ${{ github.workspace }}/SourceCache/zlib
@@ -1341,7 +1361,7 @@ jobs:
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
 
       - name: Setup sccache
-        uses: ./.github/actions/setup-sccache
+        uses: ./SourceCache/swift-build/.github/actions/setup-sccache
         with:
           disk-max-size: 100M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-zlib
@@ -1403,6 +1423,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
+          path: ${{ github.workspace }}/SourceCache/swift-build
+          show-progress: false
+
+      - uses: actions/checkout@v4
+        with:
           repository: curl/curl
           ref: ${{ inputs.curl_revision }}
           path: ${{ github.workspace }}/SourceCache/curl
@@ -1435,7 +1460,7 @@ jobs:
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
 
       - name: Setup sccache
-        uses: ./.github/actions/setup-sccache
+        uses: ./SourceCache/swift-build/.github/actions/setup-sccache
         with:
           disk-max-size: 100M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-curl
@@ -1573,6 +1598,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
+          path: ${{ github.workspace }}/SourceCache/swift-build
+          show-progress: false
+
+      - uses: actions/checkout@v4
+        with:
           repository: gnome/libxml2
           ref: ${{ inputs.libxml2_revision }}
           path: ${{ github.workspace }}/SourceCache/libxml2
@@ -1601,7 +1631,7 @@ jobs:
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
 
       - name: Setup sccache
-        uses: ./.github/actions/setup-sccache
+        uses: ./SourceCache/swift-build/.github/actions/setup-sccache
         with:
           disk-max-size: 100M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-libxml2


### PR DESCRIPTION
This wraps our usage of sccache in a custom action that will configure either direct usage, or s3 usage based on whether or not you've passed in an AWS ARN that can be used to authenticate to an S3 bucket when setting up sccache.

A side effect of this is that we will have to checkout the `swift-build` repo in order to gain access to the action that we're authoring.