### PR TITLE
compilers: Add lib2 version to CMake configuration

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1134,6 +1134,7 @@ jobs:
                 -D CLANG_VENDOR_UTI=org.compnerd.dt `
                 -D cmark-gfm_DIR=${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr/lib/cmake `
                 -D LibXml2_DIR=${{ github.workspace }}/BinaryCache/Library/libxml2-${{ inputs.libxml2_version }}/usr/lib/cmake/libxml2-${{ inputs.libxml2_version }} `
+                -D LLDB_LIBXML2_VERSION="${{ inputs.libxml2_version }}" `
                 -D PACKAGE_VENDOR=compnerd.org `
                 -D SWIFT_VENDOR=compnerd.org `
                 -D LLVM_PARALLEL_LINK_JOBS=2 `


### PR DESCRIPTION
Update the CMake configuration to match the changes done in swiftlang/swift#82210.