### PR TITLE
Add support for packaging NoAssert toolchain in CI 

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -4655,8 +4655,8 @@ jobs:
 
       - uses: actions/checkout@v4.2.2
         with:
-          repository: swiftlang/swift-installer-scripts
-          ref: ${{ inputs.swift_installer_scripts_revision }}
+          repository: mhegazy/swift-installer-scripts
+          ref: parametrize-toolchian-authoring
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 
@@ -5038,8 +5038,8 @@ jobs:
 
       - uses: actions/checkout@v4.2.2
         with:
-          repository: swiftlang/swift-installer-scripts
-          ref: ${{ inputs.swift_installer_scripts_revision }}
+          repository: mhegazy/swift-installer-scripts
+          ref: parametrize-toolchian-authoring
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 
@@ -5264,8 +5264,8 @@ jobs:
       - if: inputs.build_android
         uses: actions/checkout@v4.2.2
         with:
-          repository: swiftlang/swift-installer-scripts
-          ref: ${{ inputs.swift_installer_scripts_revision }}
+          repository: mhegazy/swift-installer-scripts
+          ref: no-asserts-poc
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 
@@ -5404,8 +5404,8 @@ jobs:
 
       - uses: actions/checkout@v4.2.2
         with:
-          repository: swiftlang/swift-installer-scripts
-          ref: ${{ inputs.swift_installer_scripts_revision }}
+          repository: mhegazy/swift-installer-scripts
+          ref: no-asserts-poc
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -4655,8 +4655,8 @@ jobs:
 
       - uses: actions/checkout@v4.2.2
         with:
-          repository: mhegazy/swift-installer-scripts
-          ref: parametrize-toolchian-authoring
+          repository: swiftlang/swift-installer-scripts
+          ref: ${{ inputs.swift_installer_scripts_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 
@@ -5133,8 +5133,8 @@ jobs:
 
       - uses: actions/checkout@v4.2.2
         with:
-          repository: mhegazy/swift-installer-scripts
-          ref: parametrize-toolchian-authoring
+          repository: swiftlang/swift-installer-scripts
+          ref: ${{ inputs.swift_installer_scripts_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 
@@ -5518,8 +5518,8 @@ jobs:
 
       - uses: actions/checkout@v4.2.2
         with:
-          repository: mhegazy/swift-installer-scripts
-          ref: parametrize-toolchian-authoring
+          repository: swiftlang/swift-installer-scripts
+          ref: ${{ inputs.swift_installer_scripts_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -5565,7 +5565,7 @@ jobs:
               -p:WindowsArchitectures="`"aarch64;i686;x86_64`"" `
               -p:ProductArchitecture=${{ matrix.arch }} `
               -p:ProductVersion=${{ inputs.swift_version }}-${{ inputs.swift_tag }} `
-              -p:ToolchainVariants="asserts;noasserts" `
+              -p:ToolchainVariants="`"asserts;noasserts`"" `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bundle/installer.wixproj
 
       - if: ${{ inputs.release }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -4631,35 +4631,6 @@ jobs:
         with:
           name: Windows-${{ matrix.arch }}-NoAsserts-compilers
           path: ${{ github.workspace }}/BuildRoot/Library
-
-      - name: Complete NoAsserts layout
-        run: |
-          $AssertToolchainRoot = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+Asserts"
-          $NoAssertToolchainRoot = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+NoAsserts"
-          $LogFile = "${{ github.workspace }}\robocopy-${{ matrix.arch }}.log"
-          # Only compilers have NoAsserts enabled. Copy the rest of the Toolcahin binaries from the Asserts output
-          # Use robocopy for efficient copying
-          #   /E : Copies subdirectories, including empty ones.
-          #   /XC: Excludes existing files with the same timestamp but different file sizes.
-          #   /XN: Excludes existing files that are newer than the copy in the source directory.
-          #   /XO: Excludes existing files that are older than the copy in the source directory.
-          #   /NFL: Do not list coppied files in output
-          #   /NDL: Do not list directories in output
-          #   /NJH: Do not write a job header
-          #   /NC: Do not write file classes
-          #   /NS: Do not write file sizes
-          #   /NP: Do not show progress indicator
-          #   /R:3                - Retry 3 times on failed copies
-          #   /W:5                - Wait 5 seconds between retries
-          #   /LOG:"D:\robocopy.log" - Write output to a log file
-          &robocopy $AssertToolchainRoot $NoAssertToolchainRoot /E /XC /XN /XO /NS /NC /NFL /NDL /NJH /R:3 /W:5 /LOG:"$LogFile"
-    
-      - name: Uploas robocopy log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: robocopy-${{ matrix.arch }}.log
-          path: ${{ github.workspace }}\robocopy-${{ matrix.arch }}.log
       
       - name: Download Developer Tools
         uses: actions/download-artifact@v4
@@ -4742,6 +4713,36 @@ jobs:
             Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
           }
 
+      - name: Complete NoAsserts layout
+        run: |
+          $AssertToolchainRoot = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+Asserts"
+          $NoAssertToolchainRoot = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+NoAsserts"
+          $LogFile = "${{ github.workspace }}\robocopy-${{ matrix.arch }}.log"
+          # Only compilers have NoAsserts enabled. Copy the rest of the Toolcahin binaries from the Asserts output
+          # Use robocopy for efficient copying
+          #   /E : Copies subdirectories, including empty ones.
+          #   /XC: Excludes existing files with the same timestamp but different file sizes.
+          #   /XN: Excludes existing files that are newer than the copy in the source directory.
+          #   /XO: Excludes existing files that are older than the copy in the source directory.
+          #   /NFL: Do not list coppied files in output
+          #   /NDL: Do not list directories in output
+          #   /NJH: Do not write a job header
+          #   /NC: Do not write file classes
+          #   /NS: Do not write file sizes
+          #   /NP: Do not show progress indicator
+          # $exitCode = &robocopy $HostPlatform.ToolchainInstallRoot $HostPlatform.NoAssertsToolchainInstallRoot /E /XC /XN /XO /NS /NC /NFL /NDL /NJH
+          $exitCode = &robocopy $AssertToolchainRoot $NoAssertToolchainRoot /E /XC /XN /XO /R:3 /W:5 /LOG:"$LogFile"
+          if ($LASTEXITCODE -gt 8) {
+              Write-Error "robocopy failed with exit code $LASTEXITCODE"
+              exit $LASTEXITCODE
+          }
+      - name: Uploas robocopy log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: robocopy-${{ matrix.arch }}.log
+          path: ${{ github.workspace }}\robocopy-${{ matrix.arch }}.log
+
       - uses: actions/checkout@v4.2.2
         with:
           repository: microsoft/mimalloc
@@ -4803,7 +4804,7 @@ jobs:
 
       - name: Package Build Tools (NoAsserts)
         run: |
-          # When cross-compiling, bundle the second mimalloc redirect dll as a workaround for
+         # When cross-compiling, bundle the second mimalloc redirect dll as a workaround for
           msbuild -nologo -restore -maxCpuCount `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
               -p:Configuration=Release `

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -4620,10 +4620,16 @@ jobs:
           name: Windows-${{ matrix.arch }}-debugging_tools
           path: ${{ github.workspace }}/BuildRoot/Library
 
-      - name: Download Compilers
+      - name: Download Compilers (Asserts)
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
         with:
           name: Windows-${{ matrix.arch }}-Asserts-compilers
+          path: ${{ github.workspace }}/BuildRoot/Library
+
+      - name: Download Compilers (NoAsserts)
+        uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
+        with:
+          name: Windows-${{ matrix.arch }}-NoAsserts-compilers
           path: ${{ github.workspace }}/BuildRoot/Library
 
       - name: Download Developer Tools
@@ -4720,11 +4726,12 @@ jobs:
           $BuildSuffix = if ("${{ inputs.build_arch }}" -eq "arm64") { "-arm64" } else { "" }
           # Reference: https://github.com/microsoft/mimalloc/tree/dev/bin#minject
           msbuild ${{ github.workspace }}\SourceCache\mimalloc\ide\vs2022\mimalloc.sln -p:Configuration=Release -p:Platform=$HostMSArch
-          $ToolchainBin = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+Asserts\usr\bin"
+          $AssertToolchainBin = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+Asserts\usr\bin"
+          $NoAssertToolchainBin = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+NoAsserts\usr\bin"
           Copy-Item -Path "${{ github.workspace }}\SourceCache\mimalloc\out\msvc-$HostMSArch\Release\mimalloc.dll" `
-            -Destination "$ToolchainBin"
+            -Destination "$AssertToolchainBin"
           Copy-Item -Path "${{ github.workspace }}\SourceCache\mimalloc\out\msvc-$HostMSArch\Release\mimalloc-redirect$HostSuffix.dll" `
-            -Destination "$ToolchainBin"
+            -Destination "$AssertToolchainBin"
           $MimallocExecutables = @("swift.exe",
                                    "swiftc.exe",
                                    "swift-driver.exe",
@@ -4736,11 +4743,16 @@ jobs:
                                    "lld-link.exe",
                                    "ld.lld.exe",
                                    "ld64.lld.exe")
-          foreach ($Exe in $MimallocExecutables) {
+          $AssertBinaries = $MimallocExecutables | ForEach-Object {[IO.Path]::Combine(SAssertToolchainBin, $_)}
+          $NoAssertBinaries = $MimallocExecutables `
+                              | ForEach-Object {[IO.Path]::Combine( $NoAssertToolchainBin, $_)} `
+                              | Where-Object { Test-Path $_ -PathType Leaf }
+          $Binaries = $AssertBinaries + $NoAssertBinaries
+          foreach ($Exe in $Binaries) {
             # Binary-patch in place
-            & "${{ github.workspace }}\SourceCache\mimalloc\bin\minject$BuildSuffix" -f -i -v "$ToolchainBin\$Exe"
+            & "${{ github.workspace }}\SourceCache\mimalloc\bin\minject$BuildSuffix" -f -i -v "$Exe"
             # Log the import table
-            & "${{ github.workspace }}\SourceCache\mimalloc\bin\minject$BuildSuffix" -l "$ToolchainBin\$Exe"
+            & "${{ github.workspace }}\SourceCache\mimalloc\bin\minject$BuildSuffix" -l "$Exe"
           }
 
       - name: Package Build Tools

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -4730,8 +4730,12 @@ jobs:
           $NoAssertToolchainBin = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+NoAsserts\usr\bin"
           Copy-Item -Path "${{ github.workspace }}\SourceCache\mimalloc\out\msvc-$HostMSArch\Release\mimalloc.dll" `
             -Destination "$AssertToolchainBin"
+          Copy-Item -Path "${{ github.workspace }}\SourceCache\mimalloc\out\msvc-$HostMSArch\Release\mimalloc.dll" `
+            -Destination "$NoAssertToolchainBin"
           Copy-Item -Path "${{ github.workspace }}\SourceCache\mimalloc\out\msvc-$HostMSArch\Release\mimalloc-redirect$HostSuffix.dll" `
             -Destination "$AssertToolchainBin"
+          Copy-Item -Path "${{ github.workspace }}\SourceCache\mimalloc\out\msvc-$HostMSArch\Release\mimalloc-redirect$HostSuffix.dll" `
+            -Destination "$NoAssertToolchainBin"
           $MimallocExecutables = @("swift.exe",
                                    "swiftc.exe",
                                    "swift-driver.exe",
@@ -4743,10 +4747,8 @@ jobs:
                                    "lld-link.exe",
                                    "ld.lld.exe",
                                    "ld64.lld.exe")
-          $AssertBinaries = $MimallocExecutables | ForEach-Object {[IO.Path]::Combine(SAssertToolchainBin, $_)}
-          $NoAssertBinaries = $MimallocExecutables `
-                              | ForEach-Object {[IO.Path]::Combine( $NoAssertToolchainBin, $_)} `
-                              | Where-Object { Test-Path $_ -PathType Leaf }
+          $AssertBinaries = $MimallocExecutables | ForEach-Object {[IO.Path]::Combine($AssertToolchainBin, $_)}
+          $NoAssertBinaries = $MimallocExecutables | ForEach-Object {[IO.Path]::Combine($NoAssertToolchainBin, $_)}
           $Binaries = $AssertBinaries + $NoAssertBinaries
           foreach ($Exe in $Binaries) {
             # Binary-patch in place
@@ -4755,7 +4757,7 @@ jobs:
             & "${{ github.workspace }}\SourceCache\mimalloc\bin\minject$BuildSuffix" -l "$Exe"
           }
 
-      - name: Package Build Tools
+      - name: Package Build Tools (Asserts)
         run: |
           # When cross-compiling, bundle the second mimalloc redirect dll as a workaround for
           msbuild -nologo -restore -maxCpuCount `
@@ -4770,7 +4772,22 @@ jobs:
               -p:ProductArchitecture=${{ matrix.arch }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bld/asserts/bld.asserts.wixproj
 
-      - name: Package CLI Tools
+      - name: Package Build Tools (NoAsserts)
+        run: |
+          # When cross-compiling, bundle the second mimalloc redirect dll as a workaround for
+          msbuild -nologo -restore -maxCpuCount `
+              -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
+              -p:Configuration=Release `
+              -p:SignOutput=${{ inputs.signed }} `
+              -p:CERTIFICATE=${env:CERTIFICATE} `
+              -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
+              -p:WORKAROUND_MIMALLOC_ISSUE_997=false `
+              -p:ProductVersion=${{ inputs.swift_version }} `
+              -p:ProductArchitecture=${{ matrix.arch }} `
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bld/noasserts/bld.noasserts.wixproj
+
+      - name: Package CLI Tools (Asserts)
         run: |
           msbuild -nologo -restore -maxCpuCount `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
@@ -4783,7 +4800,20 @@ jobs:
               -p:ProductArchitecture=${{ matrix.arch }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/cli/asserts/cli.asserts.wixproj
 
-      - name: Package Debugging Tools
+      - name: Package CLI Tools (NoAsserts)
+        run: |
+          msbuild -nologo -restore -maxCpuCount `
+              -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
+              -p:Configuration=Release `
+              -p:SignOutput=${{ inputs.signed }} `
+              -p:CERTIFICATE=${env:CERTIFICATE} `
+              -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
+              -p:ProductVersion=${{ inputs.swift_version }} `
+              -p:ProductArchitecture=${{ matrix.arch }} `
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/cli/noasserts/cli.noasserts.wixproj
+ 
+      - name: Package Debugging Tools (Asserts)
         run: |
           msbuild -nologo -restore -maxCpuCount `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
@@ -4796,7 +4826,20 @@ jobs:
               -p:ProductArchitecture=${{ matrix.arch }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/dbg/asserts/dbg.asserts.wixproj
 
-      - name: Package IDE Tools
+      - name: Package Debugging Tools (NoAsserts)
+        run: |
+          msbuild -nologo -restore -maxCpuCount `
+              -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
+              -p:Configuration=Release `
+              -p:SignOutput=${{ inputs.signed }} `
+              -p:CERTIFICATE=${env:CERTIFICATE} `
+              -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
+              -p:ProductVersion=${{ inputs.swift_version }} `
+              -p:ProductArchitecture=${{ matrix.arch }} `
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/dbg/noasserts/dbg.noasserts.wixproj
+
+      - name: Package IDE Tools (Asserts)
         run: |
           msbuild -nologo -restore -maxCpuCount `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
@@ -4808,6 +4851,19 @@ jobs:
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/ide/asserts/ide.asserts.wixproj
+
+      - name: Package IDE Tools (NoAsserts)
+        run: |
+          msbuild -nologo -restore -maxCpuCount `
+              -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
+              -p:Configuration=Release `
+              -p:SignOutput=${{ inputs.signed }} `
+              -p:CERTIFICATE=${env:CERTIFICATE} `
+              -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
+              -p:ProductVersion=${{ inputs.swift_version }} `
+              -p:ProductArchitecture=${{ matrix.arch }} `
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/ide/noasserts/ide.noasserts.wixproj
 
       - name: Package Runtime
         run: |
@@ -4831,13 +4887,21 @@ jobs:
         with:
           subject-path: |
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.asserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.noasserts.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.asserts.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.noasserts.cab
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.asserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.noasserts.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.asserts.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.noasserts.cab
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.asserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.noasserts.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.asserts.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.noasserts.cab
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.asserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.noasserts.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.asserts.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.noasserts.cab
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/rtl.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/rtl.cab
 
@@ -4847,24 +4911,55 @@ jobs:
           path: |
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.asserts.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.asserts.cab
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Windows-${{ matrix.arch }}-bld-noasserts-msi
+          path: |
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.noasserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.noasserts.cab
+
       - uses: actions/upload-artifact@v4
         with:
           name: Windows-${{ matrix.arch }}-cli-asserts-msi
           path: |
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.asserts.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.asserts.cab
+   
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Windows-${{ matrix.arch }}-cli-noasserts-msi
+          path: |
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.noasserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.noasserts.cab
+
       - uses: actions/upload-artifact@v4
         with:
           name: Windows-${{ matrix.arch }}-dbg-asserts-msi
           path: |
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.asserts.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.asserts.cab
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Windows-${{ matrix.arch }}-dbg-noasserts-msi
+          path: |
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.noasserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.noasserts.cab
+
       - uses: actions/upload-artifact@v4
         with:
           name: Windows-${{ matrix.arch }}-ide-asserts-msi
           path: |
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.asserts.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.asserts.cab
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Windows-${{ matrix.arch }}-ide-noasserts-msi
+          path: |
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.noasserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.noasserts.cab
 
       - uses: actions/upload-artifact@v4
         with:
@@ -5265,7 +5360,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           repository: mhegazy/swift-installer-scripts
-          ref: no-asserts-poc
+          ref: parametrize-toolchain-authoring
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 
@@ -5364,15 +5459,34 @@ jobs:
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
       - uses: actions/download-artifact@v4
         with:
+          name: Windows-${{ matrix.arch }}-bld-noasserts-msi
+          path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
+
+      - uses: actions/download-artifact@v4
+        with:
           name: Windows-${{ matrix.arch }}-cli-asserts-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: Windows-${{ matrix.arch }}-cli-noasserts-msi
+          path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
+
       - uses: actions/download-artifact@v4
         with:
           name: Windows-${{ matrix.arch }}-dbg-asserts-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
       - uses: actions/download-artifact@v4
         with:
+          name: Windows-${{ matrix.arch }}-dbg-noasserts-msi
+          path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
+
+      - uses: actions/download-artifact@v4
+        with:
           name: Windows-${{ matrix.arch }}-ide-asserts-msi
+          path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: Windows-${{ matrix.arch }}-ide-noasserts-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
 
       - uses: actions/download-artifact@v4
@@ -5405,7 +5519,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
         with:
           repository: mhegazy/swift-installer-scripts
-          ref: no-asserts-poc
+          ref: parametrize-toolchian-authoring
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 
@@ -5451,6 +5565,7 @@ jobs:
               -p:WindowsArchitectures="`"aarch64;i686;x86_64`"" `
               -p:ProductArchitecture=${{ matrix.arch }} `
               -p:ProductVersion=${{ inputs.swift_version }}-${{ inputs.swift_tag }} `
+              -p:ToolchainVariants="asserts;noasserts" `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bundle/installer.wixproj
 
       - if: ${{ inputs.release }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1108,7 +1108,7 @@ jobs:
                 ${{ matrix.cmake_linker_flags }} `
                 -D CMAKE_STATIC_LIBRARY_PREFIX_Swift= `
                 -D CMAKE_FIND_PACKAGE_PREFER_CONFIG=YES `
-                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+${{ matrix.variant }}/usr `
                 -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
                 ${{ steps.setup-context.outputs.extra_flags }} `
                 -G Ninja `
@@ -1168,9 +1168,9 @@ jobs:
       - name: Copy cmark-gfm shared libraries
         run: |
           if ("${{ matrix.os }}" -eq "Windows") {
-            Copy-Item -Path "${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr/bin/*.dll" -Destination "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin"
+            Copy-Item -Path "${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr/bin/*.dll" -Destination "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+${{ matrix.variant }}/usr/bin"
           } else {
-            Copy-Item -Path "${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr/lib/*.dylib" -Destination "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/lib/swift/host/compiler"
+            Copy-Item -Path "${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr/lib/*.dylib" -Destination "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+${{ matrix.variant }}/usr/lib/swift/host/compiler"
           }
 
       - uses: actions/setup-python@v5
@@ -1185,7 +1185,7 @@ jobs:
             from datetime import datetime
 
             now = datetime.now()
-            info_plist = r'${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/ToolchainInfo.plist'
+            info_plist = r'${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+${{ matrix.variant }}/ToolchainInfo.plist'
             with open(os.path.normpath(info_plist), 'wb') as plist:
               plistlib.dump({ 'Identifier': 'org.compnerd.dt.toolchain.{0}.{1}-asserts'.format(now.strftime('%Y%m%d'), now.timetuple().tm_hour % 6) }, plist)
 
@@ -1198,7 +1198,7 @@ jobs:
       - name: Extract swift-syntax
         run: |
           New-Item -Path ${{ github.workspace }}/BinaryCache/swift-syntax/lib/swift/host -ItemType Directory | Out-Null
-          $ToolchainRoot = "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts"
+          $ToolchainRoot = "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+${{ matrix.variant }}"
           if ("${{ matrix.os }}" -eq "Windows") {
             $bindir = cygpath -m "${{ github.workspace }}/BinaryCache/1"
             Copy-Item -Path "${ToolchainRoot}/usr/lib/*.lib" -Destination "${{ github.workspace }}/BinaryCache/swift-syntax/lib"

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -4636,6 +4636,7 @@ jobs:
         run: |
           $AssertToolchainRoot = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+Asserts"
           $NoAssertToolchainRoot = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+NoAsserts"
+          $LogFile = "${{ github.workspace }}\robocopy-${{ matrix.arch }}.log"
           # Only compilers have NoAsserts enabled. Copy the rest of the Toolcahin binaries from the Asserts output
           # Use robocopy for efficient copying
           #   /E : Copies subdirectories, including empty ones.
@@ -4648,7 +4649,17 @@ jobs:
           #   /NC: Do not write file classes
           #   /NS: Do not write file sizes
           #   /NP: Do not show progress indicator
-          &robocopy $AssertToolchainRoot $NoAssertToolchainRoot /E /XC /XN /XO /NS /NC /NFL /NDL /NJH
+          #   /R:3                - Retry 3 times on failed copies
+          #   /W:5                - Wait 5 seconds between retries
+          #   /LOG:"D:\robocopy.log" - Write output to a log file
+          &robocopy $AssertToolchainRoot $NoAssertToolchainRoot /E /XC /XN /XO /NS /NC /NFL /NDL /NJH /R:3 /W:5 /LOG:"$LogFile"
+    
+      - name: Uploas robocopy log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: robocopy-${{ matrix.arch }}.log
+          path: ${{ github.workspace }}\robocopy-${{ matrix.arch }}.log
       
       - name: Download Developer Tools
         uses: actions/download-artifact@v4

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -5383,8 +5383,8 @@ jobs:
       - if: inputs.build_android
         uses: actions/checkout@v4.2.2
         with:
-          repository: mhegazy/swift-installer-scripts
-          ref: parametrize-toolchain-authoring
+          repository: swiftlang/swift-installer-scripts
+          ref: ${{ inputs.swift_installer_scripts_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -4632,6 +4632,24 @@ jobs:
           name: Windows-${{ matrix.arch }}-NoAsserts-compilers
           path: ${{ github.workspace }}/BuildRoot/Library
 
+      - name: Complete NoAsserts layout
+        run: |
+          $AssertToolchainRoot = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+Asserts"
+          $NoAssertToolchainRoot = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+NoAsserts"
+          # Only compilers have NoAsserts enabled. Copy the rest of the Toolcahin binaries from the Asserts output
+          # Use robocopy for efficient copying
+          #   /E : Copies subdirectories, including empty ones.
+          #   /XC: Excludes existing files with the same timestamp but different file sizes.
+          #   /XN: Excludes existing files that are newer than the copy in the source directory.
+          #   /XO: Excludes existing files that are older than the copy in the source directory.
+          #   /NFL: Do not list coppied files in output
+          #   /NDL: Do not list directories in output
+          #   /NJH: Do not write a job header
+          #   /NC: Do not write file classes
+          #   /NS: Do not write file sizes
+          #   /NP: Do not show progress indicator
+          &robocopy $AssertToolchainRoot $NoAssertToolchainRoot /E /XC /XN /XO /NS /NC /NFL /NDL /NJH
+      
       - name: Download Developer Tools
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -4714,6 +4714,7 @@ jobs:
           }
 
       - name: Complete NoAsserts layout
+        continue-on-error: true
         run: |
           $AssertToolchainRoot = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+Asserts"
           $NoAssertToolchainRoot = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+NoAsserts"
@@ -4736,6 +4737,8 @@ jobs:
               Write-Error "robocopy failed with exit code $LASTEXITCODE"
               exit $LASTEXITCODE
           }
+          exit 0 
+    
       - name: Uploas robocopy log
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -4718,7 +4718,6 @@ jobs:
         run: |
           $AssertToolchainRoot = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+Asserts"
           $NoAssertToolchainRoot = "${{ github.workspace }}\BuildRoot\Library\Developer\Toolchains\${{ inputs.swift_version }}+NoAsserts"
-          $LogFile = "${{ github.workspace }}\robocopy-${{ matrix.arch }}.log"
           # Only compilers have NoAsserts enabled. Copy the rest of the Toolcahin binaries from the Asserts output
           # Use robocopy for efficient copying
           #   /E : Copies subdirectories, including empty ones.
@@ -4731,20 +4730,12 @@ jobs:
           #   /NC: Do not write file classes
           #   /NS: Do not write file sizes
           #   /NP: Do not show progress indicator
-          # $exitCode = &robocopy $HostPlatform.ToolchainInstallRoot $HostPlatform.NoAssertsToolchainInstallRoot /E /XC /XN /XO /NS /NC /NFL /NDL /NJH
-          $exitCode = &robocopy $AssertToolchainRoot $NoAssertToolchainRoot /E /XC /XN /XO /R:3 /W:5 /LOG:"$LogFile"
-          if ($LASTEXITCODE -gt 8) {
-              Write-Error "robocopy failed with exit code $LASTEXITCODE"
-              exit $LASTEXITCODE
+          $exitCode = &robocopy $HostPlatform.ToolchainInstallRoot $HostPlatform.NoAssertsToolchainInstallRoot /E /XC /XN /XO /NS /NC /NFL /NDL /NJH
+          if ($LastExitCode -gt 8) {
+              Write-Error "robocopy failed with exit code $LastExitCode"
+              exit $LastExitCode
           }
           exit 0 
-    
-      - name: Uploas robocopy log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: robocopy-${{ matrix.arch }}.log
-          path: ${{ github.workspace }}\robocopy-${{ matrix.arch }}.log
 
       - uses: actions/checkout@v4.2.2
         with:


### PR DESCRIPTION
Follow up to https://github.com/swiftlang/swift-installer-scripts/pull/448. Adding packaging support for NoAssert toolchain in CI.

# Changes include:

- Apply mimalloc patch to outputs of both no-asserts and asserts toolchains
- Use `matrix.variant` in places where `Asserts` was assumed
- Add robocopy step to fill missing binaries in NoAssert layout
- Independently build and upload msi's for bld, cli, dbg, and ide by variant
- pass the ToolchainVariant flag to the installer.wixproj

Downstream runs can be found at: https://github.com/thebrowsercompany/swift-build/actions/runs/16843690745?pr=308