### PR TITLE
Escape input to LLVM_EXTERNAL_SWIFT_SOURCE_DIR

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -689,6 +689,7 @@ jobs:
 
       - name: Configure Tools
         run: |
+          $LLVM_EXTERNAL_SWIFT_SOURCE_DIR = cygpath -m ${{ github.workspace }}/SourceCache/swift
           cmake -B ${{ github.workspace }}/BinaryCache/0 `
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=${{ matrix.cc }} `
@@ -706,7 +707,7 @@ jobs:
                 -D LLVM_ENABLE_LIBXML2=NO `
                 -D LLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lldb" `
                 -D LLVM_EXTERNAL_PROJECTS="swift" `
-                -D LLVM_EXTERNAL_SWIFT_SOURCE_DIR=${{ github.workspace }}/SourceCache/swift `
+                -D LLVM_EXTERNAL_SWIFT_SOURCE_DIR=$LLVM_EXTERNAL_SWIFT_SOURCE_DIR `
                 -D LLDB_ENABLE_PYTHON=NO `
                 -D LLDB_INCLUDE_TESTS=NO `
                 -D LLDB_ENABLE_SWIFT_SUPPORT=NO `
@@ -1094,6 +1095,8 @@ jobs:
             $ExeSuffix = ""
           }
 
+          $LLVM_EXTERNAL_SWIFT_SOURCE_DIR = cygpath -m ${{ github.workspace }}/SourceCache/swift
+
           cmake -B ${{ github.workspace }}/BinaryCache/1 `
                 -C "${{ github.workspace }}/SourceCache/swift/cmake/caches/${{ matrix.os }}-${{ matrix.cpu }}.cmake" `
                 -D CMAKE_BUILD_TYPE=Release `
@@ -1119,7 +1122,7 @@ jobs:
                 -D LLDB_TABLEGEN="${{ github.workspace }}/BinaryCache/0/bin/lldb-tblgen${ExeSuffix}" `
                 -D LLVM_CONFIG_PATH="${{ github.workspace }}/BinaryCache/0/bin/llvm-config${ExeSuffix}" `
                 -D LLVM_ENABLE_ASSERTIONS=${{ matrix.variant == 'Asserts' && 'YES' || 'NO' }} `
-                -D LLVM_EXTERNAL_SWIFT_SOURCE_DIR=${{ github.workspace }}/SourceCache/swift `
+                -D LLVM_EXTERNAL_SWIFT_SOURCE_DIR=$LLVM_EXTERNAL_SWIFT_SOURCE_DIR `
                 -D LLVM_NATIVE_TOOL_DIR=${{ github.workspace }}/BinaryCache/0/bin `
                 -D LLVM_TABLEGEN="${{ github.workspace }}/BinaryCache/0/bin/llvm-tblgen${ExeSuffix}" `
                 -D LLVM_USE_HOST_TOOLS=NO `


### PR DESCRIPTION
A temprorary fix to allow CI to make progress until  https://github.com/swiftlang/llvm-project/pull/10949 lands

Here is a downstream run: https://github.com/thebrowsercompany/swift-build/actions/runs/16124908464