### PR TITLE
Upstream experimental overlay fix

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2369,17 +2369,6 @@ jobs:
           if ("${{ matrix.os }}" -eq "Android") {
             # Used by matrix definitions.
             $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          }
-
-          if ("${{ matrix.os }}" -eq "Windows") {
-            $WINDOWS_VFS_OVERLAY = cygpath -m "${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml"
-            $SwiftResourceDir = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift"
-            $SwiftFlags += " -vfsoverlay ${WINDOWS_VFS_OVERLAY}"
-            $SwiftFlags += " -strict-implicit-module-context"
-            $SwiftFlags += " -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules"
-            $SwiftFlags += " -resource-dir $SwiftResourceDir"
-            $SwiftFlags += " -L $SwiftResourceDir/windows"
-          } elseif ("${{ matrix.os }}" -eq "Android") {
             $SwiftResourceDir = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Android.platform/Developer/SDKs/Android.sdk/usr/lib/swift"
             $SwiftFlags += " -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot"
             $SwiftFlags += " -resource-dir $SwiftResourceDir"
@@ -2434,17 +2423,6 @@ jobs:
           if ("${{ matrix.os }}" -eq "Android") {
             # Used by matrix definitions.
             $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          }
-
-          if ("${{ matrix.os }}" -eq "Windows") {
-            $WINDOWS_VFS_OVERLAY = cygpath -m "${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml"
-            $SwiftResourceDir = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift"
-            $SwiftFlags += " -vfsoverlay ${WINDOWS_VFS_OVERLAY}"
-            $SwiftFlags += " -strict-implicit-module-context"
-            $SwiftFlags += " -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules"
-            $SwiftFlags += " -resource-dir $SwiftResourceDir"
-            $SwiftFlags += " -L $SwiftResourceDir/windows"
-          } elseif ("${{ matrix.os }}" -eq "Android") {
             $SwiftResourceDir = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Android.platform/Developer/SDKs/Android.sdk/usr/lib/swift"
             $SwiftFlags += " -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot"
             $SwiftFlags += " -resource-dir $SwiftResourceDir"
@@ -2497,17 +2475,6 @@ jobs:
           if ("${{ matrix.os }}" -eq "Android") {
             # Used by matrix definitions.
             $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          }
-
-          if ("${{ matrix.os }}" -eq "Windows") {
-            $WINDOWS_VFS_OVERLAY = cygpath -m "${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml"
-            $SwiftResourceDir = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift"
-            $SwiftFlags += " -vfsoverlay ${WINDOWS_VFS_OVERLAY}"
-            $SwiftFlags += " -strict-implicit-module-context"
-            $SwiftFlags += " -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules"
-            $SwiftFlags += " -resource-dir $SwiftResourceDir"
-            $SwiftFlags += " -L $SwiftResourceDir/windows"
-          } elseif ("${{ matrix.os }}" -eq "Android") {
             $SwiftResourceDir = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Android.platform/Developer/SDKs/Android.sdk/usr/lib/swift"
             $SwiftFlags += " -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot"
             $SwiftFlags += " -resource-dir $SwiftResourceDir"
@@ -2555,17 +2522,6 @@ jobs:
           if ("${{ matrix.os }}" -eq "Android") {
             # Used by matrix definitions.
             $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          }
-
-          if ("${{ matrix.os }}" -eq "Windows") {
-            $WINDOWS_VFS_OVERLAY = cygpath -m "${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml"
-            $SwiftResourceDir = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift"
-            $SwiftFlags += " -vfsoverlay ${WINDOWS_VFS_OVERLAY}"
-            $SwiftFlags += " -strict-implicit-module-context"
-            $SwiftFlags += " -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules"
-            $SwiftFlags += " -resource-dir $SwiftResourceDir"
-            $SwiftFlags += " -L $SwiftResourceDir/windows"
-          } elseif ("${{ matrix.os }}" -eq "Android") {
             $SwiftResourceDir = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Android.platform/Developer/SDKs/Android.sdk/usr/lib/swift"
             $SwiftFlags += " -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot"
             $SwiftFlags += " -resource-dir $SwiftResourceDir"
@@ -2614,17 +2570,6 @@ jobs:
           if ("${{ matrix.os }}" -eq "Android") {
             # Used by matrix definitions.
             $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          }
-
-          if ("${{ matrix.os }}" -eq "Windows") {
-            $WINDOWS_VFS_OVERLAY = cygpath -m "${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml"
-            $SwiftResourceDir = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift"
-            $SwiftFlags += " -vfsoverlay ${WINDOWS_VFS_OVERLAY}"
-            $SwiftFlags += " -strict-implicit-module-context"
-            $SwiftFlags += " -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules"
-            $SwiftFlags += " -resource-dir $SwiftResourceDir"
-            $SwiftFlags += " -L $SwiftResourceDir/windows"
-          } elseif ("${{ matrix.os }}" -eq "Android") {
             $SwiftResourceDir = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Android.platform/Developer/SDKs/Android.sdk/usr/lib/swift"
             $SwiftFlags += " -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot"
             $SwiftFlags += " -resource-dir $SwiftResourceDir"
@@ -2677,17 +2622,6 @@ jobs:
           if ("${{ matrix.os }}" -eq "Android") {
             # Used by matrix definitions.
             $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          }
-
-          if ("${{ matrix.os }}" -eq "Windows") {
-            $WINDOWS_VFS_OVERLAY = cygpath -m "${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml"
-            $SwiftResourceDir = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift"
-            $SwiftFlags += " -vfsoverlay ${WINDOWS_VFS_OVERLAY}"
-            $SwiftFlags += " -strict-implicit-module-context"
-            $SwiftFlags += " -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules"
-            $SwiftFlags += " -resource-dir $SwiftResourceDir"
-            $SwiftFlags += " -L $SwiftResourceDir/windows"
-          } elseif ("${{ matrix.os }}" -eq "Android") {
             $SwiftResourceDir = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Android.platform/Developer/SDKs/Android.sdk/usr/lib/swift"
             $SwiftFlags += " -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot"
             $SwiftFlags += " -resource-dir $SwiftResourceDir"
@@ -2736,17 +2670,6 @@ jobs:
           if ("${{ matrix.os }}" -eq "Android") {
             # Used by matrix definitions.
             $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          }
-
-          if ("${{ matrix.os }}" -eq "Windows") {
-            $WINDOWS_VFS_OVERLAY = cygpath -m "${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml"
-            $SwiftResourceDir = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift"
-            $SwiftFlags += " -vfsoverlay ${WINDOWS_VFS_OVERLAY}"
-            $SwiftFlags += " -strict-implicit-module-context"
-            $SwiftFlags += " -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules"
-            $SwiftFlags += " -resource-dir $SwiftResourceDir"
-            $SwiftFlags += " -L $SwiftResourceDir/windows"
-          } elseif ("${{ matrix.os }}" -eq "Android") {
             $SwiftResourceDir = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Android.platform/Developer/SDKs/Android.sdk/usr/lib/swift"
             $SwiftFlags += " -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot"
             $SwiftFlags += " -resource-dir $SwiftResourceDir"
@@ -2800,17 +2723,6 @@ jobs:
           if ("${{ matrix.os }}" -eq "Android") {
             # Used by matrix definitions.
             $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          }
-
-          if ("${{ matrix.os }}" -eq "Windows") {
-            $WINDOWS_VFS_OVERLAY = cygpath -m "${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml"
-            $SwiftResourceDir = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift"
-            $SwiftFlags += " -vfsoverlay ${WINDOWS_VFS_OVERLAY}"
-            $SwiftFlags += " -strict-implicit-module-context"
-            $SwiftFlags += " -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules"
-            $SwiftFlags += " -resource-dir $SwiftResourceDir"
-            $SwiftFlags += " -L $SwiftResourceDir/windows"
-          } elseif ("${{ matrix.os }}" -eq "Android") {
             $SwiftResourceDir = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Android.platform/Developer/SDKs/Android.sdk/usr/lib/swift"
             $SwiftFlags += " -sdk $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot"
             $SwiftFlags += " -resource-dir $SwiftResourceDir"

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2411,6 +2411,7 @@ jobs:
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/swift/Runtimes/Core `
                 -D SwiftCore_ENABLE_CONCURRENCY=YES `
+                -D SwiftCore_ENABLE_REMOTE_MIRROR=YES `
                 -D dispatch_DIR=${{ github.workspace }}/BinaryCache/libdispatch-c/cmake/modules
       - name: Build Experimental Runtime
         if: matrix.os != 'Android' || inputs.build_android
@@ -2473,7 +2474,8 @@ jobs:
                 ${{ matrix.extra_flags }} `
                 -G Ninja `
                 -S ${{ github.workspace }}/SourceCache/swift/Runtimes/Overlay `
-                -D SwiftCore_DIR=${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore
+                -D SwiftCore_DIR=${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore `
+                -D SwiftOverlay_ENABLE_CXX_INTEROP=YES
       - name: Build Experimental Overlay
         if: matrix.os != 'Android' || inputs.build_android
         run: |


### PR DESCRIPTION
Fix build break for missing CxxStdlib in experimental runtime build 

Changes
- Add missing `SwiftCore_ENABLE_REMOTE_MIRROR` to core
- Add missing `SwiftOverlay_ENABLE_CXX_INTEROP` to overlay
- Remove all swiftFlags from all targets

Downstream successful job: https://github.com/thebrowsercompany/swift-build/actions/runs/17053239286