### PR TITLE
Add dynamic configuration of sccache based on available environment variables

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -43,12 +43,12 @@ runs:
           }
 
           Write-Host "Using S3 bucket ${{ inputs.s3-bucket }} for cache storage."
-          Write-Host SCCACHE_BUCKET=${{ inputs.s3-bucket }} | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          Write-Host SCCACHE_REGION=${{ inputs.aws-region }} | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          Write-Host SCCACHE_S3_SERVER_SIDE_ENCRYPTION=${{ inputs.s3-bucket-encryption }} | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "SCCACHE_BUCKET=${{ inputs.s3-bucket }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "SCCACHE_REGION=${{ inputs.aws-region }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "SCCACHE_S3_SERVER_SIDE_ENCRYPTION=${{ inputs.s3-bucket-encryption }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         } else {
           Write-Host "Using local disk cache."
-          Write-Host SCCACHE_DIRECT='on' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "SCCACHE_DIRECT=on" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         }
 
     - name: Authenticate to AWS

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -146,8 +146,6 @@ on:
       PASSPHRASE:
         required: true
 
-env:
-  SCCACHE_DIRECT: yes
 
 jobs:
   context:
@@ -788,6 +786,9 @@ jobs:
   windows-build:
     needs: [context]
     name: Windows Swift Toolchains Build
+    permissions:
+      contents: read
+      id-token: write
 
     uses: ./.github/workflows/swift-toolchain.yml
     with:
@@ -866,6 +867,10 @@ jobs:
     if: false
     needs: [context]
     name: macOS Swift Toolchains Build
+    permissions:
+      contents: read
+      id-token: write
+
     uses: ./.github/workflows/swift-toolchain.yml
     with:
       build_os: Darwin

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -273,8 +273,6 @@ on:
         required: true
 
 env:
-  SCCACHE_DIRECT: on
-
   # Workaround for needing llvm-17 on macOS preventing us from using the 5.10 toolchain release.
   WORKAROUND_MACOS_PINNED_BOOTSTRAP_TOOLCHAIN_BRANCH: swift-6.0.1-release
   WORKAROUND_MACOS_PINNED_BOOTSTRAP_TOOLCHAIN_TAG: 6.0.1-RELEASE
@@ -345,6 +343,9 @@ jobs:
       - name: Setup sccache
         uses: ./SourceCache/swift-build/.github/actions/setup-sccache
         with:
+          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
+          aws-region: ${{ vars.SCCACHE_AWS_REGION }}
+          aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
           disk-max-size: 100M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-sqlite
 
@@ -595,6 +596,9 @@ jobs:
       - name: Setup sccache
         uses: ./SourceCache/swift-build/.github/actions/setup-sccache
         with:
+          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
+          aws-region: ${{ vars.SCCACHE_AWS_REGION }}
+          aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
           disk-max-size: 1M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-cmark-gfm
 
@@ -683,6 +687,9 @@ jobs:
       - name: Setup sccache
         uses: ./SourceCache/swift-build/.github/actions/setup-sccache
         with:
+          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
+          aws-region: ${{ vars.SCCACHE_AWS_REGION }}
+          aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
           disk-max-size: 100M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-build_tools
 
@@ -1084,6 +1091,9 @@ jobs:
       - name: Setup sccache
         uses: ./SourceCache/swift-build/.github/actions/setup-sccache
         with:
+          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
+          aws-region: ${{ vars.SCCACHE_AWS_REGION }}
+          aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
           disk-max-size: 500M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.variant }}-compilers
 
@@ -1363,6 +1373,9 @@ jobs:
       - name: Setup sccache
         uses: ./SourceCache/swift-build/.github/actions/setup-sccache
         with:
+          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
+          aws-region: ${{ vars.SCCACHE_AWS_REGION }}
+          aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
           disk-max-size: 100M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-zlib
 
@@ -1462,6 +1475,9 @@ jobs:
       - name: Setup sccache
         uses: ./SourceCache/swift-build/.github/actions/setup-sccache
         with:
+          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
+          aws-region: ${{ vars.SCCACHE_AWS_REGION }}
+          aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
           disk-max-size: 100M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-curl
 
@@ -1633,6 +1649,9 @@ jobs:
       - name: Setup sccache
         uses: ./SourceCache/swift-build/.github/actions/setup-sccache
         with:
+          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
+          aws-region: ${{ vars.SCCACHE_AWS_REGION }}
+          aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
           disk-max-size: 100M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-libxml2
 


### PR DESCRIPTION
We want to dynamically upgrade the sccache configuration if S3 access via SSO is setup. To do this while preserving backward disk caching compatibility we specify 3 new environment variables:
- `SCCACHE_S3_BUCKET`
- `SCCACHE_AWS_REGION `
- `SCCACHE_AWS_ARN `

If the `SCCACHE_AWS_ARN` is set the sccache action will attempt to validate that the other two values are not null or an empty string before pushing them into the environment for sccache to pick up.

We have to also specify `id-token: write` permissions at the top level entry points into the CI process since github tokens cannot be upgraded when workflows get called (they can only get downgraded) so we have to put the complete set of permissions at the root of CI.