### PR TITLE
Only setup local cache when arn is missing

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -67,6 +67,7 @@ runs:
         variant: sccache
 
     - name: Setup sccache (local)
+      if: inputs.aws-arn == ''
       uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.17
       with:
         max-size: ${{ inputs.disk-max-size }}


### PR DESCRIPTION
We should only setup the local cache when the arn is missing for s3 usage. Otherwise we will try to spawn two different configurations of sccache.