### PR TITLE
Installer: Properly include Android platform

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -4348,8 +4348,8 @@ jobs:
 
       - name: Build installer bundle
         run: |
-          $Platforms=@( "windows" )
-          if (${{ inputs.build_android }}) {
+          $Platforms=@("windows")
+          if ("${{ inputs.build_android }}" -eq "true") {
             $Platforms=@("android") + $Platforms
           }
 


### PR DESCRIPTION
`if (true)` is not valid PowerShell. This updates the test to properly include the Android platform if needed.