### PR TITLE
Upload the VS Installer log

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -2,6 +2,12 @@ name: Setup build
 description: Sets up the build environment for the current job
 
 inputs:
+  upload-prefix:
+    description: |
+      The prefix to use for the uploaded artifacts. This is used to distinguish
+      between different matrix jobs in the same workflow.
+    required: true
+    type: string
   windows-sdk-version:
     description: The Windows SDK version to use, e.g. "10.0.22621.0"
     required: false
@@ -108,6 +114,7 @@ runs:
 
     - name: Install Windows SDK version ${{ inputs.windows-sdk-version }}
       if: steps.sanitize-input.outputs.build-os == 'windows' && inputs.windows-sdk-version != ''
+      id: setup-windows-sdk
       shell: pwsh
       run: |
         $WinSdkVersionString = "${{ inputs.windows-sdk-version }}"
@@ -140,13 +147,13 @@ runs:
                   "--add", "Microsoft.VisualStudio.Component.Windows11SDK.${WinSdkVersionBuild}"
           $process.WaitForExit()
 
+          $LogFile = Get-ChildItem "${env:TEMP}" -Filter "dd_installer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          "log-file=$($LogFile.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
           if (Test-Path -Path $Win10SdkIncludeVersion -PathType Container) {
             Write-Output "ℹ️ Windows SDK ${WinSdkVersionString} installed successfully."
           } else {
-            Write-Output "::error::Failed to install Windows SDK ${WinSdkVersionString}."
-            Write-Output "Installer log:"
-            $log = Get-ChildItem "${env:TEMP}" -Filter "dd_installer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-            Get-Content $log.FullName
+            Write-Output "::error::Failed to install Windows SDK ${WinSdkVersionString}. Check the installer log for details."
             exit 1
           }
         }
@@ -169,6 +176,13 @@ runs:
             # Skip if the directory cannot be parsed as a version.
           }
         }
+
+    - name: Upload installer log
+      if: always() && steps.setup-windows-sdk.outputs.log-file != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.upload-prefix }}-windows-sdk-installer-log
+        path: ${{ steps.setup-windows-sdk.outputs.log-file }}
 
     - name: Install Windows MSVC version ${{ inputs.msvc-version }}
       if: steps.sanitize-input.outputs.build-os == 'windows' && inputs.msvc-version != ''
@@ -212,6 +226,9 @@ runs:
                 "--add", "Microsoft.VisualStudio.Component.VC.${MSVCPackageVersion}.ATL.ARM64"
         $process.WaitForExit()
 
+        $LogFile = Get-ChildItem "${env:TEMP}" -Filter "dd_installer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        "log-file=$($LogFile.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
         # Check if the MSVC version was installed successfully.
         $MSVCBuildToolsVersion = ""
         foreach ($dir in Get-ChildItem -Path $MSVCDir -Directory) {
@@ -224,15 +241,19 @@ runs:
         }
 
         if ($MSVCBuildToolsVersion -eq "") {
-          Write-Output "::error::Failed to install MSVC ${MSVCVersionString}."
-          Write-Output "Installer log:"
-          $log = Get-ChildItem "${env:TEMP}" -Filter "dd_installer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-          Get-Content $log.FullName
+          Write-Output "::error::Failed to install MSVC ${MSVCVersionString}. Check the installer log for details."
           exit 1
         } else {
           Write-Output "ℹ️ MSVC ${MSVCBuildToolsVersion} installed successfully."
           "windows-build-tools-version=${MSVCBuildToolsVersion}" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
         }
+
+    - name: Upload installer log
+      if: always() && steps.setup-msvc.outputs.log-file != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.upload-prefix }}-msvc-installer-log
+        path: ${{ steps.setup-msvc.outputs.log-file }}
 
     - name: Setup Visual Studio Developer Environment
       if: steps.sanitize-input.outputs.build-os == 'windows' && inputs.setup-vs-dev-env == 'true'

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -2,12 +2,6 @@ name: Setup build
 description: Sets up the build environment for the current job
 
 inputs:
-  upload-prefix:
-    description: |
-      The prefix to use for the uploaded artifacts. This is used to distinguish
-      between different matrix jobs in the same workflow.
-    required: true
-    type: string
   windows-sdk-version:
     description: The Windows SDK version to use, e.g. "10.0.22621.0"
     required: false
@@ -147,13 +141,12 @@ runs:
                   "--add", "Microsoft.VisualStudio.Component.Windows11SDK.${WinSdkVersionBuild}"
           $process.WaitForExit()
 
-          $LogFile = Get-ChildItem "${env:TEMP}" -Filter "dd_installer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-          "log-file=$($LogFile.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-
           if (Test-Path -Path $Win10SdkIncludeVersion -PathType Container) {
             Write-Output "ℹ️ Windows SDK ${WinSdkVersionString} installed successfully."
           } else {
             Write-Output "::error::Failed to install Windows SDK ${WinSdkVersionString}. Check the installer log for details."
+            $LogFile = Get-ChildItem "${env:TEMP}" -Filter "dd_installer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+            "log-file=$($LogFile.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
             exit 1
           }
         }
@@ -181,7 +174,7 @@ runs:
       if: always() && steps.setup-windows-sdk.outputs.log-file != ''
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.upload-prefix }}-windows-sdk-installer-log
+        name: ${{ github.job }}-windows-sdk-installer-log
         path: ${{ steps.setup-windows-sdk.outputs.log-file }}
 
     - name: Install Windows MSVC version ${{ inputs.msvc-version }}
@@ -226,9 +219,6 @@ runs:
                 "--add", "Microsoft.VisualStudio.Component.VC.${MSVCPackageVersion}.ATL.ARM64"
         $process.WaitForExit()
 
-        $LogFile = Get-ChildItem "${env:TEMP}" -Filter "dd_installer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-        "log-file=$($LogFile.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-
         # Check if the MSVC version was installed successfully.
         $MSVCBuildToolsVersion = ""
         foreach ($dir in Get-ChildItem -Path $MSVCDir -Directory) {
@@ -242,6 +232,8 @@ runs:
 
         if ($MSVCBuildToolsVersion -eq "") {
           Write-Output "::error::Failed to install MSVC ${MSVCVersionString}. Check the installer log for details."
+          $LogFile = Get-ChildItem "${env:TEMP}" -Filter "dd_installer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          "log-file=$($LogFile.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           exit 1
         } else {
           Write-Output "ℹ️ MSVC ${MSVCBuildToolsVersion} installed successfully."
@@ -252,7 +244,7 @@ runs:
       if: always() && steps.setup-msvc.outputs.log-file != ''
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.upload-prefix }}-msvc-installer-log
+        name: ${{ github.job }}-msvc-installer-log
         path: ${{ steps.setup-msvc.outputs.log-file }}
 
     - name: Setup Visual Studio Developer Environment

--- a/.github/workflows/test-setup-build.yml
+++ b/.github/workflows/test-setup-build.yml
@@ -36,7 +36,6 @@ jobs:
         id: setup-build
         uses: ./.github/actions/setup-build
         with:
-          upload-prefix: "test-build-windows-vs-dev-env"
           windows-sdk-version: ${{ env.TEST_WIN_SDK_VERSION }}
           msvc-version: ${{ env.TEST_MSVC_VERSION }}
           setup-vs-dev-env: true
@@ -142,7 +141,6 @@ jobs:
         id: setup-build
         uses: ./.github/actions/setup-build
         with:
-          upload-prefix: "test-build-windows-no-vs-dev-env"
           windows-sdk-version: ${{ env.TEST_WIN_SDK_VERSION }}
           msvc-version: ${{ env.TEST_MSVC_VERSION }}
           setup-vs-dev-env: false
@@ -241,14 +239,13 @@ jobs:
         id: setup-build
         uses: ./.github/actions/setup-build
         with:
-          upload-prefix: "test-incorrect-windows-sdk-version"
           windows-sdk-version: "99.99.9999.0"  # Intentionally incorrect version
         continue-on-error: true
 
       - name: Download log file
         uses: actions/download-artifact@v4
         with:
-          name: test-incorrect-windows-sdk-version-windows-sdk-installer-log
+          name: ${{ github.job }}-windows-sdk-installer-log
           path: ${{ github.workspace }}/windows-sdk-installer-log
 
       - name: Check the log file existence
@@ -273,14 +270,13 @@ jobs:
         id: setup-build
         uses: ./.github/actions/setup-build
         with:
-          upload-prefix: "test-incorrect-msvc-version"
           msvc-version: "14.99"  # Intentionally incorrect version
         continue-on-error: true
 
       - name: Download log file
         uses: actions/download-artifact@v4
         with:
-          name: test-incorrect-msvc-version-msvc-installer-log
+          name: ${{ github.job }}-msvc-installer-log
           path: ${{ github.workspace }}/msvc-installer-log
 
       - name: Check the log file existence

--- a/.github/workflows/test-setup-build.yml
+++ b/.github/workflows/test-setup-build.yml
@@ -36,6 +36,7 @@ jobs:
         id: setup-build
         uses: ./.github/actions/setup-build
         with:
+          upload-prefix: "test-build-windows-vs-dev-env"
           windows-sdk-version: ${{ env.TEST_WIN_SDK_VERSION }}
           msvc-version: ${{ env.TEST_MSVC_VERSION }}
           setup-vs-dev-env: true
@@ -141,6 +142,7 @@ jobs:
         id: setup-build
         uses: ./.github/actions/setup-build
         with:
+          upload-prefix: "test-build-windows-no-vs-dev-env"
           windows-sdk-version: ${{ env.TEST_WIN_SDK_VERSION }}
           msvc-version: ${{ env.TEST_MSVC_VERSION }}
           setup-vs-dev-env: false
@@ -226,4 +228,68 @@ jobs:
             exit 1
           } else {
             Write-Output "🎉 All environment checks passed successfully."
+          }
+
+  test-incorrect-windows-sdk-version:
+    name: Incorrect Windows SDK Version
+    runs-on: ${{ inputs.windows-runner || 'windows-latest' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Set up build with incorrect Windows SDK version
+        id: setup-build
+        uses: ./.github/actions/setup-build
+        with:
+          upload-prefix: "test-incorrect-windows-sdk-version"
+          windows-sdk-version: "99.99.9999.0"  # Intentionally incorrect version
+        continue-on-error: true
+
+      - name: Download log file
+        uses: actions/download-artifact@v4
+        with:
+          name: test-incorrect-windows-sdk-version-windows-sdk-installer-log
+          path: ${{ github.workspace }}/windows-sdk-installer-log
+
+      - name: Check the log file existence
+        run: |
+          $LogFile = Get-ChildItem -Path "${{ github.workspace }}/windows-sdk-installer-log"
+          if (-Not (Test-Path -Path $LogFile)) {
+            Write-Output "::error::Log file not found."
+            exit 1
+          } else {
+            Write-Output "✅ Log file found. File contents:"
+            Get-Content -Path "$LogFile"
+          }
+
+  test-incorrect-msvc-version:
+    name: Incorrect MSVC Version
+    runs-on: ${{ inputs.windows-runner || 'windows-latest' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Set up build with incorrect MSVC version
+        id: setup-build
+        uses: ./.github/actions/setup-build
+        with:
+          upload-prefix: "test-incorrect-msvc-version"
+          msvc-version: "14.99"  # Intentionally incorrect version
+        continue-on-error: true
+
+      - name: Download log file
+        uses: actions/download-artifact@v4
+        with:
+          name: test-incorrect-msvc-version-msvc-installer-log
+          path: ${{ github.workspace }}/msvc-installer-log
+
+      - name: Check the log file existence
+        run: |
+          $LogFile = Get-ChildItem -Path "${{ github.workspace }}/msvc-installer-log"
+          if (-Not (Test-Path -Path $LogFile)) {
+            Write-Output "::error::Log file not found."
+            exit 1
+          } else {
+            Write-Output "✅ Log file found. File contents:"
+            Get-Content -Path "$LogFile"
           }


### PR DESCRIPTION
Rather than dumping the log to the bot output, the log file is now uploaded as an artifact named after the job name.