### PR TITLE
GHA: emit `TESTING_VERSION` into `Info.plist`

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2710,7 +2710,7 @@ jobs:
             info_plist = r'${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Info.plist'
             with open(os.path.normpath(info_plist), 'wb') as plist:
               # TODO(compnerd) derive this from the install directory
-              plistlib.dump({ 'DefaultProperties': { 'XCTEST_VERSION': '${{ inputs.swift_version }}', 'SWIFTC_FLAGS': ['-use-ld=lld'] } }, plist)
+              plistlib.dump({ 'DefaultProperties': { 'XCTEST_VERSION': '${{ inputs.swift_version }}', 'TESTING_VERSION': '${{ inputs.swift_version }}', 'SWIFTC_FLAGS': ['-use-ld=lld'] } }, plist)
 
             sdk_settings_plist = r'${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/SDKSettings.plist'
             with open(os.path.normpath(sdk_settings_plist), 'wb') as plist:


### PR DESCRIPTION
We did not record the swift-testing version into the `Info.plist` which is expected by tools. Add this missing key to silence the warnings.