### PR TITLE
Use a variable to control the version of python used in ci actions

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -381,11 +381,7 @@ jobs:
           echo ANDROID_CLANG_VERSION=18 >> ${GITHUB_OUTPUT}
 
           # Set Python version used in the build
-          if [[ "${{ inputs.windows_build_arch }}" == "arm64" ]] ; then
-            echo python_version=3.11 >> ${GITHUB_OUTPUT}
-          else
-            echo python_version=3.9 >> ${GITHUB_OUTPUT}
-          fi
+          echo python_version=3.9.10>> ${GITHUB_OUTPUT}
 
       - uses: actions/upload-artifact@v4
         if: inputs.create_snapshot == true

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -220,6 +220,7 @@ jobs:
       windows_x64_build_runner: ${{ steps.context.outputs.windows_x64_build_runner }}
       windows_x64_compilers_runner: ${{ steps.context.outputs.windows_x64_compilers_runner }}
       mac_build_runner: ${{ steps.context.outputs.mac_build_runner }}
+      python_version: ${{ steps.context.outputs.python_version }}
       windows_arm64_build_matrix: ${{ steps.setup-matrix.outputs.windows_arm64_build_matrix }}
       windows_arm64_host_matrix: ${{ steps.setup-matrix.outputs.windows_arm64_host_matrix }}
       windows_arm64_compilers_matrix: ${{ steps.setup-matrix.outputs.windows_arm64_compilers_matrix }}
@@ -378,6 +379,13 @@ jobs:
           echo ANDROID_API_LEVEL=${{ inputs.android_api_level }} >> ${GITHUB_OUTPUT}
           echo ANDROID_NDK_VERSION=r27c >> ${GITHUB_OUTPUT}
           echo ANDROID_CLANG_VERSION=18 >> ${GITHUB_OUTPUT}
+
+          # Set Python version used in the build
+          if [[ "${{ inputs.windows_build_arch }}" == "arm64" ]] ; then
+            echo python_version=3.11 >> ${GITHUB_OUTPUT}
+          else
+            echo python_version=3.9 >> ${GITHUB_OUTPUT}
+          fi
 
       - uses: actions/upload-artifact@v4
         if: inputs.create_snapshot == true
@@ -862,6 +870,7 @@ jobs:
       default_build_runner: ${{ needs.context.outputs[format('windows_{0}_build_runner', needs.context.outputs.windows_build_cpu)] }}
       compilers_build_runner: ${{ needs.context.outputs[format('windows_{0}_compilers_runner', needs.context.outputs.windows_build_cpu)] }}
       build_android: ${{ inputs.build_android }}
+      python_version: ${{ needs.context.outputs.python_version }}
     secrets:
       SYMBOL_SERVER_PAT: ${{ secrets.SYMBOL_SERVER_PAT }}
       CERTIFICATE: ${{ secrets.CERTIFICATE }}
@@ -945,6 +954,7 @@ jobs:
       swift_tag: ${{ needs.context.outputs.swift_tag }}
       default_build_runner: ${{ needs.context.outputs.mac_build_runner }}
       compilers_build_runner: ${{ needs.context.outputs.mac_build_runner }}
+      python_version: ${{ needs.context.outputs.python_version }}
     secrets:
       SYMBOL_SERVER_PAT: ${{ secrets.SYMBOL_SERVER_PAT }}
       CERTIFICATE: ${{ secrets.CERTIFICATE }}

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -381,7 +381,7 @@ jobs:
           echo ANDROID_CLANG_VERSION=18 >> ${GITHUB_OUTPUT}
 
           # Set Python version used in the build
-          echo python_version=3.9.10>> ${GITHUB_OUTPUT}
+          echo python_version=3.9.10 >> ${GITHUB_OUTPUT}
 
       - uses: actions/upload-artifact@v4
         if: inputs.create_snapshot == true

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -272,6 +272,10 @@ on:
         default: false
         type: boolean
 
+      python_version:
+        required: true
+        type: string
+
     secrets:
       SYMBOL_SERVER_PAT:
         required: true
@@ -683,7 +687,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: ${{ inputs.python_version }}
 
       - name: Configure Tools
         run: |
@@ -1005,6 +1009,10 @@ jobs:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
           local-cache: true
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python_version }}
+
       - name: Setup context
         id: setup-context
         run: |
@@ -1173,9 +1181,7 @@ jobs:
             Copy-Item -Path "${{ github.workspace }}/BinaryCache/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr/lib/*.dylib" -Destination "${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/lib/swift/host/compiler"
           }
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.9'
+
 
       - uses: jannekem/run-python-script-action@v1
         with:
@@ -1691,7 +1697,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: ${{ inputs.python_version }}
 
       - name: Configure LLVM
         if: matrix.os != 'Android' || inputs.build_android
@@ -2136,7 +2142,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: ${{ inputs.python_version }}
 
       - name: Compute workspace hash
         if: matrix.os != 'Android' || inputs.build_android
@@ -3600,7 +3606,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: ${{ inputs.python_version }}
 
       - uses: jannekem/run-python-script-action@v1
         if: matrix.os != 'Android' || inputs.build_android

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -688,7 +688,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
-          architecture: x64
+          architecture: x64 # FIXME(#1004): Remove workaround installing x64 Python on ARM64 CI hosts
 
       - name: Configure Tools
         run: |
@@ -982,7 +982,7 @@ jobs:
         id: python
         with:
           python-version: '${{ env.PYTHON_VERSION_WINDOWS }}'
-          architecture: x64
+          architecture: x64 
 
       - uses: nuget/setup-nuget@v2
         if: inputs.build_os == 'Windows' && (matrix.arch == 'arm64' || inputs.build_arch == 'arm64')
@@ -1013,7 +1013,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
-          architecture: x64
+          architecture: x64 # FIXME(#1004): Remove workaround installing x64 Python on ARM64 CI hosts
 
       - name: Setup context
         id: setup-context
@@ -1700,7 +1700,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
-          architecture: x64
+          architecture: x64 # FIXME(#1004): Remove workaround installing x64 Python on ARM64 CI hosts
 
       - name: Configure LLVM
         if: matrix.os != 'Android' || inputs.build_android
@@ -2146,7 +2146,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
-          architecture: x64
+          architecture: x64 # FIXME(#1004): Remove workaround installing x64 Python on ARM64 CI hosts
 
       - name: Compute workspace hash
         if: matrix.os != 'Android' || inputs.build_android
@@ -3611,7 +3611,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
-          architecture: x64
+          architecture: x64 # FIXME(#1004): Remove workaround installing x64 Python on ARM64 CI hosts
 
       - uses: jannekem/run-python-script-action@v1
         if: matrix.os != 'Android' || inputs.build_android

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -688,6 +688,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
+          architecture: x64
 
       - name: Configure Tools
         run: |
@@ -1012,6 +1013,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
+          architecture: x64
 
       - name: Setup context
         id: setup-context
@@ -1698,6 +1700,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
+          architecture: x64
 
       - name: Configure LLVM
         if: matrix.os != 'Android' || inputs.build_android
@@ -2143,6 +2146,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
+          architecture: x64
 
       - name: Compute workspace hash
         if: matrix.os != 'Android' || inputs.build_android
@@ -3607,6 +3611,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
+          architecture: x64
 
       - uses: jannekem/run-python-script-action@v1
         if: matrix.os != 'Android' || inputs.build_android


### PR DESCRIPTION
Follow up on to https://github.com/compnerd/swift-build/pull/983. This changes adds a new var to control the version of Python used in the execution of CI actions (not the version used to build lldb).

This also fixes an break introduced in the same PR on ARM64 machines by forcing the use of `x64` emulated version. 

Downstream runs:
AMD: https://github.com/thebrowsercompany/swift-build/actions/runs/16863879408
ARM: https://github.com/thebrowsercompany/swift-build/actions/runs/16863881987