### PR TITLE
build: Use the setup-build action in swift-toolchain

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -284,13 +284,11 @@ env:
 
   # Workaround for issues with building with SDK version 26100.
   # See https://github.com/compnerd/swift-build/issues/909 for details.
-  WORKAROUND_WINDOWS_SDK_VERSION: 10.0.22621.0
-  UNSUPPORTED_WINDOWS_SDK_VERSION: 10.0.26100.0
+  WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION: 10.0.22621.0
 
   # Workaround for issues with building with MSVC 14.43.
   # See https://github.com/swiftlang/swift/issues/79852 for details.
-  WORKAROUND_WINDOWS_COMPILER_VERSION: 14.42.34433
-  WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE: 14.42.17.12
+  WORKAROUND_BOOTSTRAP_WINDOWS_MSVC_VERSION: 14.42
 
 defaults:
   run:
@@ -309,22 +307,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/swift-build
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
           show-progress: false
-
-      - uses: actions/checkout@v4.2.2
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
         with:
-          repository: swiftlang/swift-toolchain-sqlite
-          ref: ${{ inputs.swift_toolchain_sqlite_revision }}
-          path: ${{ github.workspace }}/SourceCache/swift-toolchain-sqlite
-          show-progress: false
-
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
+          windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
+          setup-vs-dev-env: true
+          host-arch: ${{ matrix.arch }}
 
       - uses: seanmiddleditch/gha-setup-ninja@96bed6edff20d1dd61ecff9b75cc519d516e6401 # master
         if: inputs.build_os == 'Darwin'
@@ -339,15 +328,21 @@ jobs:
           $stringAsStream.Position = 0
           $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
-
       - name: Setup sccache
-        uses: ./SourceCache/swift-build/.github/actions/setup-sccache
+        uses: ./SourceCache/gha-swift-build/.github/actions/setup-sccache
         with:
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           aws-region: ${{ vars.SCCACHE_AWS_REGION }}
           aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
           disk-max-size: 100M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-sqlite
+
+      - uses: actions/checkout@v4.2.2
+        with:
+          repository: swiftlang/swift-toolchain-sqlite
+          ref: ${{ inputs.swift_toolchain_sqlite_revision }}
+          path: ${{ github.workspace }}/SourceCache/swift-toolchain-sqlite
+          show-progress: false
 
       - name: Configure SQLite
         run: |
@@ -383,6 +378,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          show-progress: false
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+        with:
+          windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
+          setup-vs-dev-env: true
+
+      - uses: actions/checkout@v4.2.2
         # There is currently no Android NDK for Windows ARM64 so build ds2_tools only on Windows X64 host only
         if: inputs.build_android
         with:
@@ -390,14 +394,6 @@ jobs:
           ref: ${{ inputs.ds2_revision }}
           path: ${{ github.workspace }}/SourceCache/ds2
           show-progress: false
-
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        if: inputs.build_android
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: amd64
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
 
       # TODO(issues/205): Preload Chocolatey package manager on Azure images so we can remove this step.
       - uses: andrurogerz/ensure-chocolatey@v1
@@ -480,6 +476,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          show-progress: false
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+        if: inputs.build_android
+        with:
+          windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
+          setup-vs-dev-env:  ${{ matrix.os == 'Windows' }}
+          host-arch: ${{ matrix.arch }}
+
+      - uses: actions/checkout@v4.2.2
         # There is currently no Android NDK for Windows ARM64 so build ds2 only on Windows X64 host only
         if: inputs.build_android
         with:
@@ -487,14 +494,6 @@ jobs:
           ref: ${{ inputs.ds2_revision }}
           path: ${{ github.workspace }}/SourceCache/ds2
           show-progress: false
-
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        if: inputs.build_android
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
 
       # TODO(issues/205): Preload Chocolatey package manager on Azure images so we can remove this step.
       - uses: andrurogerz/ensure-chocolatey@v1
@@ -563,23 +562,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/swift-build
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
           show-progress: false
-
-      - uses: actions/checkout@v4.2.2
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
         with:
-          repository: swiftlang/swift-cmark
-          ref: ${{ inputs.swift_cmark_revision }}
-          path: ${{ github.workspace }}/SourceCache/cmark-gfm
-          show-progress: false
-
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
-
+          windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
+          setup-vs-dev-env: true
+          host-arch: ${{ matrix.arch }}
       - uses: seanmiddleditch/gha-setup-ninja@96bed6edff20d1dd61ecff9b75cc519d516e6401 # master
         if: inputs.build_os == 'Darwin'
 
@@ -593,15 +582,21 @@ jobs:
           $stringAsStream.Position = 0
           $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
-
       - name: Setup sccache
-        uses: ./SourceCache/swift-build/.github/actions/setup-sccache
+        uses: ./SourceCache/gha-swift-build/.github/actions/setup-sccache
         with:
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           aws-region: ${{ vars.SCCACHE_AWS_REGION }}
           aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
           disk-max-size: 1M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-cmark-gfm
+
+      - uses: actions/checkout@v4.2.2
+        with:
+          repository: swiftlang/swift-cmark
+          ref: ${{ inputs.swift_cmark_revision }}
+          path: ${{ github.workspace }}/SourceCache/cmark-gfm
+          show-progress: false
 
       - name: Configure cmark-gfm
         run: >
@@ -643,8 +638,34 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/swift-build
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
           show-progress: false
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+        with:
+          windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
+          setup-vs-dev-env: true
+          host-arch: ${{ matrix.arch }}
+      - uses: seanmiddleditch/gha-setup-ninja@96bed6edff20d1dd61ecff9b75cc519d516e6401 # master
+        if: inputs.build_os == 'Darwin'
+
+      - name: Compute workspace hash
+        id: workspace_hash
+        run: |
+          $stringAsStream = [System.IO.MemoryStream]::new()
+          $writer = [System.IO.StreamWriter]::new($stringAsStream)
+          $writer.write("${{ github.workspace }}")
+          $writer.Flush()
+          $stringAsStream.Position = 0
+          $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
+          echo "hash=$hash" >> $env:GITHUB_OUTPUT
+      - name: Setup sccache
+        uses: ./SourceCache/gha-swift-build/.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
+          aws-region: ${{ vars.SCCACHE_AWS_REGION }}
+          aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
+          disk-max-size: 100M
+          disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-build_tools
 
       - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
@@ -663,36 +684,6 @@ jobs:
           ref: ${{ inputs.swift_revision }}
           path: ${{ github.workspace }}/SourceCache/swift
           show-progress: false
-
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
-
-      - uses: seanmiddleditch/gha-setup-ninja@96bed6edff20d1dd61ecff9b75cc519d516e6401 # master
-        if: inputs.build_os == 'Darwin'
-
-      - name: Compute workspace hash
-        id: workspace_hash
-        run: |
-          $stringAsStream = [System.IO.MemoryStream]::new()
-          $writer = [System.IO.StreamWriter]::new($stringAsStream)
-          $writer.write("${{ github.workspace }}")
-          $writer.Flush()
-          $stringAsStream.Position = 0
-          $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
-          echo "hash=$hash" >> $env:GITHUB_OUTPUT
-
-      - name: Setup sccache
-        uses: ./SourceCache/swift-build/.github/actions/setup-sccache
-        with:
-          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
-          aws-region: ${{ vars.SCCACHE_AWS_REGION }}
-          aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
-          disk-max-size: 100M
-          disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-build_tools
 
       - name: Configure Tools
         run: |
@@ -788,6 +779,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          show-progress: false
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+        id: setup-build
+        with:
+          msvc-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_MSVC_VERSION }}
+          windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
+          host-arch: ${{ matrix.arch }}
+
+      - uses: actions/checkout@v4.2.2
+        with:
           repository: swiftlang/swift-llbuild
           ref: ${{ inputs.swift_llbuild_revision }}
           path: ${{ github.workspace }}/SourceCache/llbuild
@@ -833,43 +835,23 @@ jobs:
           release-asset-name: installer-${{ inputs.build_arch }}.exe
           release-tag-name: ${{ env.WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_RELEASE }}
 
-      # This is a workaround for not being able to build with MSVC 14.43.
-      # See https://github.com/swiftlang/swift/issues/79852 for details.
-      - name: Install MSVC ${{ env.WORKAROUND_WINDOWS_COMPILER_VERSION }}
-        if: matrix.os == 'Windows'
-        run: |
-          $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
-          $VsWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
-          $VsInstaller = Join-Path "${InstallerLocation}" "vs_installer.exe"
-          $InstallPath = (& "$VsWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
-          $process = Start-Process "$VsInstaller" `
-              -PassThru `
-              -ArgumentList "modify", `
-                  "--installPath", "`"$InstallPath`"", `
-                  "--channelId", "https://aka.ms/vs/17/release/channel", `
-                  "--quiet", "--norestart", "--nocache", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.x86.x64", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.ATL", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.ARM64", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.ATL.ARM64"
-          $process.WaitForExit()
-
       - name: Build early swift-driver
         run: |
           $env:SWIFTCI_USE_LOCAL_DEPS=1
-          $ExtraFlags = if ("${{ matrix.os }}" -eq "Windows") {
+          $BuildToolsVersion = "${{ steps.setup-build.outputs.windows-build-tools-version }}"
+          $ExtraFlags = if ($BuildToolsVersion -ne "") {
               $Win10SdkRoot = Get-ItemPropertyValue `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots" `
                 -Name "KitsRoot10"
               @("-Xlinker", "${env:SDKROOT}/usr/lib/swift/windows/${{ matrix.cpu }}/swiftCore.lib",
-                "-Xswiftc", "-windows-sdk-version", "-Xswiftc", "${env:WORKAROUND_WINDOWS_SDK_VERSION}",
+                "-Xswiftc", "-windows-sdk-version", "-Xswiftc", "${env:WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION}",
                 "-Xswiftc", "-windows-sdk-root", "-Xswiftc", "${Win10SdkRoot}",
-                "-Xbuild-tools-swiftc", "-windows-sdk-version", "-Xbuild-tools-swiftc", "${env:WORKAROUND_WINDOWS_SDK_VERSION}",
+                "-Xbuild-tools-swiftc", "-windows-sdk-version", "-Xbuild-tools-swiftc", "${env:WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION}",
                 "-Xbuild-tools-swiftc", "-windows-sdk-root", "-Xbuild-tools-swiftc", "${Win10SdkRoot}",
-                "-Xswiftc", "-visualc-tools-version", "-Xswiftc", "${env:WORKAROUND_WINDOWS_COMPILER_VERSION}",
-                "-Xbuild-tools-swiftc", "-visualc-tools-version", "-Xbuild-tools-swiftc", "${env:WORKAROUND_WINDOWS_COMPILER_VERSION}",
-                "-Xcc", "-Xmicrosoft-visualc-tools-version", "-Xcc", "${env:WORKAROUND_WINDOWS_COMPILER_VERSION}",
-                "-Xcxx", "-Xmicrosoft-visualc-tools-version", "-Xcxx", "${env:WORKAROUND_WINDOWS_COMPILER_VERSION}"
+                "-Xswiftc", "-visualc-tools-version", "-Xswiftc", "${BuildToolsVersion}",
+                "-Xbuild-tools-swiftc", "-visualc-tools-version", "-Xbuild-tools-swiftc", "${BuildToolsVersion}",
+                "-Xcc", "-Xmicrosoft-visualc-tools-version", "-Xcc", "${BuildToolsVersion}",
+                "-Xcxx", "-Xmicrosoft-visualc-tools-version", "-Xcxx", "${BuildToolsVersion}"
               )
           } else {
             @()
@@ -932,8 +914,36 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/swift-build
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
           show-progress: false
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+        with:
+          msvc-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_MSVC_VERSION }}
+          windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
+          setup-vs-dev-env: true
+          host-arch: ${{ matrix.arch }}
+      - uses: seanmiddleditch/gha-setup-ninja@96bed6edff20d1dd61ecff9b75cc519d516e6401 # master
+        if: inputs.build_os == 'Darwin'
+
+      - name: Compute workspace hash
+        id: workspace_hash
+        shell: pwsh
+        run: |
+          $stringAsStream = [System.IO.MemoryStream]::new()
+          $writer = [System.IO.StreamWriter]::new($stringAsStream)
+          $writer.write("${{ github.workspace }}")
+          $writer.Flush()
+          $stringAsStream.Position = 0
+          $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
+          echo "hash=$hash" >> $env:GITHUB_OUTPUT
+      - name: Setup sccache
+        uses: ./SourceCache/gha-swift-build/.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
+          aws-region: ${{ vars.SCCACHE_AWS_REGION }}
+          aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
+          disk-max-size: 500M
+          disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.variant }}-compilers
 
       - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
@@ -1016,45 +1026,6 @@ jobs:
           echo "PYTHON_LOCATION_amd64=$env:pythonLocation" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "PYTHON_LOCATION_arm64=${{ github.workspace }}\pythonarm64.${{ env.PYTHON_VERSION_WINDOWS }}\tools" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      # This is a workaround for not being able to build with MSVC 14.43.
-      # See https://github.com/swiftlang/swift/issues/79852 for details.
-      - name: Install MSVC ${{ env.WORKAROUND_WINDOWS_COMPILER_VERSION }}
-        if: matrix.os == 'Windows'
-        run: |
-          $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
-          $VsWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
-          $VsInstaller = Join-Path "${InstallerLocation}" "vs_installer.exe"
-          $InstallPath = (& "$VsWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
-          $process = Start-Process "$VsInstaller" `
-              -PassThru `
-              -ArgumentList "modify", `
-                  "--installPath", "`"$InstallPath`"", `
-                  "--channelId", "https://aka.ms/vs/17/release/channel", `
-                  "--quiet", "--norestart", "--nocache", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.x86.x64", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.ATL", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.ARM64", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.ATL.ARM64"
-          $process.WaitForExit()
-
-          # Delete the unsupported directory version in the `Lib` and `Include` directories.
-          $Win10SdkRoot = Get-ItemPropertyValue `
-            -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots" `
-            -Name "KitsRoot10"
-          Remove-Item -Path "${Win10SdkRoot}\Lib\${env:UNSUPPORTED_WINDOWS_SDK_VERSION}" -Recurse -Force -ErrorAction Ignore
-          Remove-Item -Path "${Win10SdkRoot}\Include\${env:UNSUPPORTED_WINDOWS_SDK_VERSION}" -Recurse -Force -ErrorAction Ignore
-
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
-          toolset_version: ${{ env.WORKAROUND_WINDOWS_COMPILER_VERSION }}
-
-      - uses: seanmiddleditch/gha-setup-ninja@96bed6edff20d1dd61ecff9b75cc519d516e6401 # master
-        if: inputs.build_os == 'Darwin'
-
       - name: Install Swift Toolchain
         if: inputs.build_os == 'Windows'
         uses: compnerd/gha-setup-swift@6c9f2db7c3155c57fe35f160bcd5cf5859b9c1ba # main
@@ -1077,27 +1048,6 @@ jobs:
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
           local-cache: true
-
-      - name: Compute workspace hash
-        id: workspace_hash
-        shell: pwsh
-        run: |
-          $stringAsStream = [System.IO.MemoryStream]::new()
-          $writer = [System.IO.StreamWriter]::new($stringAsStream)
-          $writer.write("${{ github.workspace }}")
-          $writer.Flush()
-          $stringAsStream.Position = 0
-          $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
-          echo "hash=$hash" >> $env:GITHUB_OUTPUT
-
-      - name: Setup sccache
-        uses: ./SourceCache/swift-build/.github/actions/setup-sccache
-        with:
-          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
-          aws-region: ${{ vars.SCCACHE_AWS_REGION }}
-          aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
-          disk-max-size: 500M
-          disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.variant }}-compilers
 
       - name: Setup context
         id: setup-context
@@ -1341,23 +1291,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/swift-build
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
           show-progress: false
-
-      - uses: actions/checkout@v4.2.2
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
         with:
-          repository: madler/zlib
-          ref: ${{ inputs.zlib_revision }}
-          path: ${{ github.workspace }}/SourceCache/zlib
-          show-progress: false
-
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
-
+          windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
+          setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
+          host-arch: ${{ matrix.arch }}
       - uses: seanmiddleditch/gha-setup-ninja@96bed6edff20d1dd61ecff9b75cc519d516e6401 # master
         if: inputs.build_os == 'Darwin'
 
@@ -1371,15 +1311,21 @@ jobs:
           $stringAsStream.Position = 0
           $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
-
       - name: Setup sccache
-        uses: ./SourceCache/swift-build/.github/actions/setup-sccache
+        uses: ./SourceCache/gha-swift-build/.github/actions/setup-sccache
         with:
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           aws-region: ${{ vars.SCCACHE_AWS_REGION }}
           aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
           disk-max-size: 100M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-zlib
+
+      - uses: actions/checkout@v4.2.2
+        with:
+          repository: madler/zlib
+          ref: ${{ inputs.zlib_revision }}
+          path: ${{ github.workspace }}/SourceCache/zlib
+          show-progress: false
 
       - uses: nttld/setup-ndk@v1
         if: matrix.os == 'Android'
@@ -1439,28 +1385,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/swift-build
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
           show-progress: false
 
-      - uses: actions/checkout@v4.2.2
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
         with:
-          repository: curl/curl
-          ref: ${{ inputs.curl_revision }}
-          path: ${{ github.workspace }}/SourceCache/curl
-          show-progress: false
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: ${{ matrix.os }}-${{ matrix.arch }}-zlib-${{ inputs.zlib_version }}
-          path: ${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr
-
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
-
+          windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
+          setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
+          host-arch: ${{ matrix.arch }}
       - uses: seanmiddleditch/gha-setup-ninja@96bed6edff20d1dd61ecff9b75cc519d516e6401 # master
         if: inputs.build_os == 'Darwin'
 
@@ -1474,15 +1406,26 @@ jobs:
           $stringAsStream.Position = 0
           $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
-
       - name: Setup sccache
-        uses: ./SourceCache/swift-build/.github/actions/setup-sccache
+        uses: ./SourceCache/gha-swift-build/.github/actions/setup-sccache
         with:
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           aws-region: ${{ vars.SCCACHE_AWS_REGION }}
           aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
           disk-max-size: 100M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-curl
+
+      - uses: actions/checkout@v4.2.2
+        with:
+          repository: curl/curl
+          ref: ${{ inputs.curl_revision }}
+          path: ${{ github.workspace }}/SourceCache/curl
+          show-progress: false
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.os }}-${{ matrix.arch }}-zlib-${{ inputs.zlib_version }}
+          path: ${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr
 
       - uses: nttld/setup-ndk@v1
         if: matrix.os == 'Android'
@@ -1618,23 +1561,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/swift-build
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
           show-progress: false
-
-      - uses: actions/checkout@v4.2.2
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
         with:
-          repository: gnome/libxml2
-          ref: ${{ inputs.libxml2_revision }}
-          path: ${{ github.workspace }}/SourceCache/libxml2
-          show-progress: false
-
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
-
+          windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
+          setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
+          host-arch: ${{ matrix.arch }}
       - uses: seanmiddleditch/gha-setup-ninja@96bed6edff20d1dd61ecff9b75cc519d516e6401 # master
         if: inputs.build_os == 'Darwin'
 
@@ -1649,15 +1582,21 @@ jobs:
           $stringAsStream.Position = 0
           $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
-
       - name: Setup sccache
-        uses: ./SourceCache/swift-build/.github/actions/setup-sccache
+        uses: ./SourceCache/gha-swift-build/.github/actions/setup-sccache
         with:
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           aws-region: ${{ vars.SCCACHE_AWS_REGION }}
           aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
           disk-max-size: 100M
           disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-libxml2
+
+      - uses: actions/checkout@v4.2.2
+        with:
+          repository: gnome/libxml2
+          ref: ${{ inputs.libxml2_revision }}
+          path: ${{ github.workspace }}/SourceCache/libxml2
+          show-progress: false
 
       - uses: nttld/setup-ndk@v1
         if: matrix.os == 'Android'
@@ -1721,6 +1660,19 @@ jobs:
     name: ${{ matrix.os }} ${{ matrix.arch }} Standard Library
 
     steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          show-progress: false
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+        if: matrix.os != 'Android' || inputs.build_android
+        with:
+          windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
+          setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
+          host-arch: ${{ matrix.arch }}
+      - uses: seanmiddleditch/gha-setup-ninja@96bed6edff20d1dd61ecff9b75cc519d516e6401 # master
+        if: inputs.build_os == 'Darwin'
+
       - name: Download Compilers
         if: matrix.os != 'Android' || inputs.build_android
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
@@ -1770,18 +1722,6 @@ jobs:
         with:
           branch: ${{ env.WORKAROUND_MACOS_PINNED_BOOTSTRAP_TOOLCHAIN_BRANCH }}
           tag: ${{ env.WORKAROUND_MACOS_PINNED_BOOTSTRAP_TOOLCHAIN_TAG }}
-
-      # NOTE(compnerd): we execute unconditionally as we use CMake from VSDevEnv
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        if: matrix.os != 'Android' || inputs.build_android
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
-
-      - uses: seanmiddleditch/gha-setup-ninja@96bed6edff20d1dd61ecff9b75cc519d516e6401 # master
-        if: inputs.build_os == 'Darwin'
 
       - uses: nttld/setup-ndk@v1
         if: matrix.os == 'Android' && inputs.build_android
@@ -1926,6 +1866,16 @@ jobs:
     name: Windows ${{ matrix.arch }} Macros
 
     steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          show-progress: false
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+        with:
+          windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
+          setup-vs-dev-env: true
+          host-arch: ${{ matrix.arch }}
+
       - name: Download Compilers
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
@@ -1964,14 +1914,6 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/swift-testing
           show-progress: false
 
-      # NOTE(compnerd): we execute unconditionally as we use CMake from VSDevEnv
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
-
       - run: |
           $RTLPath = cygpath -w ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/bin
           echo ${RTLPath} | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
@@ -2000,19 +1942,19 @@ jobs:
           use-external-names: false
           case-sensitive: false
           roots:
-            - name: "${Win10SdkRoot}/Include/${env:WORKAROUND_WINDOWS_SDK_VERSION}/um"
+            - name: "${Win10SdkRoot}/Include/${env:UCRTVersion}/um"
               type: directory
               contents:
                 - name: module.modulemap
                   type: file
                   external-contents: "${ModuleMapDir}/winsdk.modulemap"
-            - name: "${Win10SdkRoot}/Include/${env:WORKAROUND_WINDOWS_SDK_VERSION}/ucrt"
+            - name: "${Win10SdkRoot}/Include/${env:UCRTVersion}/ucrt"
               type: directory
               contents:
                 - name: module.modulemap
                   type: file
                   external-contents: "${ModuleMapDir}/ucrt.modulemap"
-            - name: "${VsInstallPath}/VC/Tools/MSVC/${env:WORKAROUND_WINDOWS_COMPILER_VERSION}/include"
+            - name: "${VsInstallPath}/VC/Tools/MSVC/${env:VCToolsVersion}/include"
               type: directory
               contents:
                 - name: module.modulemap
@@ -2198,6 +2140,37 @@ jobs:
     name: ${{ matrix.os }} ${{ matrix.arch }} SDK
 
     steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          show-progress: false
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+        if: matrix.os != 'Android' || inputs.build_android
+        with:
+          msvc-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_MSVC_VERSION }}
+          windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
+          setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
+          host-arch: ${{ matrix.arch }}
+
+      - name: Compute workspace hash
+        id: workspace_hash
+        run: |
+          $stringAsStream = [System.IO.MemoryStream]::new()
+          $writer = [System.IO.StreamWriter]::new($stringAsStream)
+          $writer.write("${{ github.workspace }}")
+          $writer.Flush()
+          $stringAsStream.Position = 0
+          $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
+          echo "hash=$hash" >> $env:GITHUB_OUTPUT
+      - name: Setup sccache
+        uses: ./SourceCache/gha-swift-build/.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
+          aws-region: ${{ vars.SCCACHE_AWS_REGION }}
+          aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
+          disk-max-size: 500M
+          disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-sdk
+
       - uses: actions/download-artifact@v4
         if: matrix.os != 'Android' || inputs.build_android
         with:
@@ -2284,30 +2257,6 @@ jobs:
           ref: ${{ inputs.swift_testing_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-testing
           show-progress: false
-      - uses: actions/checkout@v4.2.2
-        with:
-          path: ${{ github.workspace }}/SourceCache/swift-build
-          show-progress: false
-
-      - name: Compute workspace hash
-        id: workspace_hash
-        run: |
-          $stringAsStream = [System.IO.MemoryStream]::new()
-          $writer = [System.IO.StreamWriter]::new($stringAsStream)
-          $writer.write("${{ github.workspace }}")
-          $writer.Flush()
-          $stringAsStream.Position = 0
-          $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
-          echo "hash=$hash" >> $env:GITHUB_OUTPUT
-
-      - name: Setup sccache
-        uses: ./SourceCache/swift-build/.github/actions/setup-sccache
-        with:
-          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
-          aws-region: ${{ vars.SCCACHE_AWS_REGION }}
-          aws-arn: ${{ vars.SCCACHE_AWS_ARN }}
-          disk-max-size: 500M
-          disk-cache-key: ${{ steps.workspace_hash.outputs.hash }}-${{ matrix.os }}-${{ matrix.arch }}-sdk
 
       - name: Setup environment
         if: matrix.os != 'Android' || inputs.build_android
@@ -2317,44 +2266,6 @@ jobs:
 
           $SDKRoot = cygpath -w ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk
           echo "SDKROOT=${SDKRoot}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      # This is a workaround for not being able to build with MSVC 14.43.
-      # See https://github.com/swiftlang/swift/issues/79852 for details.
-      - name: Install MSVC ${{ env.WORKAROUND_WINDOWS_COMPILER_VERSION }}
-        if: matrix.os == 'Windows'
-        run: |
-          $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
-          $VsWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
-          $VsInstaller = Join-Path "${InstallerLocation}" "vs_installer.exe"
-          $InstallPath = (& "$VsWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
-          $process = Start-Process "$VsInstaller" `
-              -PassThru `
-              -ArgumentList "modify", `
-                  "--installPath", "`"$InstallPath`"", `
-                  "--channelId", "https://aka.ms/vs/17/release/channel", `
-                  "--quiet", "--norestart", "--nocache", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.x86.x64", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.ATL", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.ARM64", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.ATL.ARM64"
-          $process.WaitForExit()
-
-          # Delete the unsupported directory version in the `Lib` and `Include` directories.
-          $Win10SdkRoot = Get-ItemPropertyValue `
-            -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots" `
-            -Name "KitsRoot10"
-          Remove-Item -Path "${Win10SdkRoot}\Lib\${env:UNSUPPORTED_WINDOWS_SDK_VERSION}" -Recurse -Force -ErrorAction Ignore
-          Remove-Item -Path "${Win10SdkRoot}\Include\${env:UNSUPPORTED_WINDOWS_SDK_VERSION}" -Recurse -Force -ErrorAction Ignore
-
-      # NOTE(compnerd): we execute unconditionally as we use CMake from VSDevEnv
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        if: matrix.os != 'Android' || inputs.build_android
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
-          toolset_version: ${{ env.WORKAROUND_WINDOWS_COMPILER_VERSION }}
 
       # FIXME(compnerd): workaround CMake 3.29-3.30 issue
       - uses: lukka/get-cmake@aa1df13cce8c30d2cb58efa871271c5a764623f8 # main
@@ -2388,19 +2299,19 @@ jobs:
           use-external-names: false
           case-sensitive: false
           roots:
-            - name: "${Win10SdkRoot}/Include/${env:WORKAROUND_WINDOWS_SDK_VERSION}/um"
+            - name: "${Win10SdkRoot}/Include/${env:UCRTVersion}/um"
               type: directory
               contents:
                 - name: module.modulemap
                   type: file
                   external-contents: "${ModuleMapDir}/winsdk.modulemap"
-            - name: "${Win10SdkRoot}/Include/${env:WORKAROUND_WINDOWS_SDK_VERSION}/ucrt"
+            - name: "${Win10SdkRoot}/Include/${env:UCRTVersion}/ucrt"
               type: directory
               contents:
                 - name: module.modulemap
                   type: file
                   external-contents: "${ModuleMapDir}/ucrt.modulemap"
-            - name: "${VsInstallPath}/VC/Tools/MSVC/${env:WORKAROUND_WINDOWS_COMPILER_VERSION}/include"
+            - name: "${VsInstallPath}/VC/Tools/MSVC/${env:VCToolsVersion}/include"
               type: directory
               contents:
                 - name: module.modulemap
@@ -2775,6 +2686,17 @@ jobs:
     name: Windows ${{ matrix.arch }} Developer Tools
 
     steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          show-progress: false
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+        with:
+          msvc-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_MSVC_VERSION }}
+          windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
+          setup-vs-dev-env: true
+          host-arch: ${{ matrix.arch }}
+
       - uses: actions/download-artifact@v4
         with:
           name: Windows-${{ matrix.arch }}-sqlite-${{ inputs.swift_toolchain_sqlite_version }}
@@ -2915,41 +2837,6 @@ jobs:
 
           $SDKRoot = cygpath -w ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk
           echo "SDKROOT=${SDKRoot}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      # This is a workaround for not being able to build with MSVC 14.43.
-      # See https://github.com/swiftlang/swift/issues/79852 for details.
-      - name: Install MSVC ${{ env.WORKAROUND_WINDOWS_COMPILER_VERSION }}
-        if: matrix.os == 'Windows'
-        run: |
-          $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
-          $VsWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
-          $VsInstaller = Join-Path "${InstallerLocation}" "vs_installer.exe"
-          $InstallPath = (& "$VsWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
-          $process = Start-Process "$VsInstaller" `
-              -PassThru `
-              -ArgumentList "modify", `
-                  "--installPath", "`"$InstallPath`"", `
-                  "--channelId", "https://aka.ms/vs/17/release/channel", `
-                  "--quiet", "--norestart", "--nocache", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.x86.x64", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.ATL", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.ARM64", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.ATL.ARM64"
-          $process.WaitForExit()
-
-          # Delete the unsupported directory version in the `Lib` and `Include` directories.
-          $Win10SdkRoot = Get-ItemPropertyValue `
-            -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots" `
-            -Name "KitsRoot10"
-          Remove-Item -Path "${Win10SdkRoot}\Lib\${env:UNSUPPORTED_WINDOWS_SDK_VERSION}" -Recurse -Force -ErrorAction Ignore
-          Remove-Item -Path "${Win10SdkRoot}\Include\${env:UNSUPPORTED_WINDOWS_SDK_VERSION}" -Recurse -Force -ErrorAction Ignore
-
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
 
       - run: |
           Move-Item ${env:SDKROOT}/usr/lib/swift/dispatch ${env:SDKROOT}/usr/include/
@@ -3569,6 +3456,17 @@ jobs:
     name: Windows ${{ matrix.arch }} Debugging Tools
 
     steps:
+
+      - uses: actions/checkout@v4.2.2
+        with:
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          show-progress: false
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+        with:
+          windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
+          setup-vs-dev-env: true
+          host-arch: ${{ matrix.arch }}
+
       - name: Download swift-argument-parser
         uses: actions/download-artifact@v4
         with:
@@ -3604,41 +3502,6 @@ jobs:
 
           $SDKRoot = cygpath -w "${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
           echo "SDKROOT=${SDKRoot}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      # This is a workaround for not being able to build with MSVC 14.43.
-      # See https://github.com/swiftlang/swift/issues/79852 for details.
-      - name: Install MSVC ${{ env.WORKAROUND_WINDOWS_COMPILER_VERSION }}
-        if: matrix.os == 'Windows'
-        run: |
-          $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
-          $VsWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
-          $VsInstaller = Join-Path "${InstallerLocation}" "vs_installer.exe"
-          $InstallPath = (& "$VsWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
-          $process = Start-Process "$VsInstaller" `
-              -PassThru `
-              -ArgumentList "modify", `
-                  "--installPath", "`"$InstallPath`"", `
-                  "--channelId", "https://aka.ms/vs/17/release/channel", `
-                  "--quiet", "--norestart", "--nocache", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.x86.x64", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.ATL", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.ARM64", `
-                  "--add", "Microsoft.VisualStudio.Component.VC.${env:WORKAROUND_WINDOWS_COMPILER_VERSION_PACKAGE}.ATL.ARM64"
-          $process.WaitForExit()
-
-          # Delete the unsupported directory version in the `Lib` and `Include` directories.
-          $Win10SdkRoot = Get-ItemPropertyValue `
-            -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots" `
-            -Name "KitsRoot10"
-          Remove-Item -Path "${Win10SdkRoot}\Lib\${env:UNSUPPORTED_WINDOWS_SDK_VERSION}" -Recurse -Force -ErrorAction Ignore
-          Remove-Item -Path "${Win10SdkRoot}\Include\${env:UNSUPPORTED_WINDOWS_SDK_VERSION}" -Recurse -Force -ErrorAction Ignore
-
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        with:
-          host_arch: amd64
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
 
       - run: |
           Move-Item ${env:SDKROOT}/usr/lib/swift/dispatch ${env:SDKROOT}/usr/include/
@@ -3708,6 +3571,15 @@ jobs:
       matrix: ${{ fromJSON(inputs.host_matrix) }}
 
     steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          show-progress: false
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+        with:
+          setup-vs-dev-env: true
+          host-arch: ${{ matrix.arch }}
+
       - name: Download Debugging Tools
         uses: actions/download-artifact@v4
         with:
@@ -3741,6 +3613,13 @@ jobs:
           name: Windows-${{ matrix.arch }}-sdk
           path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform
 
+      - uses: actions/checkout@v4.2.2
+        with:
+          repository: swiftlang/swift-installer-scripts
+          ref: ${{ inputs.swift_installer_scripts_revision }}
+          path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
+          show-progress: false
+
       - run: |
           New-Item -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows/${{ matrix.cpu }}/" -ItemType Directory -Force | Out-Null
 
@@ -3758,13 +3637,6 @@ jobs:
           New-Item -Path "${{ github.workspace }}/BuildRoot/Library/Developer/Runtimes/usr" -ItemType Directory -Force | Out-Null
 
           Move-Item "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/bin" "${{ github.workspace }}/BuildRoot/Library/Developer/Runtimes/usr"
-
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ inputs.build_arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
 
       - run: |
           $CertificatePath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath CodeSign.b64
@@ -3786,20 +3658,6 @@ jobs:
           Move-Item ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/Block ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/include/
           Move-Item ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/_foundation_unicode ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/include/
           Move-Item ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/_FoundationCShims ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/include/
-
-      - uses: actions/checkout@v4.2.2
-        with:
-          repository: swiftlang/swift-installer-scripts
-          ref: ${{ inputs.swift_installer_scripts_revision }}
-          path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
-          show-progress: false
-
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
 
       - run: |
           $CertificatePath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath CodeSign.b64
@@ -3962,6 +3820,14 @@ jobs:
     runs-on: ${{ inputs.default_build_runner }}
 
     steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          show-progress: false
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+        with:
+          setup-vs-dev-env: true
+
       - uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
           name: Windows-amd64-stdlib
@@ -4050,13 +3916,6 @@ jobs:
 
           Move-Item "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/bin" "${{ github.workspace }}/BuildRoot/Library/Developer/Runtimes/Windows-i686/usr"
 
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ inputs.build_arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
-
       - run: |
           $CertificatePath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath CodeSign.b64
           $PFXPath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath CodeSign.pfx
@@ -4130,6 +3989,16 @@ jobs:
     runs-on: ${{ inputs.default_build_runner }}
 
     steps:
+      - if: inputs.build_android
+        uses: actions/checkout@v4.2.2
+        with:
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          show-progress: false
+      - if: inputs.build_android
+        uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+        with:
+          setup-vs-dev-env: true
+
       - if: inputs.build_android
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
@@ -4218,14 +4087,6 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 
-      - if: inputs.build_android
-        uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ inputs.build_arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
-
       - if: inputs.build_android && inputs.signed
         run: |
           $CertificatePath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath CodeSign.b64
@@ -4288,6 +4149,15 @@ jobs:
       matrix: ${{ fromJSON(inputs.host_matrix) }}
 
     steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          show-progress: false
+      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+        with:
+          setup-vs-dev-env: true
+          host-arch: ${{ matrix.arch }}
+
       - uses: actions/download-artifact@v4
         with:
           name: Windows-${{ matrix.arch }}-bld-msi
@@ -4338,13 +4208,6 @@ jobs:
           ref: ${{ inputs.swift_installer_scripts_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
-
-      - uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main
-        with:
-          host_arch: ${{ inputs.build_arch }}
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }}
-          winsdk: ${{ env.WORKAROUND_WINDOWS_SDK_VERSION }}
 
       - run: |
           $CertificatePath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath CodeSign.b64

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -307,9 +307,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         with:
           windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
           setup-vs-dev-env: true
@@ -329,7 +329,7 @@ jobs:
           $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
       - name: Setup sccache
-        uses: ./SourceCache/gha-swift-build/.github/actions/setup-sccache
+        uses: ./SourceCache/ci-build/.github/actions/setup-sccache
         with:
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           aws-region: ${{ vars.SCCACHE_AWS_REGION }}
@@ -379,9 +379,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         with:
           windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
           setup-vs-dev-env: true
@@ -477,9 +477,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         if: inputs.build_android
         with:
           windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
@@ -562,9 +562,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         with:
           windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
           setup-vs-dev-env: true
@@ -583,7 +583,7 @@ jobs:
           $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
       - name: Setup sccache
-        uses: ./SourceCache/gha-swift-build/.github/actions/setup-sccache
+        uses: ./SourceCache/ci-build/.github/actions/setup-sccache
         with:
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           aws-region: ${{ vars.SCCACHE_AWS_REGION }}
@@ -638,9 +638,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         with:
           windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
           setup-vs-dev-env: true
@@ -659,7 +659,7 @@ jobs:
           $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
       - name: Setup sccache
-        uses: ./SourceCache/gha-swift-build/.github/actions/setup-sccache
+        uses: ./SourceCache/ci-build/.github/actions/setup-sccache
         with:
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           aws-region: ${{ vars.SCCACHE_AWS_REGION }}
@@ -779,9 +779,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         id: setup-build
         with:
           msvc-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_MSVC_VERSION }}
@@ -914,9 +914,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         with:
           msvc-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_MSVC_VERSION }}
           windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
@@ -937,7 +937,7 @@ jobs:
           $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
       - name: Setup sccache
-        uses: ./SourceCache/gha-swift-build/.github/actions/setup-sccache
+        uses: ./SourceCache/ci-build/.github/actions/setup-sccache
         with:
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           aws-region: ${{ vars.SCCACHE_AWS_REGION }}
@@ -1291,9 +1291,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         with:
           windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
           setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
@@ -1312,7 +1312,7 @@ jobs:
           $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
       - name: Setup sccache
-        uses: ./SourceCache/gha-swift-build/.github/actions/setup-sccache
+        uses: ./SourceCache/ci-build/.github/actions/setup-sccache
         with:
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           aws-region: ${{ vars.SCCACHE_AWS_REGION }}
@@ -1385,10 +1385,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
 
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         with:
           windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
           setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
@@ -1407,7 +1407,7 @@ jobs:
           $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
       - name: Setup sccache
-        uses: ./SourceCache/gha-swift-build/.github/actions/setup-sccache
+        uses: ./SourceCache/ci-build/.github/actions/setup-sccache
         with:
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           aws-region: ${{ vars.SCCACHE_AWS_REGION }}
@@ -1561,9 +1561,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         with:
           windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
           setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
@@ -1583,7 +1583,7 @@ jobs:
           $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
       - name: Setup sccache
-        uses: ./SourceCache/gha-swift-build/.github/actions/setup-sccache
+        uses: ./SourceCache/ci-build/.github/actions/setup-sccache
         with:
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           aws-region: ${{ vars.SCCACHE_AWS_REGION }}
@@ -1662,9 +1662,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         if: matrix.os != 'Android' || inputs.build_android
         with:
           windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
@@ -1868,9 +1868,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         with:
           windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
           setup-vs-dev-env: true
@@ -2142,9 +2142,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         if: matrix.os != 'Android' || inputs.build_android
         with:
           msvc-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_MSVC_VERSION }}
@@ -2163,7 +2163,7 @@ jobs:
           $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stringAsStream).Hash
           echo "hash=$hash" >> $env:GITHUB_OUTPUT
       - name: Setup sccache
-        uses: ./SourceCache/gha-swift-build/.github/actions/setup-sccache
+        uses: ./SourceCache/ci-build/.github/actions/setup-sccache
         with:
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           aws-region: ${{ vars.SCCACHE_AWS_REGION }}
@@ -2688,9 +2688,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         with:
           msvc-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_MSVC_VERSION }}
           windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
@@ -3459,9 +3459,9 @@ jobs:
 
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         with:
           windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
           setup-vs-dev-env: true
@@ -3573,9 +3573,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         with:
           setup-vs-dev-env: true
           host-arch: ${{ matrix.arch }}
@@ -3822,9 +3822,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         with:
           setup-vs-dev-env: true
 
@@ -3992,10 +3992,10 @@ jobs:
       - if: inputs.build_android
         uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
       - if: inputs.build_android
-        uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+        uses: ./SourceCache/ci-build/.github/actions/setup-build
         with:
           setup-vs-dev-env: true
 
@@ -4151,9 +4151,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          path: ${{ github.workspace }}/SourceCache/gha-swift-build
+          path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-      - uses: ./SourceCache/gha-swift-build/.github/actions/setup-build
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
         with:
           setup-vs-dev-env: true
           host-arch: ${{ matrix.arch }}


### PR DESCRIPTION
* Use the `setup-build` action in every job.
* Move the build machine setup to the beginning of the job as this saves time when it fails.
* Remove `WORKAROUND_WINDOWS_SDK_VERSION` for the smoke tests, they should test the latest Windows SDK version.