### PR TITLE
setup-build: Disable `vs_installer.exe` self-update

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -135,6 +135,7 @@ runs:
           $process = Start-Process "$VSInstaller" `
               -PassThru `
               -ArgumentList "modify", `
+                  "--noUpdateInstaller", `
                   "--installPath", "`"$InstallPath`"", `
                   "--channelId", "https://aka.ms/vs/17/release/channel", `
                   "--quiet", "--norestart", "--nocache", `
@@ -210,6 +211,7 @@ runs:
         $process = Start-Process "$VSInstaller" `
             -PassThru `
             -ArgumentList "modify", `
+                "--noUpdateInstaller", `
                 "--installPath", "`"$InstallPath`"", `
                 "--channelId", "https://aka.ms/vs/17/release/channel", `
                 "--quiet", "--norestart", "--nocache", `


### PR DESCRIPTION
As suggested on the [DevComm](https://developercommunity.visualstudio.com/t/Visual-Studio-Installer-randomly-fails-t/10924708?) thread, this adds `--noUpdateInstaller` to the `vs_installer.exe` invocation to disable the installer self-update.

This solves the issue of `vs_installer.exe` silently failing to install the requested packages.