### PR TITLE
GHA: setup swift toolchain version information

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1175,6 +1175,7 @@ jobs:
                 -D SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE=${{ github.workspace }}/SourceCache/swift-syntax `
                 -D SWIFT_PATH_TO_STRING_PROCESSING_SOURCE=${{ github.workspace }}/SourceCache/swift-experimental-string-processing `
                 -D SWIFT_PATH_TO_SWIFT_SDK="${{ steps.setup-context.outputs.sdkroot }}" `
+                -D SWIFT_TOOLCHAIN_VERSION="${{ inputs.swift_version}} ${{ inputs.swift_tag }}" `
                 -D CLANG_VENDOR=compnerd.org `
                 -D CLANG_VENDOR_UTI=org.compnerd.dt `
                 -D cmark-gfm_DIR=${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr/lib/cmake `


### PR DESCRIPTION
This embeds a compiler version tag into the output so that we can easily identify the toolchain.