### PR TITLE
GHA: add swift-subprocess revision tracking

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -183,6 +183,7 @@ jobs:
       swift_markdown_revision: ${{ steps.context.outputs.swift_markdown_revision }}
       swift_package_manager_revision: ${{ steps.context.outputs.swift_package_manager_revision }}
       swift_revision: ${{ steps.context.outputs.swift_revision }}
+      swift_subprocess_revision: ${{ steps.context.outputs.swift_subprocess_revision }}
       swift_syntax_revision: ${{ steps.context.outputs.swift_syntax_revision }}
       swift_system_revision: ${{ steps.context.outputs.swift_system_revision }}
       swift_testing_revision: ${{ steps.context.outputs.swift_testing_revision }}
@@ -278,6 +279,7 @@ jobs:
           swift_lmdb_revision=refs/heads/main
           swift_markdown_revision=refs/tags/${{ inputs.swift_tag }}
           swift_package_manager_revision=refs/tags/${{ inputs.swift_tag }}
+          swift_subprocess_revision=refs/heads/main
           swift_syntax_revision=refs/tags/${{ inputs.swift_tag }}
           swift_system_revision=refs/tags/1.3.0
           swift_testing_revision=refs/heads/main
@@ -831,6 +833,7 @@ jobs:
       swift_markdown_revision: ${{ needs.context.outputs.swift_markdown_revision }}
       swift_package_manager_revision: ${{ needs.context.outputs.swift_package_manager_revision }}
       swift_revision: ${{ needs.context.outputs.swift_revision }}
+      swift_subprocess_revision: ${{ needs.context.outputs.swift_subprocess_revision }}
       swift_syntax_revision: ${{ needs.context.outputs.swift_syntax_revision }}
       swift_system_revision: ${{ needs.context.outputs.swift_system_revision }}
       swift_testing_revision: ${{ needs.context.outputs.swift_testing_revision }}
@@ -914,6 +917,7 @@ jobs:
       swift_markdown_revision: ${{ needs.context.outputs.swift_markdown_revision }}
       swift_package_manager_revision: ${{ needs.context.outputs.swift_package_manager_revision }}
       swift_revision: ${{ needs.context.outputs.swift_revision }}
+      swift_subprocess_revision: ${{ needs.context.outputs.swift_subprocess_revision }}
       swift_syntax_revision: ${{ needs.context.outputs.swift_syntax_revision }}
       swift_system_revision: ${{ needs.context.outputs.swift_system_revision }}
       swift_testing_revision: ${{ needs.context.outputs.swift_testing_revision }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -155,6 +155,10 @@ on:
         required: true
         type: string
 
+      swift_subprocess_revision:
+        required: true
+        type: string
+
       swift_syntax_revision:
         required: true
         type: string


### PR DESCRIPTION
Prepare for building swift-subprocess, start tracking the revision information.