### PR TITLE
[GHA] Remove clang-pseudo

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -738,8 +738,6 @@ jobs:
         run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target lldb-tblgen
       - name: Build llvm-config
         run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target llvm-config
-      - name: Build clang-pseudo-gen
-        run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target clang-pseudo-gen
       - name: Build clang-tidy-confusable-chars-gen
         run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target clang-tidy-confusable-chars-gen
       - name: Build swift-def-to-strings-converter
@@ -757,7 +755,6 @@ jobs:
             "clang-tblgen",
             "lldb-tblgen",
             "llvm-config",
-            "clang-pseudo-gen",
             "clang-tidy-confusable-chars-gen",
             "swift-def-to-strings-converter",
             "swift-serialize-diagnostics",


### PR DESCRIPTION
clang-pseudo has been removed shortly after our current llvm update. see https://github.com/llvm/llvm-project/pull/109154

Removing it from the build.
