### PR TITLE
GHA: enable `_Builtin_float` on android

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -545,7 +545,7 @@ jobs:
                   "extra_flags": "-D CMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -D CMAKE_ANDROID_ARCH_ABI=arm64-v8a",
                   "sdk_install_dir": "${env:GITHUB_WORKSPACE}/BuildRoot/Library/Developer/Platforms/Android.platform/Developer/SDKs/Android.sdk/usr",
                   "llvm_cmake_flags": "-D LLVM_HOST_TRIPLE=aarch64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}",
-                  "stdlib_cmake_flags": "-D SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -D LLVM_ENABLE_LIBCXX=YES -D SWIFT_USE_LINKER=lld -D CMAKE_SYSTEM_PROCESSOR=aarch64"
+                  "stdlib_cmake_flags": "-D LLVM_ENABLE_LIBCXX=YES -D SWIFT_USE_LINKER=lld -D CMAKE_SYSTEM_PROCESSOR=aarch64"
                 },
                 {
                   "arch": "armv7",
@@ -564,7 +564,7 @@ jobs:
                   "extra_flags": "-D CMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -D CMAKE_ANDROID_ARCH_ABI=armeabi-v7a",
                   "sdk_install_dir": "${env:GITHUB_WORKSPACE}/BuildRoot/Library/Developer/Platforms/Android.platform/Developer/SDKs/Android.sdk/usr",
                   "llvm_cmake_flags": "-D LLVM_HOST_TRIPLE=armv7a-unknown-linux-androideabi${{ inputs.ANDROID_API_LEVEL }}",
-                  "stdlib_cmake_flags": "-D SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -D LLVM_ENABLE_LIBCXX=YES -D SWIFT_USE_LINKER=lld -D CMAKE_SYSTEM_PROCESSOR=armv7-a"
+                  "stdlib_cmake_flags": "-D LLVM_ENABLE_LIBCXX=YES -D SWIFT_USE_LINKER=lld -D CMAKE_SYSTEM_PROCESSOR=armv7-a"
                 },
                 {
                   "arch": "i686",
@@ -583,7 +583,7 @@ jobs:
                   "extra_flags": "-D CMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -D CMAKE_ANDROID_ARCH_ABI=x86",
                   "sdk_install_dir": "${env:GITHUB_WORKSPACE}/BuildRoot/Library/Developer/Platforms/Android.platform/Developer/SDKs/Android.sdk/usr",
                   "llvm_cmake_flags": "-D LLVM_HOST_TRIPLE=i686-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}",
-                  "stdlib_cmake_flags": "-D SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -D LLVM_ENABLE_LIBCXX=YES -D SWIFT_USE_LINKER=lld -D CMAKE_SYSTEM_PROCESSOR=i686"
+                  "stdlib_cmake_flags": "-D LLVM_ENABLE_LIBCXX=YES -D SWIFT_USE_LINKER=lld -D CMAKE_SYSTEM_PROCESSOR=i686"
                 },
                 {
                   "arch": "x86_64",
@@ -602,7 +602,7 @@ jobs:
                   "extra_flags": "-D CMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -D CMAKE_ANDROID_ARCH_ABI=x86_64",
                   "sdk_install_dir": "${env:GITHUB_WORKSPACE}/BuildRoot/Library/Developer/Platforms/Android.platform/Developer/SDKs/Android.sdk/usr",
                   "llvm_cmake_flags": "-D LLVM_HOST_TRIPLE=x86_64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}",
-                  "stdlib_cmake_flags": "-D SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT=YES -D LLVM_ENABLE_LIBCXX=YES -D SWIFT_USE_LINKER=lld -D CMAKE_SYSTEM_PROCESSOR=x86_64"
+                  "stdlib_cmake_flags": "-D LLVM_ENABLE_LIBCXX=YES -D SWIFT_USE_LINKER=lld -D CMAKE_SYSTEM_PROCESSOR=x86_64"
                 }
               ]
             }


### PR DESCRIPTION
This requires the NDK version to be r27 or newer. Since we are now at r27c, enable the builtin float module.