### PR TITLE
setup-build: Support Swift toolchain installation

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -22,6 +22,18 @@ inputs:
       This is the target architecture for the Visual Studio Developer Environment.
     required: false
     type: string
+  swift-version:
+    description: The Swift version to use, e.g. "6.0.1" for the upstream Apple Swift repository.
+      Or "6.0.0-20261216.0" for a specific snapshot from another repository.
+      If unspecified, the Swift toolchain is not set up.
+    required: false
+    type: string
+  swift-repo:
+    description: |
+      The Swift repository to use, e.g. "thebrowsercompany/swift-build". If unspecified, and
+      `swift-version` is specified, the upstream Apple Swift repository is used.
+    required: false
+    type: string
 
 outputs:
   windows-build-tools-version:
@@ -96,14 +108,39 @@ runs:
           $HostArch = $BuildArch
         }
 
+        ${SwiftVersion} = "${{ inputs.swift-version }}"
+        ${SwiftRepo} = "${{ inputs.swift-repo }}"
+        if ($SwiftRepo -ne "" -and $SwiftVersion -eq "") {
+          Write-Output "::error::The `swift-repo` input was specified, but the `swift-version` input was not. Please specify a Swift toolchain version to use."
+          exit 1
+        }
+
         Write-Output "ℹ️ Build OS: $BuildOS"
         Write-Output "ℹ️ Build architecture: $BuildArch"
         Write-Output "ℹ️ Host architecture: $HostArch"
+
+        # Derive the Swift version and repository from the inputs.
+        if ($SwiftVersion -ne "") {
+          if ($SwiftRepo -eq "") {
+            $SwiftBranch = "swift-${SwiftVersion}-release"
+            $SwiftTag = "${SwiftVersion}-RELEASE"
+            Write-Output "ℹ️ Using upstream Swift toolchain: $SwiftVersion (branch: $SwiftBranch, tag: $SwiftTag)"
+          } else {
+            # Note: This only supports Windows for now.
+            $SwiftReleaseAssetName = "installer-${BuildArch}.exe"
+            $SwiftReleaseTagName = "swift-${SwiftVersion}"
+            Write-Output "ℹ️ Using custom Swift toolchain: $SwiftVersion (repository: $SwiftRepo, tag: $SwiftReleaseTagName, asset: $SwiftReleaseAssetName)"
+          }
+        }
 
         @"
         build-os=$BuildOS
         build-arch=$BuildArch
         host-arch=$HostArch
+        swift-branch=$SwiftBranch
+        swift-tag=$SwiftTag
+        swift-release-asset=$SwiftReleaseAssetName
+        swift-release-tag=$SwiftReleaseTagName
         "@ | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
     - name: Install Windows SDK version ${{ inputs.windows-sdk-version }}
@@ -257,3 +294,19 @@ runs:
         arch: ${{ steps.sanitize-input.outputs.host-arch }}
         winsdk: ${{ inputs.windows-sdk-version }}
         toolset_version: ${{ inputs.msvc-version }}
+
+    - name: Setup Swift toolchain (Upstream)
+      if: inputs.swift-version != '' && inputs.swift-repo == ''
+      uses: compnerd/gha-setup-swift@6c9f2db7c3155c57fe35f160bcd5cf5859b9c1ba # main
+      with:
+        branch: ${{ steps.sanitize-input.outputs.swift-branch }}
+        tag: ${{ steps.sanitize-input.outputs.swift-tag }}
+
+    - name: Setup Swift toolchain (Custom)
+      if: inputs.swift-version != '' && inputs.swift-repo != ''
+      uses: compnerd/gha-setup-swift@6c9f2db7c3155c57fe35f160bcd5cf5859b9c1ba # main
+      with:
+        github-repo: ${{ inputs.swift-repo }}
+        github-token: ${{ github.token }}
+        release-asset-name: ${{ steps.sanitize-input.outputs.swift-release-asset }}
+        release-tag-name: ${{ steps.sanitize-input.outputs.swift-release-tag }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -277,14 +277,12 @@ on:
         required: true
 
 env:
-  # Workaround for needing llvm-17 on macOS preventing us from using the 5.10 toolchain release.
-  WORKAROUND_MACOS_PINNED_BOOTSTRAP_TOOLCHAIN_BRANCH: swift-6.0.1-release
-  WORKAROUND_MACOS_PINNED_BOOTSTRAP_TOOLCHAIN_TAG: 6.0.1-RELEASE
+  PINNED_BOOTSTRAP_TOOLCHAIN_VERSION: 6.0.1
 
   # Workaround for the upstream builds are still built with VS versions (17.9.x and 17.10.x)
   # with the ARM64 miscompile bug.
   WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_REPO: thebrowsercompany/swift-build
-  WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_RELEASE: swift-6.0.0-20241216.0
+  WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_VERSION: 6.0.0-20241216.0
 
   # Workaround for issues with building with SDK version 26100.
   # See https://github.com/compnerd/swift-build/issues/909 for details.
@@ -795,6 +793,8 @@ jobs:
           msvc-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_MSVC_VERSION }}
           windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
           host-arch: ${{ matrix.arch }}
+          swift-version: ${{ inputs.build_os == 'Windows' && env.WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_VERSION || env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+          swift-repo: ${{ inputs.build_os == 'Windows' && env.WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_REPO || '' }}
 
       - uses: actions/checkout@v4.2.2
         with:
@@ -826,22 +826,6 @@ jobs:
           ref: ${{ inputs.swift_driver_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-driver
           show-progress: false
-
-      - name: Install Swift Toolchain (macOS)
-        if: matrix.os == 'Darwin'
-        uses: compnerd/gha-setup-swift@6c9f2db7c3155c57fe35f160bcd5cf5859b9c1ba # main
-        with:
-          branch: ${{ env.WORKAROUND_MACOS_PINNED_BOOTSTRAP_TOOLCHAIN_BRANCH }}
-          tag: ${{ env.WORKAROUND_MACOS_PINNED_BOOTSTRAP_TOOLCHAIN_TAG }}
-
-      - name: Install Swift Toolchain (Windows)
-        if: matrix.os == 'Windows'
-        uses: compnerd/gha-setup-swift@6c9f2db7c3155c57fe35f160bcd5cf5859b9c1ba # main
-        with:
-          github-repo: ${{ env.WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_REPO }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          release-asset-name: installer-${{ inputs.build_arch }}.exe
-          release-tag-name: ${{ env.WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_RELEASE }}
 
       - name: Build early swift-driver
         run: |
@@ -930,6 +914,9 @@ jobs:
           windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
           setup-vs-dev-env: true
           host-arch: ${{ matrix.arch }}
+          swift-version: ${{ inputs.build_os == 'Windows' && env.WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_VERSION || env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+          swift-repo: ${{ inputs.build_os == 'Windows' && env.WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_REPO || '' }}
+
       - uses: seanmiddleditch/gha-setup-ninja@96bed6edff20d1dd61ecff9b75cc519d516e6401 # master
         if: inputs.build_os == 'Darwin'
 
@@ -1034,22 +1021,6 @@ jobs:
           echo "PYTHON_LOCATION_amd64=$env:pythonLocation" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "PYTHON_LOCATION_arm64=${{ github.workspace }}\pythonarm64.${{ env.PYTHON_VERSION_WINDOWS }}\tools" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Install Swift Toolchain
-        if: inputs.build_os == 'Windows'
-        uses: compnerd/gha-setup-swift@6c9f2db7c3155c57fe35f160bcd5cf5859b9c1ba # main
-        with:
-          github-repo: ${{ env.WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_REPO }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          release-asset-name: installer-${{ inputs.build_arch }}.exe
-          release-tag-name: ${{ env.WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_RELEASE }}
-
-      - name: Install Swift Toolchain
-        if: inputs.build_os == 'Darwin'
-        uses: compnerd/gha-setup-swift@6c9f2db7c3155c57fe35f160bcd5cf5859b9c1ba # main
-        with:
-          branch: ${{ env.WORKAROUND_MACOS_PINNED_BOOTSTRAP_TOOLCHAIN_BRANCH }}
-          tag: ${{ env.WORKAROUND_MACOS_PINNED_BOOTSTRAP_TOOLCHAIN_TAG }}
-
       - uses: nttld/setup-ndk@v1
         if: matrix.os == 'Android'
         id: setup-ndk
@@ -1085,7 +1056,7 @@ jobs:
             Remove-Item env:\SDKROOT
           } elseif ( "${{ matrix.os }}" -eq "Darwin" ) {
             # Default swiftc comes from /usr/bin and is not compatible with the toolchain.
-            $CLANG_LOCATION = "${env:HOME}/Library/Developer/Toolchains/swift-${{ env.WORKAROUND_MACOS_PINNED_BOOTSTRAP_TOOLCHAIN_TAG }}.xctoolchain/usr/bin"
+            $CLANG_LOCATION = "${env:HOME}/Library/Developer/Toolchains/swift-${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}-RELEASE.xctoolchain/usr/bin"
             $SWIFTC = Join-Path $CLANG_LOCATION "swiftc"
 
             # We need to use llvm-17 to build the compiler on macOS. We get it from the Swift toolchain.
@@ -1679,6 +1650,8 @@ jobs:
           windows-sdk-version: ${{ env.WORKAROUND_BOOTSTRAP_WINDOWS_SDK_VERSION }}
           setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
           host-arch: ${{ matrix.arch }}
+          swift-version: ${{ inputs.build_os == 'Windows' && env.WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_VERSION || env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+          swift-repo: ${{ inputs.build_os == 'Windows' && env.WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_REPO || '' }}
       - uses: seanmiddleditch/gha-setup-ninja@96bed6edff20d1dd61ecff9b75cc519d516e6401 # master
         if: inputs.build_os == 'Darwin'
 
@@ -1716,21 +1689,6 @@ jobs:
           ref: ${{ inputs.swift_experimental_string_processing_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-experimental-string-processing
           show-progress: false
-
-      - name: Install Swift Toolchain
-        if: inputs.build_os == 'Windows' && (matrix.os != 'Android' || inputs.build_android)
-        uses: compnerd/gha-setup-swift@6c9f2db7c3155c57fe35f160bcd5cf5859b9c1ba # main
-        with:
-          github-repo: ${{ env.WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_REPO }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          release-asset-name: installer-${{ inputs.build_arch }}.exe
-          release-tag-name: ${{ env.WORKAROUND_WINDOWS_PINNED_BOOTSTRAP_TOOLCHAIN_RELEASE }}
-      - name: Install Swift Toolchain
-        if: inputs.build_os == 'Darwin'
-        uses: compnerd/gha-setup-swift@6c9f2db7c3155c57fe35f160bcd5cf5859b9c1ba # main
-        with:
-          branch: ${{ env.WORKAROUND_MACOS_PINNED_BOOTSTRAP_TOOLCHAIN_BRANCH }}
-          tag: ${{ env.WORKAROUND_MACOS_PINNED_BOOTSTRAP_TOOLCHAIN_TAG }}
 
       - uses: nttld/setup-ndk@v1
         if: matrix.os == 'Android' && inputs.build_android

--- a/.github/workflows/test-setup-build.yml
+++ b/.github/workflows/test-setup-build.yml
@@ -23,6 +23,9 @@ env:
   TEST_WIN_SDK_VERSION: "10.0.22000.0"
   TEST_MSVC_VERSION: "14.40"
   TEST_BUILD_TOOLS_EXPECTED_VERSION: "14.40.33807"
+  TEST_UPSTREAM_SWIFT_VERSION: "5.10"
+  TEST_BCNY_SWIFT_VERSION: "6.0.0-20241216.0"
+  TEST_BCNY_SWIFT_REPO: "thebrowsercompany/swift-build"
 
 jobs:
   test-setup-build-windows-vs-dev-env:
@@ -288,4 +291,54 @@ jobs:
           } else {
             Write-Output "✅ Log file found. File contents:"
             Get-Content -Path "$LogFile"
+          }
+
+  test-upstream-swift-install:
+    name: Upstream Swift Installation
+    runs-on: ${{ inputs.windows-runner || 'windows-latest' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Set up build with upstream Swift
+        id: setup-build
+        uses: ./.github/actions/setup-build
+        with:
+          swift-version: ${{ env.TEST_UPSTREAM_SWIFT_VERSION }}
+
+      - name: Check Swift installation
+        run: |
+          $SwiftVersion = & swift --version
+          if ($SwiftVersion -match "Swift version ${env:TEST_UPSTREAM_SWIFT_VERSION}") {
+            Write-Output "✅ Upstream Swift version `"$env:TEST_UPSTREAM_SWIFT_VERSION`" is installed."
+          } else {
+            Write-Output "::error::Expected to find Swift version `"$env:TEST_UPSTREAM_SWIFT_VERSION`" in output:"
+            Write-Output "$SwiftVersion"
+            exit 1
+          }
+
+  test-bcny-swift-install:
+    name: BCNY Swift Installation
+    runs-on: ${{ inputs.windows-runner || 'windows-latest' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+      - name: Set up build with BCNY Swift
+        id: setup-build
+        uses: ./.github/actions/setup-build
+        with:
+          swift-version: ${{ env.TEST_BCNY_SWIFT_VERSION }}
+          swift-repo: ${{ env.TEST_BCNY_SWIFT_REPO }}
+
+      - name: Check Swift installation
+        run: |
+          # Get the expected Swift version from the environment variable (i.e. "6.0" for "6.0.0-20241216.0")
+          $ExpectedSwiftVersion = ${env:TEST_BCNY_SWIFT_VERSION} -replace '-.*$', '' | ForEach-Object { ($_ -split '\.')[0..1] -join '.' }
+          $SwiftVersionOutput = & swift --version
+          if (${SwiftVersionOutput} -match "Swift version ${ExpectedSwiftVersion}") {
+            Write-Output "✅ BCNY Swift version `"${env:TEST_BCNY_SWIFT_VERSION}`" is installed."
+          } else {
+            Write-Output "::error::Expected to find Swift version `"${ExpectedSwiftVersion}`" in output:"
+            Write-Output "${SwiftVersionOutput}"
+            exit 1
           }


### PR DESCRIPTION
* Add support for both upstream and BCNY Swift toolchain installation as part of the `setup-build` action.
* Update users of the `gha-setup-swift` action.