### PR TITLE
test-setup-build: Properly escape quotes

### DIFF
--- a/.github/workflows/test-setup-build.yml
+++ b/.github/workflows/test-setup-build.yml
@@ -83,7 +83,7 @@ jobs:
             Write-Output "::error::Expected build tools version `"${env:TEST_BUILD_TOOLS_EXPECTED_VERSION}`", but got `"${BuildToolsVersion}`"."
             $HasError = $true
           } else {
-            Write-Output "✅ Build tools version `${BuildToolsVersion}` matches expected version."
+            Write-Output "✅ Build tools version `"${BuildToolsVersion}`" matches expected version."
           }
 
           # Check if the correct MSVC version is installed.
@@ -92,7 +92,7 @@ jobs:
           $InstallPath = (& "$VSWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
           $MSVCDir = Join-Path $InstallPath "VC" "Tools" "MSVC" $BuildToolsVersion
           if (Test-Path -Path $MSVCDir) {
-            Write-Output "✅ MSVC version `${env:TEST_MSVC_VERSION}`" is installed."
+            Write-Output "✅ MSVC version `"${env:TEST_MSVC_VERSION}`" is installed."
           } else {
             Write-Output "::error::MSVC directory not found: `"${MSVCDir}`"."
             $HasError = $true
@@ -189,7 +189,7 @@ jobs:
             Write-Output "::error::Expected build tools version `"${env:TEST_BUILD_TOOLS_EXPECTED_VERSION}`", but got `"${BuildToolsVersion}`"."
             $HasError = $true
           } else {
-            Write-Output "✅ Build tools version `${BuildToolsVersion}` matches expected version."
+            Write-Output "✅ Build tools version `"${BuildToolsVersion}`" matches expected version."
           }
 
           # Check if the correct MSVC version is installed.
@@ -198,7 +198,7 @@ jobs:
           $InstallPath = (& "$VSWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
           $MSVCDir = Join-Path $InstallPath "VC" "Tools" "MSVC" $BuildToolsVersion
           if (Test-Path -Path $MSVCDir) {
-            Write-Output "✅ MSVC version `${env:TEST_MSVC_VERSION}`" is installed."
+            Write-Output "✅ MSVC version `"${env:TEST_MSVC_VERSION}`" is installed."
           } else {
             Write-Output "::error::MSVC directory not found: `"${MSVCDir}`"."
             $HasError = $true


### PR DESCRIPTION
The back ticks were meant to escape quotes, not the dollar sign.