### PR TITLE
[Cherry-pick] mimalloc: Remove workaround for mimalloc

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3454,12 +3454,6 @@ jobs:
             -Destination "$ToolchainBin"
           Copy-Item -Path "${{ github.workspace }}\SourceCache\mimalloc\out\msvc-$HostMSArch\Release\mimalloc-redirect$HostSuffix.dll" `
             -Destination "$ToolchainBin"
-          # When cross-compiling, bundle the second mimalloc redirect dll as a workaround for
-          # https://github.com/microsoft/mimalloc/issues/997
-          if ("${{ inputs.build_arch }}" -ne "${{ matrix.arch }}") {
-            Copy-Item -Path "${{ github.workspace }}\SourceCache\mimalloc\out\msvc-$HostMSArch\Release\mimalloc-redirect$HostSuffix.dll" `
-              -Destination "$ToolchainBin/mimalloc-redirect$BuildSuffix.dll"
-          }
           $MimallocExecutables = @("swift.exe",
                                    "swiftc.exe",
                                    "swift-driver.exe",
@@ -3481,8 +3475,6 @@ jobs:
       - name: Package Build Tools
         run: |
           # When cross-compiling, bundle the second mimalloc redirect dll as a workaround for
-          # https://github.com/microsoft/mimalloc/issues/997
-          $WORKAROUND_MIMALLOC_ISSUE_997 = if ("${{ inputs.build_arch }}" -ne "${{ matrix.arch }}") { "true" } else { "false" }
           msbuild -nologo -restore -maxCpuCount `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
               -p:Configuration=Release `
@@ -3490,7 +3482,7 @@ jobs:
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
-              -p:WORKAROUND_MIMALLOC_ISSUE_997=$WORKAROUND_MIMALLOC_ISSUE_997 `
+              -p:WORKAROUND_MIMALLOC_ISSUE_997=false `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bld/bld.wixproj

--- a/default.xml
+++ b/default.xml
@@ -62,7 +62,7 @@
 
   <project remote="github" name="madler/zlib" path="zlib" revision="refs/tags/v1.3.1" />
 
-  <project remote="github" name="microsoft/mimalloc" path="mimalloc" revision="refs/tags/v3.0.1" />
+  <project remote="github" name="microsoft/mimalloc" path="mimalloc" revision="refs/tags/v3.0.3" />
 
   <project remote="github" name="ninja-build/ninja" path="ninja" groups="notdefault,dependencies" revision="master" />
 </manifest>


### PR DESCRIPTION
Cherry-pick https://github.com/compnerd/swift-build/pull/945 into release/6.2

This is no longer required with mimalloc 3.0.3.