### PR TITLE
GHA: adjust build invocation for SourceKit-LSP

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3137,6 +3137,7 @@ jobs:
                 -D ArgumentParser_DIR=${{ github.workspace }}/BinaryCache/swift-argument-parser/cmake/modules `
                 -D IndexStoreDB_DIR=${{ github.workspace }}/BinaryCache/indexstore-db/cmake/modules `
                 -D LLBuild_DIR=${{ github.workspace }}/BinaryCache/swift-llbuild/cmake/modules `
+                -D SwiftASN1_DIR=${{ github.workspace }}/BinaryCache/swift-asn1/cmake/modules `
                 -D SwiftCollections_DIR=${{ github.workspace }}/BinaryCache/swift-collections/cmake/modules `
                 -D SwiftCrypto_DIR=${{ github.workspace }}/BinaryCache/swift-crypto/cmake/modules `
                 -D SwiftPM_DIR=${{ github.workspace }}/BinaryCache/swift-package-manager/cmake/modules `


### PR DESCRIPTION
SourceKit-LSP gained a new dependency on ASN1, update the workflow to accommodate that in the CMake invocation.