### PR TITLE
GHA: enable caching of the NDK

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -515,6 +515,7 @@ jobs:
         id: setup-ndk
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
+          local-cache: true
 
       - name: Configure DS2
         if: inputs.build_android
@@ -1075,6 +1076,7 @@ jobs:
         id: setup-ndk
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
+          local-cache: true
 
       - name: Compute workspace hash
         id: workspace_hash
@@ -1384,6 +1386,7 @@ jobs:
         id: setup-ndk
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
+          local-cache: true
 
       - name: Configure zlib
         run: |
@@ -1486,6 +1489,7 @@ jobs:
         id: setup-ndk
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
+          local-cache: true
 
       - name: Configure curl
         run: |
@@ -1660,6 +1664,7 @@ jobs:
         id: setup-ndk
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
+          local-cache: true
 
       - name: Configure libxml2
         run: |
@@ -1783,6 +1788,7 @@ jobs:
         id: setup-ndk
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
+          local-cache: true
 
       - name: Configure LLVM
         if: matrix.os != 'Android' || inputs.build_android
@@ -2361,6 +2367,7 @@ jobs:
         id: setup-ndk
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
+          local-cache: true
 
       - name: Create vfs-overlay
         if: matrix.os == 'Windows'


### PR DESCRIPTION
Enable caching for the NDK when installing to speed up subsequent installations. This is important as the Android NDK installation takes ~6x longer than the longest step for jobs such as zlib.