### PR TITLE
ds2_tools: Use `build_arch` for the artifact name

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -427,7 +427,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: inputs.build_android
         with:
-          name: Windows-${{ inputs.build_os }}-regsgen2
+          name: Windows-${{ inputs.build_arch }}-regsgen2
           path: |
             ${{ github.workspace }}/BinaryCache/RegsGen2/regsgen2.exe
 
@@ -507,7 +507,7 @@ jobs:
       - uses: actions/download-artifact@v4
         if: inputs.build_android
         with:
-          name: Windows-${{ inputs.build_os }}-regsgen2
+          name: Windows-${{ inputs.build_arch }}-regsgen2
           path: ${{ github.workspace }}/BinaryCache/RegsGen2
 
       - uses: nttld/setup-ndk@v1


### PR DESCRIPTION
The artifact name had been incorrectly set to `Windows-${{ inputs.build_os}}`, which expands to `Windows-Windows`.