### PR TITLE
[6.2] Switch swift-system to build statically

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2807,7 +2807,7 @@ jobs:
           $SWIFTC = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/swiftc.exe
 
           cmake -B ${{ github.workspace }}/BinaryCache/swift-system `
-                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_SHARED_LIBS=NO `
                 -D BUILD_TESTING=NO `
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${CLANG_CL} `


### PR DESCRIPTION
Cherry-picked from #955

This matches upstream `build.ps1` behavior.