### PR TITLE
compilers: Compute the number of linker jobs

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1053,6 +1053,19 @@ jobs:
 
           $SwiftFlags += " -sdk `"${SDKROOT}`""
 
+          # Compute the number of parallel jobs to use for the build.
+          $RamBytes = if ($IsWindows) {
+            (Get-CimInstance -ClassName Win32_ComputerSystem).TotalPhysicalMemory
+          } elseif ($IsMacOS) {
+            [int64](sysctl -n hw.memsize)
+          } else {
+              throw "Unsupported OS"
+          }
+          $RamGB = [math]::Round($RamBytes / 1GB)
+
+          # Consider 24 GB per link job, to a minimum of 2 jobs.
+          $LinkJobs = [math]::Max(2, [math]::Floor($RamGB / 24))
+
           # Output the context for the configure task.
           $Context = @"
           cc=${CC}
@@ -1066,6 +1079,7 @@ jobs:
           python_include_dir=${PYTHON_INCLUDE_DIR}
           python_binary=${PYTHON_BINARY}
           sdkroot=${SDKROOT}
+          link_jobs=${LinkJobs}
           "@
           Write-Output $Context | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
@@ -1134,8 +1148,8 @@ jobs:
                 -D LLDB_LIBXML2_VERSION="${{ inputs.libxml2_version }}" `
                 -D PACKAGE_VENDOR=compnerd.org `
                 -D SWIFT_VENDOR=compnerd.org `
-                -D LLVM_PARALLEL_LINK_JOBS=2 `
-                -D SWIFT_PARALLEL_LINK_JOBS=2 `
+                -D LLVM_PARALLEL_LINK_JOBS=${{ steps.setup-context.outputs.link_jobs }} `
+                -D SWIFT_PARALLEL_LINK_JOBS=${{ steps.setup-context.outputs.link_jobs }} `
                 -D LLVM_APPEND_VC_REV=NO `
                 -D LLVM_VERSION_SUFFIX="" `
                 -D LLDB_PYTHON_EXE_RELATIVE_PATH=${{ steps.setup-context.outputs.python_binary }} `


### PR DESCRIPTION
Best guesstimate puts the amount of RAM required per linker job at around 24 GiB. This allows us to remove the last differences between the upstream and downstream swift-toolchain workflow.