### PR TITLE
[GHA Build] Add no-asserts toolchain packaging support

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3714,10 +3714,16 @@ jobs:
           name: Windows-${{ matrix.arch }}-debugging_tools
           path: ${{ github.workspace }}/BuildRoot/Library
 
-      - name: Download Compilers
+      - name: Download Compilers (Asserts)
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
           name: Windows-${{ matrix.arch }}-Asserts-compilers
+          path: ${{ github.workspace }}/BuildRoot/Library
+
+      - name: Download Compilers (NoAsserts)
+        uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
+        with:
+          name: Windows-${{ matrix.arch }}-NoAsserts-compilers
           path: ${{ github.workspace }}/BuildRoot/Library
 
       - name: Download Developer Tools
@@ -3828,11 +3834,12 @@ jobs:
           $BuildSuffix = if ("${{ inputs.build_arch }}" -eq "arm64") { "-arm64" } else { "" }
           # Reference: https://github.com/microsoft/mimalloc/tree/dev/bin#minject
           msbuild ${{ github.workspace }}\SourceCache\mimalloc\ide\vs2022\mimalloc.sln -p:Configuration=Release -p:Platform=$HostMSArch
-          $ToolchainBin = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+Asserts\usr\bin"
+          $AssertToolchainBin = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+Asserts\usr\bin"
+          $NoAssertToolchainBin = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+NoAsserts\usr\bin"
           Copy-Item -Path "${{ github.workspace }}\SourceCache\mimalloc\out\msvc-$HostMSArch\Release\mimalloc.dll" `
-            -Destination "$ToolchainBin"
+            -Destination "$AssertToolchainBin"
           Copy-Item -Path "${{ github.workspace }}\SourceCache\mimalloc\out\msvc-$HostMSArch\Release\mimalloc-redirect$HostSuffix.dll" `
-            -Destination "$ToolchainBin"
+            -Destination "$AssertToolchainBin"
           $MimallocExecutables = @("swift.exe",
                                    "swiftc.exe",
                                    "swift-driver.exe",
@@ -3844,11 +3851,16 @@ jobs:
                                    "lld-link.exe",
                                    "ld.lld.exe",
                                    "ld64.lld.exe")
-          foreach ($Exe in $MimallocExecutables) {
+          $AssertBinaries = $MimallocExecutables | ForEach-Object {[IO.Path]::Combine(SAssertToolchainBin, $_)}
+          $NoAssertBinaries = $MimallocExecutables `
+                              | ForEach-Object {[IO.Path]::Combine( $NoAssertToolchainBin, $_)} `
+                              | Where-Object { Test-Path $_ -PathType Leaf }
+          $Binaries = $AssertBinaries + $NoAssertBinaries
+          foreach ($Exe in $Binaries) {
             # Binary-patch in place
-            & "${{ github.workspace }}\SourceCache\mimalloc\bin\minject$BuildSuffix" -f -i -v "$ToolchainBin\$Exe"
+            & "${{ github.workspace }}\SourceCache\mimalloc\bin\minject$BuildSuffix" -f -i -v "$Exe"
             # Log the import table
-            & "${{ github.workspace }}\SourceCache\mimalloc\bin\minject$BuildSuffix" -l "$ToolchainBin\$Exe"
+            & "${{ github.workspace }}\SourceCache\mimalloc\bin\minject$BuildSuffix" -l "$Exe"
           }
 
       - name: Package Build Tools

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -4462,7 +4462,7 @@ jobs:
               -p:WindowsArchitectures="`"aarch64;i686;x86_64`"" `
               -p:ProductArchitecture=${{ matrix.arch }} `
               -p:ProductVersion=${{ inputs.swift_version }}-${{ inputs.swift_tag }} `
-              -p:ToolchainVariants="asserts;noasserts" `
+              -p:ToolchainVariants="`"asserts;noasserts`"" `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bundle/installer.wixproj
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3851,9 +3851,9 @@ jobs:
                                    "lld-link.exe",
                                    "ld.lld.exe",
                                    "ld64.lld.exe")
-          $AssertBinaries = $MimallocExecutables | ForEach-Object {[IO.Path]::Combine(SAssertToolchainBin, $_)}
+          $AssertBinaries = $MimallocExecutables | ForEach-Object {[IO.Path]::Combine($AssertToolchainBin, $_)}
           $NoAssertBinaries = $MimallocExecutables `
-                              | ForEach-Object {[IO.Path]::Combine( $NoAssertToolchainBin, $_)} `
+                              | ForEach-Object {[IO.Path]::Combine($NoAssertToolchainBin, $_)} `
                               | Where-Object { Test-Path $_ -PathType Leaf }
           $Binaries = $AssertBinaries + $NoAssertBinaries
           foreach ($Exe in $Binaries) {

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3863,7 +3863,7 @@ jobs:
             & "${{ github.workspace }}\SourceCache\mimalloc\bin\minject$BuildSuffix" -l "$Exe"
           }
 
-      - name: Package Build Tools
+      - name: Package Build Tools (Asserts)
         run: |
           # When cross-compiling, bundle the second mimalloc redirect dll as a workaround for
           msbuild -nologo -restore -maxCpuCount `
@@ -3876,9 +3876,24 @@ jobs:
               -p:WORKAROUND_MIMALLOC_ISSUE_997=false `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bld/bld.wixproj
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bld/asserts/bld.asserts.wixproj
 
-      - name: Package CLI Tools
+      - name: Package Build Tools (NoAsserts)
+        run: |
+          # When cross-compiling, bundle the second mimalloc redirect dll as a workaround for
+          msbuild -nologo -restore -maxCpuCount `
+              -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
+              -p:Configuration=Release `
+              -p:SignOutput=${{ inputs.signed }} `
+              -p:CERTIFICATE=${env:CERTIFICATE} `
+              -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
+              -p:WORKAROUND_MIMALLOC_ISSUE_997=false `
+              -p:ProductVersion=${{ inputs.swift_version }} `
+              -p:ProductArchitecture=${{ matrix.arch }} `
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bld/noasserts/bld.noasserts.wixproj
+
+      - name: Package CLI Tools (Asserts)
         run: |
           msbuild -nologo -restore -maxCpuCount `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
@@ -3889,9 +3904,9 @@ jobs:
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/cli/cli.wixproj
-
-      - name: Package Debugging Tools
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/cli/asserts/cli.asserts.wixproj
+        
+      - name: Package CLI Tools (NoAsserts)
         run: |
           msbuild -nologo -restore -maxCpuCount `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
@@ -3902,9 +3917,9 @@ jobs:
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/dbg/dbg.wixproj
-
-      - name: Package IDE Tools
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/cli/noasserts/cli.noasserts.wixproj
+ 
+      - name: Package Debugging Tools (Asserts)
         run: |
           msbuild -nologo -restore -maxCpuCount `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
@@ -3915,7 +3930,46 @@ jobs:
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/ide/ide.wixproj
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/dbg/asserts/dbg.asserts.wixproj
+
+      - name: Package Debugging Tools (NoAsserts)
+        run: |
+          msbuild -nologo -restore -maxCpuCount `
+              -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
+              -p:Configuration=Release `
+              -p:SignOutput=${{ inputs.signed }} `
+              -p:CERTIFICATE=${env:CERTIFICATE} `
+              -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
+              -p:ProductVersion=${{ inputs.swift_version }} `
+              -p:ProductArchitecture=${{ matrix.arch }} `
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/dbg/noasserts/dbg.noasserts.wixproj
+
+      - name: Package IDE Tools (Asserts)
+        run: |
+          msbuild -nologo -restore -maxCpuCount `
+              -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
+              -p:Configuration=Release `
+              -p:SignOutput=${{ inputs.signed }} `
+              -p:CERTIFICATE=${env:CERTIFICATE} `
+              -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
+              -p:ProductVersion=${{ inputs.swift_version }} `
+              -p:ProductArchitecture=${{ matrix.arch }} `
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/ide/asserts/ide.asserts.wixproj
+
+      - name: Package IDE Tools (NoAsserts)
+        run: |
+          msbuild -nologo -restore -maxCpuCount `
+              -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
+              -p:Configuration=Release `
+              -p:SignOutput=${{ inputs.signed }} `
+              -p:CERTIFICATE=${env:CERTIFICATE} `
+              -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
+              -p:ProductVersion=${{ inputs.swift_version }} `
+              -p:ProductArchitecture=${{ matrix.arch }} `
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/ide/noasserts/ide.noasserts.wixproj
 
       - name: Package Runtime
         run: |
@@ -3938,26 +3992,34 @@ jobs:
         with:
           name: Windows-${{ matrix.arch }}-bld-msi
           path: |
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.msi
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.asserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.asserts.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.noasserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.noasserts.cab
       - uses: actions/upload-artifact@v4
         with:
           name: Windows-${{ matrix.arch }}-cli-msi
           path: |
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.msi
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.asserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.asserts.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.noasserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.noasserts.cab
       - uses: actions/upload-artifact@v4
         with:
           name: Windows-${{ matrix.arch }}-dbg-msi
           path: |
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.msi
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.asserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.asserts.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.noasserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.noasserts.cab
       - uses: actions/upload-artifact@v4
         with:
           name: Windows-${{ matrix.arch }}-ide-msi
           path: |
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.msi
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.asserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.asserts.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.noasserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.noasserts.cab
 
       - uses: actions/upload-artifact@v4
         with:
@@ -4400,6 +4462,7 @@ jobs:
               -p:WindowsArchitectures="`"aarch64;i686;x86_64`"" `
               -p:ProductArchitecture=${{ matrix.arch }} `
               -p:ProductVersion=${{ inputs.swift_version }}-${{ inputs.swift_tag }} `
+              -p:ToolchainVariants="asserts;noasserts" `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bundle/installer.wixproj
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1186,7 +1186,7 @@ jobs:
                 ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_STATIC_LIBRARY_PREFIX_Swift= `
                 -D CMAKE_FIND_PACKAGE_PREFER_CONFIG=YES `
-                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+${{ matrix.variant }}/usr `
                 -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
                 ${{ steps.setup-context.outputs.extra_flags }} `
                 -G Ninja `
@@ -1244,9 +1244,9 @@ jobs:
       - name: Copy cmark-gfm shared libraries
         run: |
           if ("${{ matrix.os }}" -eq "Windows") {
-            Copy-Item -Path "${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr/bin/*.dll" -Destination "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin"
+            Copy-Item -Path "${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr/bin/*.dll" -Destination "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+${{ matrix.variant }}/usr/bin"
           } else {
-            Copy-Item -Path "${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr/lib/*.dylib" -Destination "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/lib/swift/host/compiler"
+            Copy-Item -Path "${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr/lib/*.dylib" -Destination "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+${{ matrix.variant }}/usr/lib/swift/host/compiler"
           }
 
       - uses: actions/setup-python@v5
@@ -1258,7 +1258,7 @@ jobs:
             from datetime import datetime
 
             now = datetime.now()
-            info_plist = r'${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/ToolchainInfo.plist'
+            info_plist = r'${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+${{ matrix.variant }}/ToolchainInfo.plist'
             with open(os.path.normpath(info_plist), 'wb') as plist:
               plistlib.dump({ 'Identifier': 'org.compnerd.dt.toolchain.{0}.{1}-asserts'.format(now.strftime('%Y%m%d'), now.timetuple().tm_hour % 6) }, plist)
 
@@ -1271,7 +1271,7 @@ jobs:
       - name: Extract swift-syntax
         run: |
           New-Item -Path ${{ github.workspace }}/BinaryCache/swift-syntax/lib/swift/host -ItemType Directory | Out-Null
-          $ToolchainRoot = "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts"
+          $ToolchainRoot = "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+${{ matrix.variant }}"
           if ("${{ matrix.os }}" -eq "Windows") {
             $bindir = cygpath -m "${{ github.workspace }}/BinaryCache/1"
             Copy-Item -Path "${ToolchainRoot}/usr/lib/*.lib" -Destination "${{ github.workspace }}/BinaryCache/swift-syntax/lib"


### PR DESCRIPTION
This is the github counterpart of https://github.com/swiftlang/swift-installer-scripts/pull/425. 

Changes include:
- Apply mimalloc patch to outputs of both no-asserts and asserts toolchains
- Independently build and upload msi's for bld, cli, dbg, and ide by variant 
- pass the ToolchainVariant flag to the installer.wixproj

A successful run using these changes: https://github.com/thebrowsercompany/swift-build/actions/runs/15315765184/job/43096722362