### PR TITLE
Update to python 3.10.1

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -381,7 +381,7 @@ jobs:
           echo ANDROID_CLANG_VERSION=18 >> ${GITHUB_OUTPUT}
 
           # Set Python version used in the build
-          echo python_version=3.9.10 >> ${GITHUB_OUTPUT}
+          echo python_version=3.10.1 >> ${GITHUB_OUTPUT}
 
       - uses: actions/upload-artifact@v4
         if: inputs.create_snapshot == true

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -914,15 +914,6 @@ jobs:
   compilers:
     needs: [libxml2, build_tools, cmark_gfm, early_swift_driver]
     runs-on: ${{ inputs.compilers_build_runner }}
-
-    env:
-      # This will grab the latest Python 3.10 version available for setup-python. It is necessary to
-      # specify in this manner for Mac where actions/setup-python does not have version 3.10.1.
-      # Once the Python version is upgraded to 3.12, these should be kept in sync.
-      PYTHON_VERSION_MACOS: 3.10
-      # Must be a full version string from https://www.nuget.org/packages/pythonarm64
-      PYTHON_VERSION_WINDOWS: 3.10.1
-
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.compilers_matrix) }}
@@ -1012,38 +1003,38 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch
           show-progress: false
 
-      - name: Install Python ${{ env.PYTHON_VERSION_MACOS }} (Host)
+      - name: Install Python ${{ inputs.python_version }} (Host)
         if: matrix.os == 'Darwin'
         uses: actions/setup-python@v5
         with:
-          python-version: '${{ env.PYTHON_VERSION_MACOS }}'
+          python-version: '${{ inputs.python_version }}'
 
-      - name: Install Python ${{ env.PYTHON_VERSION_WINDOWS }} (Host)
+      - name: Install Python ${{ inputs.python_version }} (Host)
         if: matrix.os == 'Windows' && (matrix.arch == 'amd64' || inputs.build_arch == 'amd64')
         uses: actions/setup-python@v5
         id: python
         with:
-          python-version: '${{ env.PYTHON_VERSION_WINDOWS }}'
+          python-version: '${{ inputs.python_version }}'
           architecture: x64 
 
       - uses: nuget/setup-nuget@v2
         if: inputs.build_os == 'Windows' && (matrix.arch == 'arm64' || inputs.build_arch == 'arm64')
 
       # TODO(lxbndr) use actions/cache to improve this step timings
-      - name: Install Python ${{ env.PYTHON_VERSION_WINDOWS }} (Windows arm64)
+      - name: Install Python ${{ inputs.python_version}} (Windows arm64)
         if: inputs.build_os == 'Windows' && (matrix.arch == 'arm64' || inputs.build_arch == 'arm64')
         run: |
           $NugetSources=[string](nuget Sources List -Format short)
           if (-Not ($NugetSources.contains("api.nuget.org"))) {
             nuget sources Add -Name api.nuget.org -Source https://api.nuget.org/v3/index.json -NonInteractive
           }
-          nuget install pythonarm64 -Version ${{ env.PYTHON_VERSION_WINDOWS }}
+          nuget install pythonarm64 -Version ${{ inputs.python_version}}
 
       - name: Export Python Location (Windows)
         if: inputs.build_os == 'Windows'
         run: |
           echo "PYTHON_LOCATION_amd64=$env:pythonLocation" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "PYTHON_LOCATION_arm64=${{ github.workspace }}\pythonarm64.${{ env.PYTHON_VERSION_WINDOWS }}\tools" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "PYTHON_LOCATION_arm64=${{ github.workspace }}\pythonarm64.${{ inputs.python_version }}\tools" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - uses: nttld/setup-ndk@v1
         if: matrix.os == 'Android'

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -916,12 +916,12 @@ jobs:
     runs-on: ${{ inputs.compilers_build_runner }}
 
     env:
-      # This will grab the latest Python 3.9 version available for setup-python. It is necessary to
-      # specify in this manner for Mac where actions/setup-python does not have version 3.9.10.
+      # This will grab the latest Python 3.10 version available for setup-python. It is necessary to
+      # specify in this manner for Mac where actions/setup-python does not have version 3.10.1.
       # Once the Python version is upgraded to 3.12, these should be kept in sync.
-      PYTHON_VERSION_MACOS: 3.9
+      PYTHON_VERSION_MACOS: 3.10
       # Must be a full version string from https://www.nuget.org/packages/pythonarm64
-      PYTHON_VERSION_WINDOWS: 3.9.10
+      PYTHON_VERSION_WINDOWS: 3.10.1
 
     strategy:
       fail-fast: false
@@ -1063,14 +1063,14 @@ jobs:
           if ( "${{ matrix.os }}" -eq "Windows" ) {
             $CLANG_LOCATION = cygpath -m $(Split-Path (Get-Command swiftc).Source)
             $SDKROOT = cygpath -m ${env:SDKROOT}
-            $LIBPYTHON_PATH = "${env:PYTHON_LOCATION_${{ matrix.arch }}}/libs/python39.lib"
+            $LIBPYTHON_PATH = "${env:PYTHON_LOCATION_${{ matrix.arch }}}/libs/python310.lib"
             $PYTHON_INCLUDE_DIR = "${env:PYTHON_LOCATION_${{ matrix.arch }}}/include"
             $PYTHON_BINARY="python.exe"
           } elseif ( "${{ matrix.os }}" -eq "Darwin" ) {
             $CLANG_LOCATION = "${env:HOME}/Library/Developer/Toolchains/swift-${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}-RELEASE.xctoolchain/usr/bin"
             $SDKROOT = xcrun --sdk macosx --show-sdk-path
-            $LIBPYTHON_PATH = "${env:pythonLocation}/lib/python3.9/config-3.9-darwin/libpython3.9.a"
-            $PYTHON_INCLUDE_DIR = "${env:pythonLocation}/include/python3.9"
+            $LIBPYTHON_PATH = "${env:pythonLocation}/lib/python3.10/config-3.10-darwin/libpython3.10.a"
+            $PYTHON_INCLUDE_DIR = "${env:pythonLocation}/include/python3.10"
             $PYTHON_BINARY="python3"
           }
 

--- a/docs/WindowsQuickStart.md
+++ b/docs/WindowsQuickStart.md
@@ -36,7 +36,7 @@ del /q vs_community.exe
 ```
 
 > [!IMPORTANT]
-> On ARM64, Visual Studio doesn't include Python. If you are building Swift on an ARM64 processor, install Python 3.9 from https://www.python.org/downloads/release/python-3913/ and don't include the `Component.CPython39.x64` line in the command above.
+> On ARM64, Visual Studio doesn't include Python. If you are building Swift on an ARM64 processor, install Python 3.10.1 from https://www.python.org/downloads/release/python-3101/ and don't include the `Component.CPython39.x64` line in the command above.
 
 ### Enable Symbolic Links Support
 


### PR DESCRIPTION
This bumps the python version to 3.10.1 to match the one used upstream. 

Changes:
- Update both python version used to build lldb and one used by CI scripts to 3.10.1
- Remove workaround for MacOS since 3.10.1 is available to download same way for x64 - though i did not test mac builds
- Keep ARM64 workaround since 3.10.1 is not available through the GH action same as 3.9

Downstream successful job: https://github.com/thebrowsercompany/swift-build/actions/runs/17162963307