### PR TITLE
Add reusable action for MSVC + Win SDK overrides

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: The Windows SDK version to use, e.g. "10.0.22621.0"
     required: false
     type: string
-  windows-msvc-version:
+  msvc-version:
     description: The Windows MSVC version to use, e.g. "14.42"
     required: false
     type: string
@@ -28,9 +28,9 @@ runs:
       shell: pwsh
       run: |
         if ($IsWindows) {
-          $HostOs = "windows"
+          $HostOS = "windows"
         } elseif ($IsMacOS) {
-          $HostOs = "mac"
+          $HostOS = "mac"
         } else {
           Write-Output "::error::Unsupported host OS."
           exit 1
@@ -46,23 +46,23 @@ runs:
           }
         }
 
-        $WinMsvcVersion = "${{ inputs.windows-msvc-version }}"
-        if ($WinMsvcVersion -ne "") {
-          $ParsedWinMsvcVersion = [System.Version]::Parse($WinMsvcVersion)
-          if ($ParsedWinMsvcVersion -eq $null) {
-            Write-Output "::error::Invalid Windows MSVC version: `"${WinMsvcVersion}`"."
+        $MSVCVersion = "${{ inputs.msvc-version }}"
+        if ($MSVCVersion -ne "") {
+          $ParsedMSVCVersion = [System.Version]::Parse($MSVCVersion)
+          if ($ParsedMSVCVersion -eq $null) {
+            Write-Output "::error::Invalid Windows MSVC version: `"${MSVCVersion}`"."
             exit 1
           }
-          if ($ParsedWinMsvcVersion.Major -ne 14) {
-            Write-Output "::error::Unsupported Windows MSVC version (major version not supported): `"${WinMsvcVersion}`"."
+          if ($ParsedMSVCVersion.Major -ne 14) {
+            Write-Output "::error::Unsupported Windows MSVC version (major version not supported): `"${MSVCVersion}`"."
             exit 1
           }
-          if ($ParsedWinMsvcVersion.Build -ne -1) {
-            Write-Output "::error::Unsupported Windows MSVC version (build version was specified): `"${WinMsvcVersion}`"."
+          if ($ParsedMSVCVersion.Build -ne -1) {
+            Write-Output "::error::Unsupported Windows MSVC version (build version was specified): `"${MSVCVersion}`"."
             exit 1
           }
-          if ($ParsedWinMsvcVersion.Revision -ne -1) {
-            Write-Output "::error::Unsupported Windows MSVC version (revision version was specified): `"${WinMsvcVersion}`"."
+          if ($ParsedMSVCVersion.Revision -ne -1) {
+            Write-Output "::error::Unsupported Windows MSVC version (revision version was specified): `"${MSVCVersion}`"."
             exit 1
           }
         }
@@ -78,16 +78,16 @@ runs:
           }
         }
 
-        Write-Output "Host OS: $HostOs"
-        Write-Output "Host architecture: $HostArch"
-        Write-Output "Target architecture: $TargetArch"
+        Write-Output "::info::Build OS: $HostOS"
+        Write-Output "::info::Build architecture: $HostArch"
+        Write-Output "::info::Host OS: $HostOS"
+        Write-Output "::info::Host architecture: $TargetArch"
 
-        $VerifiedInput = @"
-        host-os=$HostOs
+        @"
+        host-os=$HostOS
         host-arch=$HostArch
         target-arch=$TargetArch
-        "@
-        Write-Output $VerifiedInput | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        "@ | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
     - name: Install Windows SDK version ${{ inputs.windows-sdk-version }}
       if: steps.verify-input.outputs.host-os == 'windows' && inputs.windows-sdk-version != ''
@@ -105,16 +105,16 @@ runs:
         $Win10SdkIncludeVersion = Join-Path $Win10SdkInclude $WinSdkVersionString
 
         if (Test-Path -Path $Win10SdkIncludeVersion -PathType Container) {
-          Write-Output "Windows SDK ${WinSdkVersionString} already installed."
+          Write-Output "::info::Windows SDK ${WinSdkVersionString} already installed."
         } else {
           # Install the missing SDK.
           Write-Output "Installing Windows SDK ${WinSdkVersionString}..."
 
           $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
-          $VsWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
-          $VsInstaller = Join-Path "${InstallerLocation}" "vs_installer.exe"
-          $InstallPath = (& "$VsWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
-          $process = Start-Process "$VsInstaller" `
+          $VSWhere = Join-Path "${InstallerLocation}" "VSWhere.exe"
+          $VSInstaller = Join-Path "${InstallerLocation}" "vs_installer.exe"
+          $InstallPath = (& "$VSWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
+          $process = Start-Process "$VSInstaller" `
               -PassThru `
               -ArgumentList "modify", `
                   "--installPath", "`"$InstallPath`"", `
@@ -136,6 +136,8 @@ runs:
 
         # Remove more recent Windows SDKs, if present. This is used to work
         # around issues where LLVM uses the most recent Windows SDK.
+        # This should be removed once a more permanent solution is found.
+        # See https://github.com/compnerd/swift-build/issues/958 for details.
         Get-ChildItem -Path $Win10SdkInclude -Directory | ForEach-Object {
           $IncludeDirName = $_.Name
           try {
@@ -151,65 +153,69 @@ runs:
           }
         }
 
-    - name: Install Windows MSVC version ${{ inputs.windows-msvc-version }}
-      if: steps.verify-input.outputs.host-os == 'windows' && inputs.windows-msvc-version != ''
+    - name: Install Windows MSVC version ${{ inputs.msvc-version }}
+      if: steps.verify-input.outputs.host-os == 'windows' && inputs.msvc-version != ''
       shell: pwsh
       run: |
         # This is assuming a VS2022 toolchain. e.g.
         # MSVC 14.42 corresponds to the 14.42.17.12 package.
         # MSVC 14.43 corresponds to the 14.43.17.13 package.
-        $WinMsvcVersionString = "${{ inputs.windows-msvc-version }}"
+        $MSVCVersionString = "${{ inputs.msvc-version }}"
 
         $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
-        $VsWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
-        $VsInstaller = Join-Path "${InstallerLocation}" "vs_installer.exe"
-        $InstallPath = (& "$VsWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
+        $VSWhere = Join-Path "${InstallerLocation}" "VSWhere.exe"
+        $VSInstaller = Join-Path "${InstallerLocation}" "vs_installer.exe"
+        $InstallPath = (& "$VSWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
         $MSVCDir = Join-Path $InstallPath "VC" "Tools" "MSVC"
 
         # Check if this MSVC version is already installed.
         Get-ChildItem -Path $MSVCDir -Directory | ForEach-Object {
-          $MsvcDirName = $_.Name
-          if ($MsvcDirName.StartsWith($WinMsvcVersionString)) {
-            Write-Output "MSVC ${WinMsvcVersionString} already installed."
+          $MSVCDirName = $_.Name
+          if ($MSVCDirName.StartsWith($MSVCVersionString)) {
+            Write-Output "::info::MSVC ${MSVCVersionString} already installed."
             exit 0
           }
         }
 
-        # Compute the MSVC version package name.
-        $WinMsvcVersion = [System.Version]::Parse($WinMsvcVersionString)
-        $MajorVersion = $WinMsvcVersion.Major
-        $MinorVersion = $WinMsvcVersion.Minor
+        # Compute the MSVC version package name from the MSVC version, assuming this is coming from
+        # a VS2022 installation. The version package follows the following format:
+        # * Major and minor version are the same as the MSVC version.
+        # * Build version is always 17 (VS2002 is VS17).
+        # * The revision is set to the number of minor versions since VS17 release.
+        $MSVCVersion = [System.Version]::Parse($MSVCVersionString)
+        $MajorVersion = $MSVCVersion.Major
+        $MinorVersion = $MSVCVersion.Minor
         $BuildVersion = 17
         $RevisionVersion = $MinorVersion - 30
-        $WinMsvcVersionBuild = "${MajorVersion}.${MinorVersion}.${BuildVersion}.${RevisionVersion}"
+        $MSVCPackageVersion = "${MajorVersion}.${MinorVersion}.${BuildVersion}.${RevisionVersion}"
 
         # Install the missing MSVC version.
-        Write-Output "Installing MSVC packages for ${WinMsvcVersionBuild}..."
-        $process = Start-Process "$VsInstaller" `
+        Write-Output "Installing MSVC packages for ${MSVCPackageVersion}..."
+        $process = Start-Process "$VSInstaller" `
             -PassThru `
             -ArgumentList "modify", `
                 "--installPath", "`"$InstallPath`"", `
                 "--channelId", "https://aka.ms/vs/17/release/channel", `
                 "--quiet", "--norestart", "--nocache", `
-                "--add", "Microsoft.VisualStudio.Component.VC.${WinMsvcVersionBuild}.x86.x64", `
-                "--add", "Microsoft.VisualStudio.Component.VC.${WinMsvcVersionBuild}.ATL", `
-                "--add", "Microsoft.VisualStudio.Component.VC.${WinMsvcVersionBuild}.ARM64", `
-                "--add", "Microsoft.VisualStudio.Component.VC.${WinMsvcVersionBuild}.ATL.ARM64"
+                "--add", "Microsoft.VisualStudio.Component.VC.${MSVCPackageVersion}.x86.x64", `
+                "--add", "Microsoft.VisualStudio.Component.VC.${MSVCPackageVersion}.ATL", `
+                "--add", "Microsoft.VisualStudio.Component.VC.${MSVCPackageVersion}.ARM64", `
+                "--add", "Microsoft.VisualStudio.Component.VC.${MSVCPackageVersion}.ATL.ARM64"
         $process.WaitForExit()
 
         # Check if the MSVC version was installed successfully.
         $MSVCDirFound = $false
-        Get-ChildItem -Path $MSVCDir -Directory | ForEach-Object {
-          $MsvcDirName = $_.Name
-          if ($MsvcDirName.StartsWith($WinMsvcVersionString)) {
-            Write-Output "MSVC ${WinMsvcVersionString} installed successfully."
+        foreach ($dir in Get-ChildItem -Path $MSVCDir -Directory) {
+          $MSVCDirName = $dir.Name
+          if ($MSVCDirName.StartsWith($MSVCVersionString)) {
+            Write-Output "MSVC ${MSVCVersionString} installed successfully."
             $MSVCDirFound = $true
             break
           }
         }
 
         if (-not $MSVCDirFound) {
-          Write-Output "::error::Failed to install MSVC ${WinMsvcVersionString}."
+          Write-Output "::error::Failed to install MSVC ${MSVCVersionString}."
           Write-Output "Installer log:"
           $log = Get-ChildItem "${env:TEMP}" -Filter "dd_installer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
           Get-Content $log.FullName
@@ -222,5 +228,5 @@ runs:
       with:
         host_arch: ${{ steps.verify-input.outputs.host-arch }}
         arch: ${{ steps.verify-input.outputs.target-arch }}
-        winsdk: ${{ inputs.windows-msvc-version }}
-        toolset_version: ${{ inputs.windows-msvc-version }}
+        winsdk: ${{ inputs.msvc-version }}
+        toolset_version: ${{ inputs.msvc-version }}

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -78,10 +78,10 @@ runs:
           }
         }
 
-        Write-Output "::info::Build OS: $HostOS"
-        Write-Output "::info::Build architecture: $HostArch"
-        Write-Output "::info::Host OS: $HostOS"
-        Write-Output "::info::Host architecture: $TargetArch"
+        Write-Output "ℹ️ Host OS: $HostOS"
+        Write-Output "ℹ️ Host architecture: $HostArch"
+        Write-Output "ℹ️ Host OS: $HostOS"
+        Write-Output "ℹ️ Host architecture: $TargetArch"
 
         @"
         host-os=$HostOS
@@ -105,10 +105,10 @@ runs:
         $Win10SdkIncludeVersion = Join-Path $Win10SdkInclude $WinSdkVersionString
 
         if (Test-Path -Path $Win10SdkIncludeVersion -PathType Container) {
-          Write-Output "::info::Windows SDK ${WinSdkVersionString} already installed."
+          Write-Output "ℹ️ MSVCPackageVersionWindows SDK ${WinSdkVersionString} already installed."
         } else {
           # Install the missing SDK.
-          Write-Output "Installing Windows SDK ${WinSdkVersionString}..."
+          Write-Output "ℹ️ Installing Windows SDK ${WinSdkVersionString}..."
 
           $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
           $VSWhere = Join-Path "${InstallerLocation}" "VSWhere.exe"
@@ -124,7 +124,7 @@ runs:
           $process.WaitForExit()
 
           if (Test-Path -Path $Win10SdkIncludeVersion -PathType Container) {
-            Write-Output "Windows SDK ${WinSdkVersionString} installed successfully."
+            Write-Output "ℹ️ Windows SDK ${WinSdkVersionString} installed successfully."
           } else {
             Write-Output "::error::Failed to install Windows SDK ${WinSdkVersionString}."
             Write-Output "Installer log:"
@@ -144,7 +144,7 @@ runs:
             $IncludeDirVersion = [System.Version]::Parse($IncludeDirName)
             if ($IncludeDirVersion -gt $WinSdkVersion) {
               $LibDirVersion = Join-Path $Win10SdkLib $IncludeDirName
-              Write-Output "Removing folders for Windows SDK ${IncludeDirVersion}."
+              Write-Output "ℹ️ Removing folders for Windows SDK ${IncludeDirVersion}."
               Remove-Item -Path $_.FullName -Recurse -Force -ErrorAction Ignore
               Remove-Item -Path $LibDirVersion -Recurse -Force -ErrorAction Ignore
             }
@@ -172,7 +172,7 @@ runs:
         Get-ChildItem -Path $MSVCDir -Directory | ForEach-Object {
           $MSVCDirName = $_.Name
           if ($MSVCDirName.StartsWith($MSVCVersionString)) {
-            Write-Output "::info::MSVC ${MSVCVersionString} already installed."
+            Write-Output "ℹ️ MSVCPackageVersionMSVC ${MSVCVersionString} already installed."
             exit 0
           }
         }
@@ -190,7 +190,7 @@ runs:
         $MSVCPackageVersion = "${MajorVersion}.${MinorVersion}.${BuildVersion}.${RevisionVersion}"
 
         # Install the missing MSVC version.
-        Write-Output "Installing MSVC packages for ${MSVCPackageVersion}..."
+        Write-Output "ℹ️ Installing MSVC packages for ${MSVCPackageVersion}..."
         $process = Start-Process "$VSInstaller" `
             -PassThru `
             -ArgumentList "modify", `
@@ -208,7 +208,7 @@ runs:
         foreach ($dir in Get-ChildItem -Path $MSVCDir -Directory) {
           $MSVCDirName = $dir.Name
           if ($MSVCDirName.StartsWith($MSVCVersionString)) {
-            Write-Output "MSVC ${MSVCVersionString} installed successfully."
+            Write-Output "ℹ️ MSVC ${MSVCVersionString} installed successfully."
             $MSVCDirFound = $true
             break
           }

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -20,11 +20,18 @@ inputs:
     required: false
     type: string
 
+outputs:
+  windows-build-tools-version:
+    description: |
+      The full version of the Windows build tools installed, eg. "14.42.34433". This is only set
+      if the `msvc-version` input was provided, and only on Windows.
+    value: ${{ steps.install-msvc.outputs.windows-build-tools-version }}
+
 runs:
   using: composite
   steps:
-    - name: Verify input
-      id: verify-input
+    - name: Sanitize input
+      id: sanitize-input
       shell: pwsh
       run: |
         if ($IsWindows) {
@@ -71,21 +78,24 @@ runs:
           }
         }
 
-        switch ("${{ inputs.target-arch }}") {
-          "x86" { $TargetArch = "x86" }
-          "amd64" { $TargetArch = "amd64" }
-          "arm64" { $TargetArch = "arm64" }
-          "" { $TargetArch = $HostArch }
-          default {
-            Write-Output "::error::Unsupported target architecture: `"${{ inputs.target-arch }}`""
-            exit 1
+        if ("${{ inputs.setup-vs-dev-env }}" -eq "true") {
+          switch ("${{ inputs.target-arch }}") {
+            "x86" { $TargetArch = "x86" }
+            "amd64" { $TargetArch = "amd64" }
+            "arm64" { $TargetArch = "arm64" }
+            "" { $TargetArch = $HostArch }
+            default {
+              Write-Output "::error::Unsupported target architecture: `"${{ inputs.target-arch }}`""
+              exit 1
+            }
           }
+        } else {
+          $TargetArch = $HostArch
         }
 
         Write-Output "ℹ️ Host OS: $HostOS"
         Write-Output "ℹ️ Host architecture: $HostArch"
-        Write-Output "ℹ️ Host OS: $HostOS"
-        Write-Output "ℹ️ Host architecture: $TargetArch"
+        Write-Output "ℹ️ Target architecture: $TargetArch"
 
         @"
         host-os=$HostOS
@@ -94,7 +104,7 @@ runs:
         "@ | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
     - name: Install Windows SDK version ${{ inputs.windows-sdk-version }}
-      if: steps.verify-input.outputs.host-os == 'windows' && inputs.windows-sdk-version != ''
+      if: steps.sanitize-input.outputs.host-os == 'windows' && inputs.windows-sdk-version != ''
       shell: pwsh
       run: |
         $WinSdkVersionString = "${{ inputs.windows-sdk-version }}"
@@ -158,7 +168,8 @@ runs:
         }
 
     - name: Install Windows MSVC version ${{ inputs.msvc-version }}
-      if: steps.verify-input.outputs.host-os == 'windows' && inputs.msvc-version != ''
+      if: steps.sanitize-input.outputs.host-os == 'windows' && inputs.msvc-version != ''
+      id: setup-msvc
       shell: pwsh
       run: |
         # This is assuming a VS2022 toolchain. e.g.
@@ -171,15 +182,6 @@ runs:
         $VSInstaller = Join-Path "${InstallerLocation}" "vs_installer.exe"
         $InstallPath = (& "$VSWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
         $MSVCDir = Join-Path $InstallPath "VC" "Tools" "MSVC"
-
-        # Check if this MSVC version is already installed.
-        Get-ChildItem -Path $MSVCDir -Directory | ForEach-Object {
-          $MSVCDirName = $_.Name
-          if ($MSVCDirName.StartsWith($MSVCVersionString)) {
-            Write-Output "ℹ️ MSVCPackageVersionMSVC ${MSVCVersionString} already installed."
-            exit 0
-          }
-        }
 
         # Compute the MSVC version package name from the MSVC version, assuming this is coming from
         # a VS2022 installation. The version package follows the following format:
@@ -208,29 +210,32 @@ runs:
         $process.WaitForExit()
 
         # Check if the MSVC version was installed successfully.
-        $MSVCDirFound = $false
+        $MSVCBuildToolsVersion = ""
         foreach ($dir in Get-ChildItem -Path $MSVCDir -Directory) {
           $MSVCDirName = $dir.Name
           if ($MSVCDirName.StartsWith($MSVCVersionString)) {
             Write-Output "ℹ️ MSVC ${MSVCVersionString} installed successfully."
-            $MSVCDirFound = $true
+            $MSVCBuildToolsVersion = $MsvcDirName
             break
           }
         }
 
-        if (-not $MSVCDirFound) {
+        if ($MSVCBuildToolsVersion -eq "") {
           Write-Output "::error::Failed to install MSVC ${MSVCVersionString}."
           Write-Output "Installer log:"
           $log = Get-ChildItem "${env:TEMP}" -Filter "dd_installer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
           Get-Content $log.FullName
           exit 1
+        } else {
+          Write-Output "ℹ️ MSVC ${MSVCBuildToolsVersion} installed successfully."
+          "windows-build-tools-version=${MSVCBuildToolsVersion}" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
         }
 
     - name: Setup Visual Studio Developer Environment
-      if: steps.verify-input.outputs.host-os == 'windows' && inputs.setup-vs-dev-env
+      if: steps.sanitize-input.outputs.host-os == 'windows' && inputs.setup-vs-dev-env == 'true'
       uses: compnerd/gha-setup-vsdevenv@5eb3eae1490d4f7875d574c4973539f69109700d # main
       with:
-        host_arch: ${{ steps.verify-input.outputs.host-arch }}
-        arch: ${{ steps.verify-input.outputs.target-arch }}
-        winsdk: ${{ inputs.msvc-version }}
+        host_arch: ${{ steps.sanitize-input.outputs.host-arch }}
+        arch: ${{ steps.sanitize-input.outputs.target-arch }}
+        winsdk: ${{ inputs.windows-sdk-version }}
         toolset_version: ${{ inputs.msvc-version }}

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -17,8 +17,8 @@ inputs:
     type: boolean
   host-arch:
     description: |
-      The compiler's host architecture, "x86", "amd64" or "arm64". Defaults to the build
-      architecture. (a.k.a. the current runner's architecture).
+      The output's host architecture, "x86", "amd64" or "arm64". Defaults to the build architecture
+      (a.k.a. the current runner's architecture).
       This is the target architecture for the Visual Studio Developer Environment.
     required: false
     type: string
@@ -42,7 +42,7 @@ runs:
         } elseif ($IsMacOS) {
           $BuildOS = "macosx"
         } else {
-          Write-Output "::error::Unsupported host OS."
+          Write-Output "::error::Unsupported build OS."
           exit 1
         }
 
@@ -51,7 +51,7 @@ runs:
           "X64" { $BuildArch = "amd64" }
           "Arm64" { $BuildArch = "arm64" }
           default {
-            Write-Output "::error::Unsupported host architecture: `"$BuildArch`""
+            Write-Output "::error::Unsupported build architecture: `"$Arch`""
             exit 1
           }
         }

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -15,8 +15,11 @@ inputs:
     default: false
     required: false
     type: boolean
-  target-arch:
-    description: The target architecture, "x86", "amd64" or "arm64". Defaults to the host architecture.
+  host-arch:
+    description: |
+      The compiler's host architecture, "x86", "amd64" or "arm64". Defaults to the build
+      architecture. (a.k.a. the current runner's architecture).
+      This is the target architecture for the Visual Studio Developer Environment.
     required: false
     type: string
 
@@ -35,9 +38,9 @@ runs:
       shell: pwsh
       run: |
         if ($IsWindows) {
-          $HostOS = "windows"
+          $BuildOS = "windows"
         } elseif ($IsMacOS) {
-          $HostOS = "mac"
+          $BuildOS = "macosx"
         } else {
           Write-Output "::error::Unsupported host OS."
           exit 1
@@ -45,10 +48,10 @@ runs:
 
         $Arch = ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture).ToString()
         switch ($Arch) {
-          "X64" { $HostArch = "amd64" }
-          "Arm64" { $HostArch = "arm64" }
+          "X64" { $BuildArch = "amd64" }
+          "Arm64" { $BuildArch = "arm64" }
           default {
-            Write-Output "::error::Unsupported host architecture: `"$HostArch`""
+            Write-Output "::error::Unsupported host architecture: `"$BuildArch`""
             exit 1
           }
         }
@@ -79,32 +82,32 @@ runs:
         }
 
         if ("${{ inputs.setup-vs-dev-env }}" -eq "true") {
-          switch ("${{ inputs.target-arch }}") {
-            "x86" { $TargetArch = "x86" }
-            "amd64" { $TargetArch = "amd64" }
-            "arm64" { $TargetArch = "arm64" }
-            "" { $TargetArch = $HostArch }
+          switch ("${{ inputs.host-arch }}") {
+            "x86" { $HostArch = "x86" }
+            "amd64" { $HostArch = "amd64" }
+            "arm64" { $HostArch = "arm64" }
+            "" { $HostArch = $BuildArch }
             default {
-              Write-Output "::error::Unsupported target architecture: `"${{ inputs.target-arch }}`""
+              Write-Output "::error::Unsupported host architecture: `"${{ inputs.host-arch }}`""
               exit 1
             }
           }
         } else {
-          $TargetArch = $HostArch
+          $HostArch = $BuildArch
         }
 
-        Write-Output "ℹ️ Host OS: $HostOS"
+        Write-Output "ℹ️ Build OS: $BuildOS"
+        Write-Output "ℹ️ Build architecture: $BuildArch"
         Write-Output "ℹ️ Host architecture: $HostArch"
-        Write-Output "ℹ️ Target architecture: $TargetArch"
 
         @"
-        host-os=$HostOS
+        build-os=$BuildOS
+        build-arch=$BuildArch
         host-arch=$HostArch
-        target-arch=$TargetArch
         "@ | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
     - name: Install Windows SDK version ${{ inputs.windows-sdk-version }}
-      if: steps.sanitize-input.outputs.host-os == 'windows' && inputs.windows-sdk-version != ''
+      if: steps.sanitize-input.outputs.build-os == 'windows' && inputs.windows-sdk-version != ''
       shell: pwsh
       run: |
         $WinSdkVersionString = "${{ inputs.windows-sdk-version }}"
@@ -168,7 +171,7 @@ runs:
         }
 
     - name: Install Windows MSVC version ${{ inputs.msvc-version }}
-      if: steps.sanitize-input.outputs.host-os == 'windows' && inputs.msvc-version != ''
+      if: steps.sanitize-input.outputs.build-os == 'windows' && inputs.msvc-version != ''
       id: setup-msvc
       shell: pwsh
       run: |
@@ -232,10 +235,10 @@ runs:
         }
 
     - name: Setup Visual Studio Developer Environment
-      if: steps.sanitize-input.outputs.host-os == 'windows' && inputs.setup-vs-dev-env == 'true'
+      if: steps.sanitize-input.outputs.build-os == 'windows' && inputs.setup-vs-dev-env == 'true'
       uses: compnerd/gha-setup-vsdevenv@5eb3eae1490d4f7875d574c4973539f69109700d # main
       with:
-        host_arch: ${{ steps.sanitize-input.outputs.host-arch }}
-        arch: ${{ steps.sanitize-input.outputs.target-arch }}
+        host_arch: ${{ steps.sanitize-input.outputs.build-arch }}
+        arch: ${{ steps.sanitize-input.outputs.host-arch }}
         winsdk: ${{ inputs.windows-sdk-version }}
         toolset_version: ${{ inputs.msvc-version }}

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,0 +1,226 @@
+name: Setup build
+description: Sets up the build environment for the current job
+
+inputs:
+  windows-sdk-version:
+    description: The Windows SDK version to use, e.g. "10.0.22621.0"
+    required: false
+    type: string
+  windows-msvc-version:
+    description: The Windows MSVC version to use, e.g. "14.42"
+    required: false
+    type: string
+  setup-vs-dev-env:
+    description: Whether to set up a Visual Studio Dev Environment
+    default: false
+    required: false
+    type: boolean
+  target-arch:
+    description: The target architecture, "x86", "amd64" or "arm64". Defaults to the host architecture.
+    required: false
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Verify input
+      id: verify-input
+      shell: pwsh
+      run: |
+        if ($IsWindows) {
+          $HostOs = "windows"
+        } elseif ($IsMacOS) {
+          $HostOs = "mac"
+        } else {
+          Write-Output "::error::Unsupported host OS."
+          exit 1
+        }
+
+        $Arch = ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture).ToString()
+        switch ($Arch) {
+          "X64" { $HostArch = "amd64" }
+          "Arm64" { $HostArch = "arm64" }
+          default {
+            Write-Output "::error::Unsupported host architecture: `"$HostArch`""
+            exit 1
+          }
+        }
+
+        $WinMsvcVersion = "${{ inputs.windows-msvc-version }}"
+        if ($WinMsvcVersion -ne "") {
+          $ParsedWinMsvcVersion = [System.Version]::Parse($WinMsvcVersion)
+          if ($ParsedWinMsvcVersion -eq $null) {
+            Write-Output "::error::Invalid Windows MSVC version: `"${WinMsvcVersion}`"."
+            exit 1
+          }
+          if ($ParsedWinMsvcVersion.Major -ne 14) {
+            Write-Output "::error::Unsupported Windows MSVC version (major version not supported): `"${WinMsvcVersion}`"."
+            exit 1
+          }
+          if ($ParsedWinMsvcVersion.Build -ne -1) {
+            Write-Output "::error::Unsupported Windows MSVC version (build version was specified): `"${WinMsvcVersion}`"."
+            exit 1
+          }
+          if ($ParsedWinMsvcVersion.Revision -ne -1) {
+            Write-Output "::error::Unsupported Windows MSVC version (revision version was specified): `"${WinMsvcVersion}`"."
+            exit 1
+          }
+        }
+
+        switch ("${{ inputs.target-arch }}") {
+          "x86" { $TargetArch = "x86" }
+          "amd64" { $TargetArch = "amd64" }
+          "arm64" { $TargetArch = "arm64" }
+          "" { $TargetArch = $HostArch }
+          default {
+            Write-Output "::error::Unsupported target architecture: `"${{ inputs.target-arch }}`""
+            exit 1
+          }
+        }
+
+        Write-Output "Host OS: $HostOs"
+        Write-Output "Host architecture: $HostArch"
+        Write-Output "Target architecture: $TargetArch"
+
+        $VerifiedInput = @"
+        host-os=$HostOs
+        host-arch=$HostArch
+        target-arch=$TargetArch
+        "@
+        Write-Output $VerifiedInput | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+    - name: Install Windows SDK version ${{ inputs.windows-sdk-version }}
+      if: steps.verify-input.outputs.host-os == 'windows' && inputs.windows-sdk-version != ''
+      shell: pwsh
+      run: |
+        $WinSdkVersionString = "${{ inputs.windows-sdk-version }}"
+        $WinSdkVersion = [System.Version]::Parse($WinSdkVersionString)
+        $WinSdkVersionBuild = $WinSdkVersion.Build
+
+        $Win10SdkRoot = Get-ItemPropertyValue `
+          -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots" `
+          -Name "KitsRoot10"
+        $Win10SdkLib = Join-Path $Win10SdkRoot "Lib"
+        $Win10SdkInclude = Join-Path $Win10SdkRoot "Include"
+        $Win10SdkIncludeVersion = Join-Path $Win10SdkInclude $WinSdkVersionString
+
+        if (Test-Path -Path $Win10SdkIncludeVersion -PathType Container) {
+          Write-Output "Windows SDK ${WinSdkVersionString} already installed."
+        } else {
+          # Install the missing SDK.
+          Write-Output "Installing Windows SDK ${WinSdkVersionString}..."
+
+          $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
+          $VsWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
+          $VsInstaller = Join-Path "${InstallerLocation}" "vs_installer.exe"
+          $InstallPath = (& "$VsWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
+          $process = Start-Process "$VsInstaller" `
+              -PassThru `
+              -ArgumentList "modify", `
+                  "--installPath", "`"$InstallPath`"", `
+                  "--channelId", "https://aka.ms/vs/17/release/channel", `
+                  "--quiet", "--norestart", "--nocache", `
+                  "--add", "Microsoft.VisualStudio.Component.Windows11SDK.${WinSdkVersionBuild}"
+          $process.WaitForExit()
+
+          if (Test-Path -Path $Win10SdkIncludeVersion -PathType Container) {
+            Write-Output "Windows SDK ${WinSdkVersionString} installed successfully."
+          } else {
+            Write-Output "::error::Failed to install Windows SDK ${WinSdkVersionString}."
+            Write-Output "Installer log:"
+            $log = Get-ChildItem "${env:TEMP}" -Filter "dd_installer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+            Get-Content $log.FullName
+            exit 1
+          }
+        }
+
+        # Remove more recent Windows SDKs, if present. This is used to work
+        # around issues where LLVM uses the most recent Windows SDK.
+        Get-ChildItem -Path $Win10SdkInclude -Directory | ForEach-Object {
+          $IncludeDirName = $_.Name
+          try {
+            $IncludeDirVersion = [System.Version]::Parse($IncludeDirName)
+            if ($IncludeDirVersion -gt $WinSdkVersion) {
+              $LibDirVersion = Join-Path $Win10SdkLib $IncludeDirName
+              Write-Output "Removing folders for Windows SDK ${IncludeDirVersion}."
+              Remove-Item -Path $_.FullName -Recurse -Force -ErrorAction Ignore
+              Remove-Item -Path $LibDirVersion -Recurse -Force -ErrorAction Ignore
+            }
+          } catch {
+            # Skip if the directory cannot be parsed as a version.
+          }
+        }
+
+    - name: Install Windows MSVC version ${{ inputs.windows-msvc-version }}
+      if: steps.verify-input.outputs.host-os == 'windows' && inputs.windows-msvc-version != ''
+      shell: pwsh
+      run: |
+        # This is assuming a VS2022 toolchain. e.g.
+        # MSVC 14.42 corresponds to the 14.42.17.12 package.
+        # MSVC 14.43 corresponds to the 14.43.17.13 package.
+        $WinMsvcVersionString = "${{ inputs.windows-msvc-version }}"
+
+        $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
+        $VsWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
+        $VsInstaller = Join-Path "${InstallerLocation}" "vs_installer.exe"
+        $InstallPath = (& "$VsWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
+        $MSVCDir = Join-Path $InstallPath "VC" "Tools" "MSVC"
+
+        # Check if this MSVC version is already installed.
+        Get-ChildItem -Path $MSVCDir -Directory | ForEach-Object {
+          $MsvcDirName = $_.Name
+          if ($MsvcDirName.StartsWith($WinMsvcVersionString)) {
+            Write-Output "MSVC ${WinMsvcVersionString} already installed."
+            exit 0
+          }
+        }
+
+        # Compute the MSVC version package name.
+        $WinMsvcVersion = [System.Version]::Parse($WinMsvcVersionString)
+        $MajorVersion = $WinMsvcVersion.Major
+        $MinorVersion = $WinMsvcVersion.Minor
+        $BuildVersion = 17
+        $RevisionVersion = $MinorVersion - 30
+        $WinMsvcVersionBuild = "${MajorVersion}.${MinorVersion}.${BuildVersion}.${RevisionVersion}"
+
+        # Install the missing MSVC version.
+        Write-Output "Installing MSVC packages for ${WinMsvcVersionBuild}..."
+        $process = Start-Process "$VsInstaller" `
+            -PassThru `
+            -ArgumentList "modify", `
+                "--installPath", "`"$InstallPath`"", `
+                "--channelId", "https://aka.ms/vs/17/release/channel", `
+                "--quiet", "--norestart", "--nocache", `
+                "--add", "Microsoft.VisualStudio.Component.VC.${WinMsvcVersionBuild}.x86.x64", `
+                "--add", "Microsoft.VisualStudio.Component.VC.${WinMsvcVersionBuild}.ATL", `
+                "--add", "Microsoft.VisualStudio.Component.VC.${WinMsvcVersionBuild}.ARM64", `
+                "--add", "Microsoft.VisualStudio.Component.VC.${WinMsvcVersionBuild}.ATL.ARM64"
+        $process.WaitForExit()
+
+        # Check if the MSVC version was installed successfully.
+        $MSVCDirFound = $false
+        Get-ChildItem -Path $MSVCDir -Directory | ForEach-Object {
+          $MsvcDirName = $_.Name
+          if ($MsvcDirName.StartsWith($WinMsvcVersionString)) {
+            Write-Output "MSVC ${WinMsvcVersionString} installed successfully."
+            $MSVCDirFound = $true
+            break
+          }
+        }
+
+        if (-not $MSVCDirFound) {
+          Write-Output "::error::Failed to install MSVC ${WinMsvcVersionString}."
+          Write-Output "Installer log:"
+          $log = Get-ChildItem "${env:TEMP}" -Filter "dd_installer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          Get-Content $log.FullName
+          exit 1
+        }
+
+    - name: Setup Visual Studio Developer Environment
+      if: steps.verify-input.outputs.host-os == 'windows' && inputs.setup-vs-dev-env
+      uses: compnerd/gha-setup-vsdevenv@5eb3eae1490d4f7875d574c4973539f69109700d # main
+      with:
+        host_arch: ${{ steps.verify-input.outputs.host-arch }}
+        arch: ${{ steps.verify-input.outputs.target-arch }}
+        winsdk: ${{ inputs.windows-msvc-version }}
+        toolset_version: ${{ inputs.windows-msvc-version }}

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -46,6 +46,10 @@ runs:
           }
         }
 
+        # Validate the MSVC version input.
+        # If specified, it is expected to have a format "major.minor", without the build and
+        # revision numbers. When a value such as "14.42" is parsed as a `System.Version`, the build
+        # and revision numbers in that object are set to -1.
         $MSVCVersion = "${{ inputs.msvc-version }}"
         if ($MSVCVersion -ne "") {
           $ParsedMSVCVersion = [System.Version]::Parse($MSVCVersion)

--- a/.github/workflows/test-setup-build.yml
+++ b/.github/workflows/test-setup-build.yml
@@ -78,7 +78,7 @@ jobs:
 
           # Check if the correct MSVC version is installed.
           $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
-          SWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
+          $VSWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
           $InstallPath = (& "$VSWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
           $MSVCDir = Join-Path $InstallPath "VC" "Tools" "MSVC"
           $DirFound = $false

--- a/.github/workflows/test-setup-build.yml
+++ b/.github/workflows/test-setup-build.yml
@@ -20,18 +20,19 @@ on:
         type: string
 
 env:
-  TEST_WIN_SDK_VERSION: 10.0.22621.0
-  TEST_MSVC_VERSION: 14.42
+  TEST_WIN_SDK_VERSION: "10.0.22000.0"
+  TEST_MSVC_VERSION: "14.40"
 
 jobs:
-  test-setup-build-windows:
-    name: Test MSVC and Windows SDK environment setup
+  test-setup-build-windows-vs-dev-env:
+    name: MSVC + WinSDK With Dev Environment
     runs-on: ${{ inputs.windows-runner || 'windows-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
 
       - name: Set up build
+        id: setup-build
         uses: ./.github/actions/setup-build
         with:
           windows-sdk-version: ${{ env.TEST_WIN_SDK_VERSION }}
@@ -80,19 +81,11 @@ jobs:
           $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
           $VSWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
           $InstallPath = (& "$VSWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
-          $MSVCDir = Join-Path $InstallPath "VC" "Tools" "MSVC"
-          $DirFound = $false
-          foreach ($dir in Get-ChildItem -Path $MSVCDir -Directory) {
-            $MSVCDirName = $dir.Name
-            if ($MSVCDirName.StartsWith($env:TEST_MSVC_VERSION)) {
-              $DirFound = $true
-              break
-            }
-          }
-          if ($DirFound) {
+          $MSVCDir = Join-Path $InstallPath "VC" "Tools" "MSVC" "${{ steps.setup-build.outputs.windows-build-tools-version }}"
+          if (Test-Path -Path $MSVCDir) {
             Write-Output "✅ MSVC version `${env:TEST_MSVC_VERSION}`" is installed."
           } else {
-            Write-Output "::error::Expected MSVC version not found: `"${env:TEST_MSVC_VERSION}`"."
+            Write-Output "::error::MSVC directory not found: `"${MSVCDir}`"."
             $HasError = $true
           }
 
@@ -103,7 +96,7 @@ jobs:
           $lastLine = $clOutput | Select-Object -Last 1
           Remove-Item $tempFile -Force
 
-          # _MSC_VER expands to a number like 1942 for MSVC 14.42.
+          # _MSC_VER expands to a number like 1940 for MSVC 14.40.
           $ParsedMSVCVersion = [System.Version]::Parse($env:TEST_MSVC_VERSION)
           $ExpectedVersion = ($ParsedMSVCVersion.Major + 5) * 100 + $ParsedMSVCVersion.Minor
           if ($lastLine -eq $ExpectedVersion) {
@@ -113,12 +106,101 @@ jobs:
             $HasError = $true
           }
 
-          # Check if the Windows SDK version is set in the environment.
+          # Check that the Windows SDK version is set in the environment.
           if ($env:UCRTVersion -eq $env:TEST_WIN_SDK_VERSION) {
             Write-Output "✅ UCRTVersion environment variable is set to `"${env:TEST_WIN_SDK_VERSION}`"."
           } else {
             Write-Output "::error::UCRTVersion environment variable (`"${env:UCRTVersion}`") is not set to the expected Windows SDK version (`"${env:TEST_WIN_SDK_VERSION}`")."
             $HasError = $true
+          }
+
+          if ($HasError) {
+            Write-Output "::error::There were errors in the environment setup. Check the logs for details."
+            exit 1
+          } else {
+            Write-Output "🎉 All environment checks passed successfully."
+          }
+
+  test-setup-build-windows-no-dev-env:
+    name: MSVC + WinSDK No Dev Environment
+    runs-on: ${{ inputs.windows-runner || 'windows-latest' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Set up build
+        id: setup-build
+        uses: ./.github/actions/setup-build
+        with:
+          windows-sdk-version: ${{ env.TEST_WIN_SDK_VERSION }}
+          msvc-version: ${{ env.TEST_MSVC_VERSION }}
+          setup-vs-dev-env: false
+
+      - name: Check environment
+        run: |
+          $HasError = $false
+
+          $ParsedWinSdkVersion = [System.Version]::Parse($env:TEST_WIN_SDK_VERSION)
+          $Win10SdkRoot = Get-ItemPropertyValue `
+            -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots" `
+            -Name "KitsRoot10"
+          $Win10SdkInclude = Join-Path $Win10SdkRoot "Include"
+
+          # Check if the Windows SDK version is installed.
+          $ExpectedWinSdkDir = Join-Path $Win10SdkInclude "$($env:TEST_WIN_SDK_VERSION)"
+          if (Test-Path -Path $ExpectedWinSdkDir) {
+            Write-Output "✅ Windows SDK version `"${env:TEST_WIN_SDK_VERSION}`" is installed."
+          } else {
+            Write-Output "::error::Expected Windows SDK version not found: `"${env:TEST_WIN_SDK_VERSION}`"."
+            $HasError = $true
+          }
+
+          # Check if Windows SDK versions greater than the expected version are installed.
+          $UnexpectedSdkFound = $false
+          Get-ChildItem -Path $Win10SdkInclude -Directory | ForEach-Object {
+            $Version = $_.Name
+            try {
+              $ParsedVersion = [System.Version]::Parse($Version)
+              if ($ParsedVersion -gt $ParsedWinSdkVersion) {
+                Write-Output "::error::Unexpected Windows SDK version found: `"${Version}`" (greater than expected: `"${env:TEST_WIN_SDK_VERSION}`")."
+                $HasError = $true
+                $UnexpectedSdkFound = $true
+              }
+            } catch {
+              # Skip if the directory cannot be parsed as a version.
+            }
+          }
+          if (-not $UnexpectedSdkFound) {
+            Write-Output "✅ No unexpected Windows SDK versions greater than `"${env:TEST_WIN_SDK_VERSION}`" found."
+          }
+
+          # Check if the correct MSVC version is installed.
+          $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
+          $VSWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
+          $InstallPath = (& "$VSWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
+          $MSVCDir = Join-Path $InstallPath "VC" "Tools" "MSVC" "${{ steps.setup-build.outputs.windows-build-tools-version }}"
+          if (Test-Path -Path $MSVCDir) {
+            Write-Output "✅ MSVC version `${env:TEST_MSVC_VERSION}`" is installed."
+          } else {
+            Write-Output "::error::MSVC directory not found: `"${MSVCDir}`"."
+            $HasError = $true
+          }
+
+          # Check that cl.exe was not set.
+          $CLExe = Get-Command -Name cl.exe -ErrorAction Ignore
+          if ($CLExe) {
+            Write-Output "::error::cl.exe was unexpectedly found in the PATH: `"${CLExe.Path}`"."
+            $HasError = $true
+          } else {
+            Write-Output "✅ cl.exe is not set in the PATH, as expected."
+          }
+
+          # Check that the VS Dev Environment was not set.
+          if ($env:UCRTVersion) {
+            Write-Output "::error::UCRTVersion environment variable was set to `"${env:UCRTVersion}`"."
+            $HasError = $true
+          } else {
+            Write-Output "✅ UCRTVersion environment variable is set to `"${env:TEST_WIN_SDK_VERSION}`"."
           }
 
           if ($HasError) {

--- a/.github/workflows/test-setup-build.yml
+++ b/.github/workflows/test-setup-build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: ./.github/actions/setup-build
         with:
           windows-sdk-version: ${{ env.TEST_WIN_SDK_VERSION }}
-          windows-msvc-version: ${{ env.TEST_MSVC_VERSION }}
+          msvc-version: ${{ env.TEST_MSVC_VERSION }}
           setup-vs-dev-env: true
 
       - name: Check environment
@@ -78,13 +78,13 @@ jobs:
 
           # Check if the correct MSVC version is installed.
           $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
-          $VsWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
-          $InstallPath = (& "$VsWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
+          SWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
+          $InstallPath = (& "$VSWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
           $MSVCDir = Join-Path $InstallPath "VC" "Tools" "MSVC"
           $DirFound = $false
           foreach ($dir in Get-ChildItem -Path $MSVCDir -Directory) {
-            $MsvcDirName = $dir.Name
-            if ($MsvcDirName.StartsWith($env:TEST_MSVC_VERSION)) {
+            $MSVCDirName = $dir.Name
+            if ($MSVCDirName.StartsWith($env:TEST_MSVC_VERSION)) {
               $DirFound = $true
               break
             }
@@ -103,8 +103,9 @@ jobs:
           $lastLine = $clOutput | Select-Object -Last 1
           Remove-Item $tempFile -Force
 
-          $ParsedMsvcVersion = [System.Version]::Parse($env:TEST_MSVC_VERSION)
-          $ExpectedVersion = ($ParsedMsvcVersion.Major + 5) * 100 + $ParsedMsvcVersion.Minor
+          # _MSC_VER expands to a number like 1942 for MSVC 14.42.
+          $ParsedMSVCVersion = [System.Version]::Parse($env:TEST_MSVC_VERSION)
+          $ExpectedVersion = ($ParsedMSVCVersion.Major + 5) * 100 + $ParsedMSVCVersion.Minor
           if ($lastLine -eq $ExpectedVersion) {
             Write-Output "✅ cl.exe reports expected _MSC_VER `"${ExpectedVersion}`"."
           } else {

--- a/.github/workflows/test-setup-build.yml
+++ b/.github/workflows/test-setup-build.yml
@@ -1,0 +1,128 @@
+name: Test the setup-build action
+on:
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - '.github/actions/action.yml'
+      - '.github/workflows/test-setup-build.yml'
+  workflow_dispatch:
+    inputs:
+      windows-runner:
+        description: "The Windows runner to use"
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      windows-runner:
+        description: "The Windows runner to use"
+        required: false
+        type: string
+
+env:
+  TEST_WIN_SDK_VERSION: 10.0.22621.0
+  TEST_MSVC_VERSION: 14.42
+
+jobs:
+  test-setup-build-windows:
+    name: Test MSVC and Windows SDK environment setup
+    runs-on: ${{ inputs.windows-runner || 'windows-latest' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Set up build
+        uses: ./.github/actions/setup-build
+        with:
+          windows-sdk-version: ${{ env.TEST_WIN_SDK_VERSION }}
+          windows-msvc-version: ${{ env.TEST_MSVC_VERSION }}
+          setup-vs-dev-env: true
+
+      - name: Check environment
+        run: |
+          $HasError = $false
+
+          $ParsedWinSdkVersion = [System.Version]::Parse($env:TEST_WIN_SDK_VERSION)
+          $Win10SdkRoot = Get-ItemPropertyValue `
+            -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots" `
+            -Name "KitsRoot10"
+          $Win10SdkInclude = Join-Path $Win10SdkRoot "Include"
+
+          # Check if the Windows SDK version is installed.
+          $ExpectedWinSdkDir = Join-Path $Win10SdkInclude "$($env:TEST_WIN_SDK_VERSION)"
+          if (Test-Path -Path $ExpectedWinSdkDir) {
+            Write-Output "✅ Windows SDK version `"${env:TEST_WIN_SDK_VERSION}`" is installed."
+          } else {
+            Write-Output "::error::Expected Windows SDK version not found: `"${env:TEST_WIN_SDK_VERSION}`"."
+            $HasError = $true
+          }
+
+          # Check if Windows SDK versions greater than the expected version are installed.
+          $UnexpectedSdkFound = $false
+          Get-ChildItem -Path $Win10SdkInclude -Directory | ForEach-Object {
+            $Version = $_.Name
+            try {
+              $ParsedVersion = [System.Version]::Parse($Version)
+              if ($ParsedVersion -gt $ParsedWinSdkVersion) {
+                Write-Output "::error::Unexpected Windows SDK version found: `"${Version}`" (greater than expected: `"${env:TEST_WIN_SDK_VERSION}`")."
+                $HasError = $true
+                $UnexpectedSdkFound = $true
+              }
+            } catch {
+              # Skip if the directory cannot be parsed as a version.
+            }
+          }
+          if (-not $UnexpectedSdkFound) {
+            Write-Output "✅ No unexpected Windows SDK versions greater than `"${env:TEST_WIN_SDK_VERSION}`" found."
+          }
+
+          # Check if the correct MSVC version is installed.
+          $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
+          $VsWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
+          $InstallPath = (& "$VsWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
+          $MSVCDir = Join-Path $InstallPath "VC" "Tools" "MSVC"
+          $DirFound = $false
+          foreach ($dir in Get-ChildItem -Path $MSVCDir -Directory) {
+            $MsvcDirName = $dir.Name
+            if ($MsvcDirName.StartsWith($env:TEST_MSVC_VERSION)) {
+              $DirFound = $true
+              break
+            }
+          }
+          if ($DirFound) {
+            Write-Output "✅ MSVC version `${env:TEST_MSVC_VERSION}`" is installed."
+          } else {
+            Write-Output "::error::Expected MSVC version not found: `"${env:TEST_MSVC_VERSION}`"."
+            $HasError = $true
+          }
+
+          # Check the current cl.exe version by expanding the _MSC_VER macro.
+          $tempFile = [System.IO.Path]::GetTempFileName().Replace('.tmp', '.c')
+          Set-Content -Path $tempFile -Value "_MSC_VER"
+          $clOutput = & cl /nologo /EP $tempFile 2>&1
+          $lastLine = $clOutput | Select-Object -Last 1
+          Remove-Item $tempFile -Force
+
+          $ParsedMsvcVersion = [System.Version]::Parse($env:TEST_MSVC_VERSION)
+          $ExpectedVersion = ($ParsedMsvcVersion.Major + 5) * 100 + $ParsedMsvcVersion.Minor
+          if ($lastLine -eq $ExpectedVersion) {
+            Write-Output "✅ cl.exe reports expected _MSC_VER `"${ExpectedVersion}`"."
+          } else {
+            Write-Output "::error::Unexpected MSVC version found: `"${lastLine}`" (expected: `"${ExpectedVersion}`")."
+            $HasError = $true
+          }
+
+          # Check if the Windows SDK version is set in the environment.
+          if ($env:UCRTVersion -eq $env:TEST_WIN_SDK_VERSION) {
+            Write-Output "✅ UCRTVersion environment variable is set to `"${env:TEST_WIN_SDK_VERSION}`"."
+          } else {
+            Write-Output "::error::UCRTVersion environment variable (`"${env:UCRTVersion}`") is not set to the expected Windows SDK version (`"${env:TEST_WIN_SDK_VERSION}`")."
+            $HasError = $true
+          }
+
+          if ($HasError) {
+            Write-Output "::error::There were errors in the environment setup. Check the logs for details."
+            exit 1
+          } else {
+            Write-Output "🎉 All environment checks passed successfully."
+          }


### PR DESCRIPTION
This introduces a new reusable action, `setup-build`, which will eventually replace all of the custom installation steps in the swift-build jobs. Currently it only supports providing explicit versions for MSVC and the Windows SDK.

This also adds tests for the `setup-build` action, with a configurable runner, ensuring we can catch issues early as runner images get updated.

Bug: #821