### PR TITLE
Update swift-crypto to 3.12.5

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -268,7 +268,7 @@ jobs:
           swift_corelibs_foundation_revision=refs/tags/${{ inputs.swift_tag }}
           swift_corelibs_libdispatch_revision=refs/tags/${{ inputs.swift_tag }}
           swift_corelibs_xctest_revision=refs/tags/${{ inputs.swift_tag }}
-          swift_crypto_revision=refs/tags/3.0.0
+          swift_crypto_revision=refs/tags/3.12.5
           swift_driver_revision=refs/tags/${{ inputs.swift_tag }}
           swift_experimental_string_processing_revision=refs/tags/${{ inputs.swift_tag }}
           swift_format_revision=refs/heads/main

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3768,19 +3768,45 @@ jobs:
       - name: Build swift-collections
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-collections
 
+      - name: Configure swift-asn1
+        run: |
+          # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang-cl.exe
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/swiftc.exe
+
+          cmake -B ${{ github.workspace }}/BinaryCache/swift-asn1 `
+                -D BUILD_SHARED_LIBS=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
+                -D CMAKE_Swift_COMPILER_WORKS=YES `
+                -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                ${{ matrix.cmake_linker_flags }} `
+                -D CMAKE_SYSTEM_NAME=Windows `
+                -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-asn1
+      - name: Build swift-asn1
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-asn1
+
       - name: Configure swift-crypto
         run: |
           # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang-cl.exe
           $SWIFTC = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/swiftc.exe
 
           cmake -B ${{ github.workspace }}/BinaryCache/swift-crypto `
                 -D BUILD_SHARED_LIBS=NO `
                 -D BUILD_TESTING=NO `
                 -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=cl `
+                -D CMAKE_ASM_COMPILER=${CLANG_CL} `
+                -D CMAKE_ASM_FLAGS="--target=${{ matrix.triple }}" `
+                -D CMAKE_ASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreadedDLL="/MD" `
+                -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
-                -D CMAKE_CXX_COMPILER=cl `
+                -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr `
@@ -3793,23 +3819,26 @@ jobs:
                 -D CMAKE_SYSTEM_NAME=Windows `
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
                 -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift-crypto
+                -S ${{ github.workspace }}/SourceCache/swift-crypto `
+                -D SwiftASN1_DIR=${{ github.workspace }}/BinaryCache/swift-asn1/cmake/modules
+
       - name: Build swift-crypto
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-crypto
 
       - name: Configure swift-llbuild
         run: |
           # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang-cl.exe
           $SWIFTC = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/swiftc.exe
 
           cmake -B ${{ github.workspace }}/BinaryCache/swift-llbuild `
                 -D BUILD_SHARED_LIBS=YES `
                 -D BUILD_TESTING=NO `
                 -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=cl `
+                -D CMAKE_C_COMPILER=${CLANG_CL} `
                 -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
-                -D CMAKE_CXX_COMPILER=cl `
+                -D CMAKE_CXX_COMPILER=${CLANG_CL} `
                 -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
                 -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr `
@@ -3927,28 +3956,6 @@ jobs:
                 -D TSC_DIR=${{ github.workspace }}/BinaryCache/swift-tools-support-core/cmake/modules
       - name: Build swift-driver
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-driver
-
-      - name: Configure swift-asn1
-        run: |
-          # Workaround CMake 3.20 issue
-          $CLANG_CL = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang-cl.exe
-          $SWIFTC = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/swiftc.exe
-
-          cmake -B ${{ github.workspace }}/BinaryCache/swift-asn1 `
-                -D BUILD_SHARED_LIBS=NO `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_Swift_COMPILER=${SWIFTC} `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
-                -D CMAKE_Swift_FLAGS_RELEASE="-O" `
-                ${{ matrix.cmake_linker_flags }} `
-                -D CMAKE_SYSTEM_NAME=Windows `
-                -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift-asn1
-      - name: Build swift-asn1
-        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-asn1
 
       - name: Configure swift-certificates
         run: |

--- a/default.xml
+++ b/default.xml
@@ -20,7 +20,7 @@
   <project remote="github" name="swiftlang/swift-corelibs-libdispatch" path="swift-corelibs-libdispatch" />
   <project remote="github" name="swiftlang/swift-corelibs-foundation" path="swift-corelibs-foundation" />
   <project remote="github" name="swiftlang/swift-corelibs-xctest" path="swift-corelibs-xctest" />
-  <project remote="github" name="apple/swift-crypto" path="swift-crypto" revision="refs/tags/3.12.3" />
+  <project remote="github" name="apple/swift-crypto" path="swift-crypto" revision="refs/tags/3.12.5" />
   <project remote="github" name="swiftlang/swift-docc" path="swift-docc" />
   <project remote="github" name="swiftlang/swift-docc-plugin" path="swift-docc-plugin" revision="refs/tags/1.0.0" />
   <project remote="github" name="swiftlang/swift-docc-render" path="swift-docc-render" />


### PR DESCRIPTION
This also modifies the build order to use the same build of ASN1 for swift-crypto rather than vendoring it automatically for the swift-crypto build.