### PR TITLE
Create vfs-overlay.yaml on demand

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2016,7 +2016,7 @@ jobs:
                   type: file
                   external-contents: "${ModuleMapDir}/vcruntime.apinotes"
           "@
-          $VfsOverlayDir = Split-Path -parent $VfsOverlay
+          $VfsOverlayDir = Split-Path -Parent $VfsOverlay
           New-Item -ItemType Directory -Path $VfsOverlayDir
           Write-Output $ModuleMap | Out-File -FilePath $VfsOverlay -Encoding utf8
 
@@ -2380,7 +2380,7 @@ jobs:
                   external-contents: "${ModuleMapDir}/vcruntime.apinotes"
           "@
 
-          $VfsOverlayDir = Split-Path -parent $VfsOverlay
+          $VfsOverlayDir = Split-Path -Parent $VfsOverlay
           New-Item -ItemType Directory -Path $VfsOverlayDir
           Write-Output $ModuleMap | Out-File -FilePath $VfsOverlay -Encoding utf8
 

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1882,25 +1882,12 @@ jobs:
             Remove-Item env:\SDKROOT
           }
           cmake --build ${{ github.workspace }}/BinaryCache/swift --target install
-      - name: Parameterize vfs-overlay
-        if: matrix.os == 'Windows'
-        run: |
-          $VfsOverlay = "${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml"
-          $ModuleMapDir = cygpath -m ${{ github.workspace }}/SourceCache/swift/stdlib
-          $ModuleMapDir += "\\public\\Platform\\"
-          (Get-Content $VfsOverlay).Replace("${ModuleMapDir}", "<MODULE_MAP_DIR>/") | Set-Content $VfsOverlay
 
       - uses: thebrowsercompany/gha-upload-tar-artifact@e18c33b1cd416d0d96a91dc6dce06219f98e4e27 # main
         if: matrix.os != 'Android' || inputs.build_android
         with:
           name: ${{ matrix.os }}-${{ matrix.arch }}-stdlib
           path: ${{ github.workspace }}/BuildRoot/Library
-
-      - uses: actions/upload-artifact@v4
-        if: matrix.os == 'Windows'
-        with:
-          name: ${{ matrix.os }}-${{ matrix.arch }}-vfs-overlay
-          path: ${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml
 
       - name: Upload PDBs to Azure
         uses: microsoft/action-publish-symbols@v2.1.6
@@ -1952,10 +1939,6 @@ jobs:
         with:
           name: Windows-${{ inputs.build_arch }}-stdlib
           path: ${{ github.workspace }}/BinaryCache/Library
-      - uses: actions/download-artifact@v4
-        with:
-          name: Windows-${{ matrix.arch }}-vfs-overlay
-          path: ${{ github.workspace }}/BinaryCache/swift/stdlib
       - uses: actions/checkout@v4.2.2
         with:
           repository: swiftlang/swift
@@ -1987,15 +1970,55 @@ jobs:
           $RTLPath = cygpath -w ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/bin
           echo ${RTLPath} | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - name: Extract swift-syntax and vfs-overlay
+      - name: Extract swift-syntax
         run: |
           $module = "${{ github.workspace }}/BinaryCache/swift-syntax/cmake/modules/SwiftSyntaxConfig.cmake"
           $bindir = cygpath -m ${{ github.workspace }}/BinaryCache/swift-syntax
           (Get-Content $module).Replace('<BINARY_DIR>', "${bindir}") | Set-Content $module
 
+      - name: Create vfs-overlay
+        run: |
           $VfsOverlay = "${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml"
           $ModuleMapDir = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share
-          (Get-Content $VfsOverlay).Replace("<MODULE_MAP_DIR>", "${ModuleMapDir}") | Set-Content $VfsOverlay
+          $Win10SdkRoot = Get-ItemPropertyValue `
+            -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots" `
+            -Name "KitsRoot10"
+          $Win10SdkRoot = cygpath -m ${Win10SdkRoot}
+          $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
+          $VsWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
+          $VsInstallPath = (& "$VsWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
+          $VsInstallPath = cygpath -m ${VsInstallPath}
+
+          $ModuleMap = @"
+          version: 0
+          use-external-names: false
+          case-sensitive: false
+          roots:
+            - name: "${Win10SdkRoot}/Include/${env:WORKAROUND_WINDOWS_SDK_VERSION}/um"
+              type: directory
+              contents:
+                - name: module.modulemap
+                  type: file
+                  external-contents: "${ModuleMapDir}/winsdk.modulemap"
+            - name: "${Win10SdkRoot}/Include/${env:WORKAROUND_WINDOWS_SDK_VERSION}/ucrt"
+              type: directory
+              contents:
+                - name: module.modulemap
+                  type: file
+                  external-contents: "${ModuleMapDir}/ucrt.modulemap"
+            - name: "${VsInstallPath}/VC/Tools/MSVC/${env:WORKAROUND_WINDOWS_COMPILER_VERSION}/include"
+              type: directory
+              contents:
+                - name: module.modulemap
+                  type: file
+                  external-contents: "${ModuleMapDir}/vcruntime.modulemap"
+                - name: vcruntime.apinotes
+                  type: file
+                  external-contents: "${ModuleMapDir}/vcruntime.apinotes"
+          "@
+          $VfsOverlayDir = Split-Path -parent $VfsOverlay
+          New-Item -ItemType Directory -Path $VfsOverlayDir
+          Write-Output $ModuleMap | Out-File -FilePath $VfsOverlay -Encoding utf8
 
       - name: Configure Foundation Macros
         run: |
@@ -2202,11 +2225,6 @@ jobs:
           name: Windows-${{ inputs.build_arch }}-stdlib
           path: ${{ github.workspace }}/BinaryCache/Library
       - uses: actions/download-artifact@v4
-        if: matrix.os == 'Windows'
-        with:
-          name: Windows-${{ matrix.arch }}-vfs-overlay
-          path: ${{ github.workspace }}/BinaryCache/swift/stdlib
-      - uses: actions/download-artifact@v4
         if: matrix.os != 'Android' || inputs.build_android
         with:
           name: Windows-${{ inputs.build_arch }}-macros
@@ -2320,12 +2338,51 @@ jobs:
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
 
-      - name: Extract vfs-overlay
+      - name: Create vfs-overlay
         if: matrix.os == 'Windows'
         run: |
           $VfsOverlay = "${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml"
           $ModuleMapDir = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share
-          (Get-Content $VfsOverlay).Replace("<MODULE_MAP_DIR>", "${ModuleMapDir}") | Set-Content $VfsOverlay
+          $Win10SdkRoot = Get-ItemPropertyValue `
+            -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots" `
+            -Name "KitsRoot10"
+          $Win10SdkRoot = cygpath -m ${Win10SdkRoot}
+          $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
+          $VsWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
+          $VsInstallPath = (& "$VsWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
+          $VsInstallPath = cygpath -m ${VsInstallPath}
+
+          $ModuleMap = @"
+          version: 0
+          use-external-names: false
+          case-sensitive: false
+          roots:
+            - name: "${Win10SdkRoot}/Include/${env:WORKAROUND_WINDOWS_SDK_VERSION}/um"
+              type: directory
+              contents:
+                - name: module.modulemap
+                  type: file
+                  external-contents: "${ModuleMapDir}/winsdk.modulemap"
+            - name: "${Win10SdkRoot}/Include/${env:WORKAROUND_WINDOWS_SDK_VERSION}/ucrt"
+              type: directory
+              contents:
+                - name: module.modulemap
+                  type: file
+                  external-contents: "${ModuleMapDir}/ucrt.modulemap"
+            - name: "${VsInstallPath}/VC/Tools/MSVC/${env:WORKAROUND_WINDOWS_COMPILER_VERSION}/include"
+              type: directory
+              contents:
+                - name: module.modulemap
+                  type: file
+                  external-contents: "${ModuleMapDir}/vcruntime.modulemap"
+                - name: vcruntime.apinotes
+                  type: file
+                  external-contents: "${ModuleMapDir}/vcruntime.apinotes"
+          "@
+
+          $VfsOverlayDir = Split-Path -parent $VfsOverlay
+          New-Item -ItemType Directory -Path $VfsOverlayDir
+          Write-Output $ModuleMap | Out-File -FilePath $VfsOverlay -Encoding utf8
 
       - name: Configure libdispatch
         if: matrix.os != 'Android' || inputs.build_android

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1882,6 +1882,13 @@ jobs:
             Remove-Item env:\SDKROOT
           }
           cmake --build ${{ github.workspace }}/BinaryCache/swift --target install
+      - name: Parameterize vfs-overlay
+        if: matrix.os == 'Windows'
+        run: |
+          $VfsOverlay = "${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml"
+          $ModuleMapDir = cygpath -m ${{ github.workspace }}/SourceCache/swift/stdlib
+          $ModuleMapDir += "\\public\\Platform\\"
+          (Get-Content $VfsOverlay).Replace("${ModuleMapDir}", "<MODULE_MAP_DIR>/") | Set-Content $VfsOverlay
 
       - uses: thebrowsercompany/gha-upload-tar-artifact@e18c33b1cd416d0d96a91dc6dce06219f98e4e27 # main
         if: matrix.os != 'Android' || inputs.build_android
@@ -1980,11 +1987,15 @@ jobs:
           $RTLPath = cygpath -w ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/bin
           echo ${RTLPath} | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - name: extract swift-syntax
+      - name: Extract swift-syntax and vfs-overlay
         run: |
           $module = "${{ github.workspace }}/BinaryCache/swift-syntax/cmake/modules/SwiftSyntaxConfig.cmake"
           $bindir = cygpath -m ${{ github.workspace }}/BinaryCache/swift-syntax
           (Get-Content $module).Replace('<BINARY_DIR>', "${bindir}") | Set-Content $module
+
+          $VfsOverlay = "${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml"
+          $ModuleMapDir = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share
+          (Get-Content $VfsOverlay).Replace("<MODULE_MAP_DIR>", "${ModuleMapDir}") | Set-Content $VfsOverlay
 
       - name: Configure Foundation Macros
         run: |
@@ -2308,6 +2319,13 @@ jobs:
         id: setup-ndk
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
+
+      - name: Extract vfs-overlay
+        if: matrix.os == 'Windows'
+        run: |
+          $VfsOverlay = "${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml"
+          $ModuleMapDir = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share
+          (Get-Content $VfsOverlay).Replace("<MODULE_MAP_DIR>", "${ModuleMapDir}") | Set-Content $VfsOverlay
 
       - name: Configure libdispatch
         if: matrix.os != 'Android' || inputs.build_android


### PR DESCRIPTION
`vfs-overlay.yaml` created as part of the `stdlib` step refers to paths from the `swift` source directory, which may not be available in subsequent jobs, causing build issues. These changes generate a `vfs-overlay.yaml` file on demand for jobs that need it, to work around the issue.