### PR TITLE
Build: use configure-cmake-project action in experimental-sdk job

### DIFF
--- a/.github/actions/configure-cmake-project/action.yml
+++ b/.github/actions/configure-cmake-project/action.yml
@@ -109,7 +109,7 @@ runs:
         $UseMSVCCompilers = ${{ inputs.msvc-compilers }}
         $UseBuiltCompilers = ${{ inputs.built-compilers }}
         $UsePinnedCompilers = ${{ inputs.pinned-compilers }}
-        $UseGNUDriver = ${{ inputs.use-gnu-driver == 'true' && '&True' || '$False' }}
+        $UseGNUDriver = ${{ inputs.use-gnu-driver == 'true' && '$True' || '$False' }}
         $CacheScript = '${{ inputs.cache-script }}'
         $CMakeDefines = ${{ inputs.cmake-defines }}
 

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2361,7 +2361,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("C", "CXX", "Swift")'
-          use-gnu-driver: false
+          use-gnu-driver: true
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "NO";
@@ -2398,7 +2398,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("C", "CXX", "Swift")'
-          use-gnu-driver: false
+          use-gnu-driver: true
           cmake-defines: |
             @{
                'BUILD_SHARED_LIBS' = "NO";
@@ -2435,7 +2435,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("C", "Swift")'
-          use-gnu-driver: false
+          use-gnu-driver: true
           cmake-defines: |
             @{
                'BUILD_SHARED_LIBS' = "NO";
@@ -2471,7 +2471,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("C", "Swift")'
-          use-gnu-driver: false
+          use-gnu-driver: true
           cmake-defines: |
             @{
                'BUILD_SHARED_LIBS' = "NO";
@@ -2508,7 +2508,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("C", "CXX", "Swift")'
-          use-gnu-driver: false
+          use-gnu-driver: true
           cmake-defines: |
             @{
                'BUILD_SHARED_LIBS' = "NO";
@@ -2546,7 +2546,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("CXX", "Swift")'
-          use-gnu-driver: false
+          use-gnu-driver: true
           cmake-defines: |
             @{
                'BUILD_SHARED_LIBS' = "NO";
@@ -2584,7 +2584,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("C", "Swift")'
-          use-gnu-driver: false
+          use-gnu-driver: true
           cmake-defines: |
             @{
                'BUILD_SHARED_LIBS' = "NO";
@@ -2623,7 +2623,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("C", "CXX", "Swift")'
-          use-gnu-driver: false
+          use-gnu-driver: true
           cmake-defines: |
             @{
                'BUILD_SHARED_LIBS' = "NO";

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2488,43 +2488,32 @@ jobs:
 
       - name: Configure Experimental Distributed
         if: matrix.os != 'Android' || inputs.build_android
-        run: |
-          $CLANG = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang.exe"
-          $CLANGXX = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang++.exe"
-          $CLANG_CL = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang-cl.exe"
-          $SWIFTC = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/swiftc.exe"
-          $SwiftFlags = "${{ matrix.swiftflags }}"
-
-          if ("${{ matrix.os }}" -eq "Android") {
-            # Used by matrix definitions.
-            $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          }
-
-          cmake -B ${{ github.workspace }}/BinaryCache/ExperimentalDistributed `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=${{ matrix.gnu-cc }} `
-                -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ matrix.gnu-cflags }}" `
-                -D CMAKE_CXX_COMPILER=${{ matrix.gnu-cxx }} `
-                -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ matrix.gnu-cxxflags }}  -I${{ github.workspace }}/BinaryCache/ExperimentalRuntime/include" `
-                -D CMAKE_Swift_COMPILER=${SWIFTC} `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple_no_api_level }} `
-                -D CMAKE_Swift_FLAGS="${SwiftFlags}" `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_COMPILER_USE_OLD_DRIVER=YES `
-                -D BUILD_SHARED_LIBS=NO `
-                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr `
-                -D CMAKE_FIND_PACKAGE_PREFER_CONFIG=YES `
-                -D CMAKE_STATIC_LIBRARY_PREFIX_Swift="lib" `
-                ${{ matrix.gnu-linker_flags }} `
-                ${{ matrix.extra_flags }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/Distributed `
-                -D SwiftCore_DIR=${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore `
-                -D SwiftOverlay_DIR=${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay
+        uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
+        with:
+          project-name: ExperimentalDistributed
+          swift-version: ${{ inputs.swift_version }}
+          enable-caching: true
+          debug-info: ${{ inputs.debug_info }}
+          build-os: ${{ inputs.build_os }}
+          build-arch: ${{ inputs.build_arch }}
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+          src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/Distributed 
+          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalDistributed
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
+          android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
+          ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
+          built-compilers: '@("C", "CXX", "Swift")'
+          use-gnu-driver: true
+          cmake-defines: |
+            @{
+               'BUILD_SHARED_LIBS' = "NO";
+               'CMAKE_CXX_FLAGS' = "-I${{ github.workspace }}/BinaryCache/ExperimentalRuntime/include";
+               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
+               'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
+               'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay";
+            }
       - name: Build Experimental Distributed
         if: matrix.os != 'Android' || inputs.build_android
         run: |

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2417,38 +2417,30 @@ jobs:
 
       - name: Configure Experimental String Processing
         if: matrix.os != 'Android' || inputs.build_android
-        run: |
-          $CLANG = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang.exe"
-          $CLANGXX = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang++.exe"
-          $CLANG_CL = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang-cl.exe"
-          $SWIFTC = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/swiftc.exe"
-          $SwiftFlags = "${{ matrix.swiftflags }}"
-
-          if ("${{ matrix.os }}" -eq "Android") {
-            # Used by matrix definitions.
-            $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          }
-
-          cmake -B ${{ github.workspace }}/BinaryCache/ExperimentalStringProcessing `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=${{ matrix.gnu-cc }} `
-                -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ matrix.gnu-cflags }}" `
-                -D CMAKE_Swift_COMPILER=${SWIFTC} `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple_no_api_level }} `
-                -D CMAKE_Swift_FLAGS="${SwiftFlags}" `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_COMPILER_USE_OLD_DRIVER=YES `
-                -D BUILD_SHARED_LIBS=NO `
-                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr `
-                -D CMAKE_FIND_PACKAGE_PREFER_CONFIG=YES `
-                -D CMAKE_STATIC_LIBRARY_PREFIX_Swift="lib" `
-                ${{ matrix.gnu-linker_flags }} `
-                ${{ matrix.extra_flags }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/StringProcessing `
-                -D SwiftCore_DIR=${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore
+        uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
+        with:
+          project-name: ExperimentalStringProcessing
+          swift-version: ${{ inputs.swift_version }}
+          enable-caching: true
+          debug-info: ${{ inputs.debug_info }}
+          build-os: ${{ inputs.build_os }}
+          build-arch: ${{ inputs.build_arch }}
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+          src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/StringProcessing
+          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalStringProcessing
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
+          android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
+          ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
+          built-compilers: '@("C", "Swift")'
+          use-gnu-driver: true
+          cmake-defines: |
+            @{
+               'BUILD_SHARED_LIBS' = "NO";
+               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
+               'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
+            }
       - name: Build Experimental String Processing
         if: matrix.os != 'Android' || inputs.build_android
         run: |

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2003,31 +2003,24 @@ jobs:
           - os: Windows
             arch: amd64
             triple: x86_64-unknown-windows-msvc
-            triple_no_api_level: x86_64-unknown-windows-msvc
           - os: Windows
             arch: arm64
             triple: aarch64-unknown-windows-msvc
-            triple_no_api_level: aarch64-unknown-windows-msvc
           - os: Windows
             arch: x86
             triple: i686-unknown-windows-msvc
-            triple_no_api_level: i686-unknown-windows-msvc
           - os: Android
             arch: arm64
             triple: 'aarch64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}'
-            triple_no_api_level: aarch64-unknown-linux-android
           - os: Android
             arch: armv7
             triple: 'armv7-unknown-linux-androideabi${{ inputs.ANDROID_API_LEVEL }}'
-            triple_no_api_level: armv7-unknown-linux-androideabi
           - os: Android
             arch: i686
             triple: 'i686-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}'
-            triple_no_api_level: i686-unknown-linux-android
           - os: Android
             arch: x86_64
             triple: 'x86_64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}'
-            triple_no_api_level: x86_64-unknown-linux-android
     
     name: ${{ matrix.os }} ${{ matrix.arch }} Experimental SDK
 
@@ -2459,7 +2452,6 @@ jobs:
             @{
                'BUILD_SHARED_LIBS' = "NO";
                'CMAKE_FIND_PACKAGE_PREFER_CONFIG' = "YES";
-               'CMAKE_Swift_COMPILER_TARGET' = "${{ matrix.triple_no_api_level }}";
                'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
                'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
                'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay";

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2404,6 +2404,7 @@ jobs:
                'BUILD_SHARED_LIBS' = "NO";
                'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
                'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
+               'SwiftOverlay_ENABLE_LIBRARY_EVOLUTION' = "NO";
                'SwiftOverlay_ENABLE_CXX_INTEROP' = "YES";
             }
       - name: Build Experimental Overlay
@@ -2440,6 +2441,7 @@ jobs:
                'BUILD_SHARED_LIBS' = "NO";
                'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
                'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
+               'SwiftStringProcessing_ENABLE_LIBRARY_EVOLUTION' = "NO";
             }
       - name: Build Experimental String Processing
         if: matrix.os != 'Android' || inputs.build_android
@@ -2476,6 +2478,7 @@ jobs:
                'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
                'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
                'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay";
+               'SwiftSynchronization_ENABLE_LIBRARY_EVOLUTION' = "NO";
             }
       - name: Build Experimental Synchronization
         if: matrix.os != 'Android' || inputs.build_android
@@ -2513,6 +2516,7 @@ jobs:
                'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
                'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
                'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay";
+               'SwiftDistributed_ENABLE_LIBRARY_EVOLUTION' = "NO";
             }
       - name: Build Experimental Distributed
         if: matrix.os != 'Android' || inputs.build_android
@@ -2550,6 +2554,7 @@ jobs:
                'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
                'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
                'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay";
+               'SwiftObservation_ENABLE_LIBRARY_EVOLUTION' = "NO";
             }
       - name: Build Experimental Observation
         if: matrix.os != 'Android' || inputs.build_android

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2381,43 +2381,31 @@ jobs:
 
       - name: Configure Experimental Overlay
         if: matrix.os != 'Android' || inputs.build_android
-        run: |
-          $CLANG = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang.exe"
-          $CLANGXX = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang++.exe"
-          $CLANG_CL = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang-cl.exe"
-          $SWIFTC = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/swiftc.exe"
-          $SwiftFlags = "${{ matrix.swiftflags }}"
-
-          if ("${{ matrix.os }}" -eq "Android") {
-            # Used by matrix definitions.
-            $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          }
-
-          cmake -B ${{ github.workspace }}/BinaryCache/ExperimentalOverlay `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=${{ matrix.gnu-cc }} `
-                -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ matrix.gnu-cflags }}" `
-                -D CMAKE_CXX_COMPILER=${{ matrix.gnu-cxx }} `
-                -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ matrix.gnu-cxxflags }}" `
-                -D CMAKE_Swift_COMPILER=${SWIFTC} `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple_no_api_level }} `
-                -D CMAKE_Swift_FLAGS="${SwiftFlags}" `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_COMPILER_USE_OLD_DRIVER=YES `
-                -D BUILD_SHARED_LIBS=NO `
-                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr `
-                -D CMAKE_FIND_PACKAGE_PREFER_CONFIG=YES `
-                -D CMAKE_STATIC_LIBRARY_PREFIX_Swift="lib" `
-                ${{ matrix.gnu-linker_flags }} `
-                ${{ matrix.extra_flags }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift/Runtimes/Overlay `
-                -D SwiftCore_DIR=${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore `
-                -D SwiftOverlay_ENABLE_CXX_INTEROP=YES
+        uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
+        with:
+          project-name: ExperimentalOverlay
+          swift-version: ${{ inputs.swift_version }}
+          enable-caching: true
+          debug-info: ${{ inputs.debug_info }}
+          build-os: ${{ inputs.build_os }}
+          build-arch: ${{ inputs.build_arch }}
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+          src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Overlay
+          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalOverlay
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
+          android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
+          ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
+          built-compilers: '@("C", "CXX", "Swift")'
+          use-gnu-driver: true
+          cmake-defines: |
+            @{
+               'BUILD_SHARED_LIBS' = "NO";
+               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
+               'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
+               'SwiftOverlay_ENABLE_CXX_INTEROP' = "YES";
+            }
       - name: Build Experimental Overlay
         if: matrix.os != 'Android' || inputs.build_android
         run: |

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2344,45 +2344,32 @@ jobs:
 
       - name: Configure Experimental Runtime
         if: matrix.os != 'Android' || inputs.build_android
-        run: |
-          $CLANG = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang.exe"
-          $CLANGXX = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang++.exe"
-          $CLANG_CL = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang-cl.exe"
-          $SWIFTC = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/swiftc.exe"
-          $SwiftFlags = "${{ matrix.swiftflags }}"
-
-          if ("${{ matrix.os }}" -eq "Android") {
-            # Used by matrix definitions.
-            $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          }
-
-          cmake -B ${{ github.workspace }}/BinaryCache/ExperimentalRuntime `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=${{ matrix.gnu-cc }} `
-                -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ matrix.gnu-cflags }}" `
-                -D CMAKE_CXX_COMPILER=${{ matrix.gnu-cxx }} `
-                -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ matrix.gnu-cxxflags }} -Ddispatch_STATIC" `
-                -D CMAKE_Swift_COMPILER=${SWIFTC} `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple_no_api_level }} `
-                -D CMAKE_Swift_FLAGS="${SwiftFlags} -Xcc -static-libclosure" `
-                -D CMAKE_Swift_FLAGS_RELEASE="-O" `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_COMPILER_USE_OLD_DRIVER=YES `
-                -D BUILD_SHARED_LIBS=NO `
-                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr `
-                -D CMAKE_FIND_PACKAGE_PREFER_CONFIG=YES `
-                -D CMAKE_STATIC_LIBRARY_PREFIX_Swift="lib" `
-                ${{ matrix.gnu-linker_flags }} `
-                ${{ matrix.extra_flags }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift/Runtimes/Core `
-                -D SwiftCore_ENABLE_CONCURRENCY=YES `
-                -D SwiftCore_ENABLE_REMOTE_MIRROR=YES `
-                -D dispatch_DIR=${{ github.workspace }}/BinaryCache/libdispatch-c/cmake/modules
+        uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
+        with:
+          project-name: ExperimentalRuntime
+          swift-version: ${{ inputs.swift_version }}
+          enable-caching: true
+          debug-info: ${{ inputs.debug_info }}
+          build-os: ${{ inputs.build_os }}
+          build-arch: ${{ inputs.build_arch }}
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+          src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Core
+          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalRuntime 
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
+          android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
+          ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
+          built-compilers: '@("C", "CXX", "Swift")'
+          use-gnu-driver: true
+          cmake-defines: |
+            @{
+              'BUILD_SHARED_LIBS' = "NO";
+              'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
+              'dispatch_DIR' = "${{ github.workspace }}/BinaryCache/libdispatch-c/cmake/modules";
+              'SwiftCore_ENABLE_CONCURRENCY' = "YES";
+              'SwiftCore_ENABLE_REMOTE_MIRROR' = "YES";
+            }
       - name: Build Experimental Runtime
         if: matrix.os != 'Android' || inputs.build_android
         run: |

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2562,44 +2562,34 @@ jobs:
 
       - name: Configure Experimental Volatile
         if: matrix.os != 'Android' || inputs.build_android
-        run: |
-          $CLANG = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang.exe"
-          $CLANGXX = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang++.exe"
-          $CLANG_CL = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang-cl.exe"
-          $SWIFTC = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/swiftc.exe"
-          $SwiftFlags = "${{ matrix.swiftflags }}"
-
-          if ("${{ matrix.os }}" -eq "Android") {
-            # Used by matrix definitions.
-            $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          }
-
-          cmake -B ${{ github.workspace }}/BinaryCache/ExperimentalVolatile `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=${{ matrix.gnu-cc }} `
-                -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ matrix.gnu-cflags }}" `
-                -D CMAKE_CXX_COMPILER=${{ matrix.gnu-cxx }} `
-                -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ matrix.gnu-cxxflags }}  -I${{ github.workspace }}/BinaryCache/ExperimentalRuntime/include" `
-                -D CMAKE_Swift_COMPILER=${SWIFTC} `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple_no_api_level }} `
-                -D CMAKE_Swift_FLAGS="${SwiftFlags}" `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_COMPILER_USE_OLD_DRIVER=YES `
-                -D BUILD_SHARED_LIBS=NO `
-                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr `
-                -D CMAKE_FIND_PACKAGE_PREFER_CONFIG=YES `
-                -D CMAKE_STATIC_LIBRARY_PREFIX_Swift="lib" `
-                ${{ matrix.gnu-linker_flags }} `
-                ${{ matrix.extra_flags }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/Volatile `
-                -D SwiftVolatile_ENABLE_LIBRARY_EVOLUTION=NO `
-                -D SwiftCore_DIR=${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore `
-                -D SwiftOverlay_DIR=${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay
+        uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
+        with:
+          project-name: ExperimentalVolatile
+          swift-version: ${{ inputs.swift_version }}
+          enable-caching: true
+          debug-info: ${{ inputs.debug_info }}
+          build-os: ${{ inputs.build_os }}
+          build-arch: ${{ inputs.build_arch }}
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+          src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/Volatile
+          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalVolatile
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
+          android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
+          ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
+          built-compilers: '@("C", "Swift")'
+          use-gnu-driver: true
+          cmake-defines: |
+            @{
+               'BUILD_SHARED_LIBS' = "NO";
+               'CMAKE_FIND_PACKAGE_PREFER_CONFIG' = "YES";
+               'CMAKE_Swift_COMPILER_TARGET' = "${{ matrix.triple_no_api_level }}";
+               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
+               'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
+               'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay";
+               'SwiftVolatile_ENABLE_LIBRARY_EVOLUTION' = "NO";
+            }
       - name: Build Experimental Volatile
         if: matrix.os != 'Android' || inputs.build_android
         run: |

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2674,61 +2674,44 @@ jobs:
 
       - name: Configure Static Foundation
         if: matrix.os != 'Android' || inputs.build_android
-        run: |
-          $CLANG = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang.exe"
-          $CLANGXX = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang++.exe"
-          $CLANG_CL = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang-cl.exe"
-          $SWIFTC = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/swiftc.exe"
-          $SwiftFlags = "${{ matrix.swiftflags }}"
-
-          if ("${{ matrix.os }}" -eq "Android") {
-            # Used by matrix definitions.
-            $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-            $SwiftFlags += " -sysroot $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot"
-          }
-
-          $SwiftSDKDir = cygpath -m "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk"
-          $SwiftFlags += " -sdk $SwiftSDKDir"
-
-          $SWIFT_FOUNDATION_SOURCE_DIR = cygpath -m ${{ github.workspace }}/SourceCache/swift-foundation
-          $SWIFT_FOUNDATION_ICU_SOURCE_DIR = cygpath -m ${{ github.workspace }}/SourceCache/swift-foundation-icu
-          $SWIFT_COLLECTIONS_SOURCE_DIR = cygpath -m ${{ github.workspace }}/SourceCache/swift-collections
-
-          $build_tools = if ("${{ matrix.os }}" -eq "Windows") { "YES" } else { "NO" }
-          $LIBZ = if ("${{ matrix.os }}" -eq "Windows") { "zlibstatic.lib" } else { "libz.a" }
-
-          cmake -B ${{ github.workspace }}/BinaryCache/StaticFoundation `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
-                -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
-                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
-                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_Swift_COMPILER=${SWIFTC} `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple_no_api_level }} `
-                -D CMAKE_Swift_FLAGS="${SwiftFlags} -static-stdlib -Xfrontend -use-static-resource-dir" `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_COMPILER_USE_OLD_DRIVER=YES `
-                -D BUILD_SHARED_LIBS=NO `
-                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr `
-                -D CMAKE_FIND_PACKAGE_PREFER_CONFIG=YES `
-                -D CMAKE_STATIC_LIBRARY_PREFIX_Swift="lib" `
-                ${{ matrix.linker_flags }} `
-                ${{ matrix.extra_flags }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift-corelibs-foundation `
-                -D ENABLE_TESTING=NO `
-                -D FOUNDATION_BUILD_TOOLS=${build_tools} `
-                -D CURL_DIR=${{ github.workspace }}/BuildRoot/Library/curl-${{ inputs.curl_version }}/usr/lib/cmake/CURL `
-                -D LibXml2_DIR=${{ github.workspace }}/BuildRoot/Library/libxml2-${{ inputs.libxml2_version }}/usr/lib/cmake/libxml2-${{ inputs.libxml2_version }} `
-                -D ZLIB_LIBRARY=${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr/lib/$LIBZ `
-                -D ZLIB_INCLUDE_DIR=${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr/include `
-                -D dispatch_DIR=${{ github.workspace }}/BinaryCache/ExperimentalDispatch/cmake/modules `
-                -D _SwiftFoundation_SourceDIR=${SWIFT_FOUNDATION_SOURCE_DIR} `
-                -D _SwiftFoundationICU_SourceDIR=${SWIFT_FOUNDATION_ICU_SOURCE_DIR} `
-                -D _SwiftCollections_SourceDIR=${SWIFT_COLLECTIONS_SOURCE_DIR} `
-                -D SwiftFoundation_MACRO=${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin
+        uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
+        with:
+          project-name: StaticFoundation
+          swift-version: ${{ inputs.swift_version }}
+          enable-caching: true
+          debug-info: ${{ inputs.debug_info }}
+          build-os: ${{ inputs.build_os }}
+          build-arch: ${{ inputs.build_arch }}
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+          src-dir: ${{ github.workspace }}/SourceCache/swift-corelibs-foundation
+          bin-dir: ${{ github.workspace }}/BinaryCache/StaticFoundation
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
+          android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
+          ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
+          built-compilers: '@("ASM","C", "CXX", "Swift")'
+          swift-sdk-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk
+          cmake-defines: |
+            @{
+              'BUILD_SHARED_LIBS' = "NO";
+              'CMAKE_FIND_PACKAGE_PREFER_CONFIG' = "YES";
+              'CMAKE_NINJA_FORCE_RESPONSE_FILE' = "YES";
+              'CMAKE_Swift_FLAGS' = "-static-stdlib -Xfrontend -use-static-resource-dir";
+              'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
+              'ENABLE_TESTING' = "NO";
+              'FOUNDATION_BUILD_TOOLS' = "${{ matrix.os == 'Windows' && 'YES' || 'NO' }}";
+              'CURL_DIR' = "${{ github.workspace }}/BuildRoot/Library/curl-${{ inputs.curl_version }}/usr/lib/cmake/CURL \";
+              'LibXml2_DIR' = "${{ github.workspace }}/BuildRoot/Library/libxml2-${{ inputs.libxml2_version }}/usr/lib/cmake/libxml2-${{ inputs.libxml2_version }}";
+              'ZLIB_INCLUDE_DIR' = "${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr/include";
+              'ZLIB_LIBRARY' = "${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr/lib/${{ matrix.os == 'Windows' && 'zlibstatic.lib' || 'libz.a' }}";
+              'dispatch_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalDispatch/cmake/modules";
+              'SwiftSyntax_DIR' = "${{ github.workspace }}/BinaryCache/${{ matrix.triple }}/usr/lib/cmake/Compilers";
+              '_SwiftFoundation_SourceDIR' = "${{ github.workspace }}/SourceCache/swift-foundation";
+              '_SwiftFoundationICU_SourceDIR' = "${{ github.workspace }}/SourceCache/swift-foundation-icu";
+              '_SwiftCollections_SourceDIR' = "${{ github.workspace }}/SourceCache/swift-collections";
+              'SwiftFoundation_MACRO' = "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin"
+            }
       - name: Build Static Foundation
         if: matrix.os != 'Android' || inputs.build_android
         run: |

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2664,7 +2664,7 @@ jobs:
           cmake-defines: |
             @{
                'BUILD_SHARED_LIBS' = "NO";
-               'CMAKE_Swift_FLAGS' = "-static-stdlib -Xfrontend -use-static-resource-dir";
+               'CMAKE_Swift_FLAGS' = @("-static-stdlib", "-Xfrontend", "-use-static-resource-dir");
                'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
                'ENABLE_SWIFT' = "YES";
               }
@@ -2702,7 +2702,7 @@ jobs:
               'BUILD_SHARED_LIBS' = "NO";
               'CMAKE_FIND_PACKAGE_PREFER_CONFIG' = "YES";
               'CMAKE_NINJA_FORCE_RESPONSE_FILE' = "YES";
-              'CMAKE_Swift_FLAGS' = "-static-stdlib -Xfrontend -use-static-resource-dir";
+              'CMAKE_Swift_FLAGS' = @("-static-stdlib", "-Xfrontend", "-use-static-resource-dir");
               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
               'ENABLE_TESTING' = "NO";
               'FOUNDATION_BUILD_TOOLS' = "${{ matrix.os == 'Windows' && 'YES' || 'NO' }}";

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2464,7 +2464,7 @@ jobs:
           build-arch: ${{ inputs.build_arch }}
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
-          src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Synchronization
+          src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/Synchronization
           bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalSynchronization
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2573,7 +2573,6 @@ jobs:
               'ZLIB_INCLUDE_DIR' = "${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr/include";
               'ZLIB_LIBRARY' = "${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr/lib/${{ matrix.os == 'Windows' && 'zlibstatic.lib' || 'libz.a' }}";
               'dispatch_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalDispatch/cmake/modules";
-              'SwiftSyntax_DIR' = "${{ github.workspace }}/BinaryCache/${{ matrix.triple }}/usr/lib/cmake/Compilers";
               '_SwiftFoundation_SourceDIR' = "${{ github.workspace }}/SourceCache/swift-foundation";
               '_SwiftFoundationICU_SourceDIR' = "${{ github.workspace }}/SourceCache/swift-foundation-icu";
               '_SwiftCollections_SourceDIR' = "${{ github.workspace }}/SourceCache/swift-collections";

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2638,46 +2638,31 @@ jobs:
 
       - name: Configure Experimental Dispatch
         if: matrix.os != 'Android' || inputs.build_android
-        run: |
-          $CLANG = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang.exe"
-          $CLANGXX = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang++.exe"
-          $CLANG_CL = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang-cl.exe"
-          $SWIFTC = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/swiftc.exe"
-          $SwiftFlags = "${{ matrix.swiftflags }}"
-
-          if ("${{ matrix.os }}" -eq "Android") {
-            # Used by matrix definitions.
-            $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-            $SwiftFlags += " -sysroot $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot"
-          }
-
-          $SwiftSDKDir = cygpath -m "${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk"
-          $SwiftFlags += " -sdk $SwiftSDKDir"
-
-          cmake -B ${{ github.workspace }}/BinaryCache/ExperimentalDispatch `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
-                -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
-                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
-                -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                -D CMAKE_Swift_COMPILER=${SWIFTC} `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple_no_api_level }} `
-                -D CMAKE_Swift_FLAGS="${SwiftFlags} -static-stdlib -Xfrontend -use-static-resource-dir" `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_COMPILER_USE_OLD_DRIVER=YES `
-                -D BUILD_SHARED_LIBS=NO `
-                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr `
-                -D CMAKE_FIND_PACKAGE_PREFER_CONFIG=YES `
-                -D CMAKE_STATIC_LIBRARY_PREFIX_Swift="lib" `
-                ${{ matrix.linker_flags }} `
-                ${{ matrix.extra_flags }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch `
-                -D ENABLE_SWIFT=YES
+        uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
+        with:
+          project-name: ExperimentalDispatch
+          swift-version: ${{ inputs.swift_version }}
+          enable-caching: true
+          debug-info: ${{ inputs.debug_info }}
+          build-os: ${{ inputs.build_os }}
+          build-arch: ${{ inputs.build_arch }}
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+          src-dir: ${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch
+          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalDispatch
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
+          android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
+          ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
+          built-compilers: '@("C", "CXX", "Swift")'
+          swift-sdk-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk
+          cmake-defines: |
+            @{
+               'BUILD_SHARED_LIBS' = "NO";
+               'CMAKE_Swift_FLAGS' = "-static-stdlib -Xfrontend -use-static-resource-dir";
+               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
+               'ENABLE_SWIFT' = "YES";
+              }
       - name: Build Experimental Dispatch
         if: matrix.os != 'Android' || inputs.build_android
         run: |

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2361,7 +2361,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("C", "CXX", "Swift")'
-          use-gnu-driver: true
+          use-gnu-driver: false
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "NO";
@@ -2398,7 +2398,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("C", "CXX", "Swift")'
-          use-gnu-driver: true
+          use-gnu-driver: false
           cmake-defines: |
             @{
                'BUILD_SHARED_LIBS' = "NO";
@@ -2435,7 +2435,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("C", "Swift")'
-          use-gnu-driver: true
+          use-gnu-driver: false
           cmake-defines: |
             @{
                'BUILD_SHARED_LIBS' = "NO";
@@ -2471,7 +2471,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("C", "Swift")'
-          use-gnu-driver: true
+          use-gnu-driver: false
           cmake-defines: |
             @{
                'BUILD_SHARED_LIBS' = "NO";
@@ -2508,7 +2508,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("C", "CXX", "Swift")'
-          use-gnu-driver: true
+          use-gnu-driver: false
           cmake-defines: |
             @{
                'BUILD_SHARED_LIBS' = "NO";
@@ -2546,7 +2546,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("CXX", "Swift")'
-          use-gnu-driver: true
+          use-gnu-driver: false
           cmake-defines: |
             @{
                'BUILD_SHARED_LIBS' = "NO";
@@ -2584,7 +2584,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("C", "Swift")'
-          use-gnu-driver: true
+          use-gnu-driver: false
           cmake-defines: |
             @{
                'BUILD_SHARED_LIBS' = "NO";
@@ -2623,7 +2623,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("C", "CXX", "Swift")'
-          use-gnu-driver: true
+          use-gnu-driver: false
           cmake-defines: |
             @{
                'BUILD_SHARED_LIBS' = "NO";

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2317,7 +2317,7 @@ jobs:
         if: matrix.os != 'Android' || inputs.build_android
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
-          project-name: libxml2
+          project-name: libdispatch-c
           swift-version: ${{ inputs.swift_version }}
           enable-caching: true
           debug-info: ${{ inputs.debug_info }}
@@ -2330,7 +2330,7 @@ jobs:
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          msvc-compilers: '@("C", "CXX")'
+          pinned-compilers: '@("C", "CXX")'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2004,115 +2004,31 @@ jobs:
             arch: amd64
             triple: x86_64-unknown-windows-msvc
             triple_no_api_level: x86_64-unknown-windows-msvc
-            cc: $CLANG_CL
-            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
-            cxx: $CLANG_CL
-            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
-            gnu-cc: $CLANG
-            gnu-cflags: '-fno-stack-protector -ffunction-sections -fdata-sections -fomit-frame-pointer'
-            gnu-cxx: $CLANGXX
-            gnu-cxxflags: '-fno-stack-protector -ffunction-sections -fdata-sections -fomit-frame-pointer'
-            gnu-linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="-Xlinker -debug" -D CMAKE_SHARED_LINKER_FLAGS="-Xlinker -debug"'
-            swiftflags: '${{ inputs.CMAKE_Swift_FLAGS }} -use-ld=lld-link'
-            extra_flags: -D CMAKE_SYSTEM_NAME=Windows -D CMAKE_SYSTEM_PROCESSOR=AMD64
           - os: Windows
             arch: arm64
             triple: aarch64-unknown-windows-msvc
             triple_no_api_level: aarch64-unknown-windows-msvc
-            cc: $CLANG_CL
-            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
-            cxx: $CLANG_CL
-            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
-            gnu-cc: $CLANG
-            gnu-cflags: '-fno-stack-protector -ffunction-sections -fdata-sections -fomit-frame-pointer'
-            gnu-cxx: $CLANGXX
-            gnu-cxxflags: '-fno-stack-protector -ffunction-sections -fdata-sections -fomit-frame-pointer'
-            gnu-linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="-Xlinker -debug" -D CMAKE_SHARED_LINKER_FLAGS="-Xlinker -debug"'
-            swiftflags: '${{ inputs.CMAKE_Swift_FLAGS }} -use-ld=lld-link'
-            extra_flags: -D CMAKE_SYSTEM_NAME=Windows -D CMAKE_SYSTEM_PROCESSOR=ARM64
           - os: Windows
             arch: x86
             triple: i686-unknown-windows-msvc
             triple_no_api_level: i686-unknown-windows-msvc
-            cc: $CLANG_CL
-            cflags: ${{ inputs.WINDOWS_CMAKE_C_FLAGS }}
-            cxx: $CLANG_CL
-            cxxflags: ${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.WINDOWS_CMAKE_SHARED_LINKER_FLAGS }}"'
-            gnu-cc: $CLANG
-            gnu-cflags: '-fno-stack-protector -ffunction-sections -fdata-sections -fomit-frame-pointer'
-            gnu-cxx: $CLANGXX
-            gnu-cxxflags: '-fno-stack-protector -ffunction-sections -fdata-sections -fomit-frame-pointer'
-            gnu-linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="-Xlinker -debug" -D CMAKE_SHARED_LINKER_FLAGS="-Xlinker -debug"'
-            swiftflags: '${{ inputs.CMAKE_Swift_FLAGS }} -use-ld=lld-link'
-            extra_flags: -D CMAKE_SYSTEM_NAME=Windows -D CMAKE_SYSTEM_PROCESSOR=AMD64
           - os: Android
             arch: arm64
             triple: 'aarch64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}'
             triple_no_api_level: aarch64-unknown-linux-android
-            cc: $CLANG
-            cflags: '${{ inputs.ANDROID_CMAKE_C_FLAGS }} --sysroot=$NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot'
-            cxx: $CLANGXX
-            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
-            gnu-cc: $CLANG
-            gnu-cflags: '${{ inputs.ANDROID_CMAKE_C_FLAGS }} --sysroot=$NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot'
-            gnu-cxx: $CLANGXX
-            gnu-cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
-            gnu-linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
-            swiftflags: -Xclang-linker -target -Xclang-linker aarch64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/${{ inputs.ANDROID_CLANG_VERSION }} -g
-            extra_flags: -D CMAKE_SYSTEM_NAME=Android -D CMAKE_SYSTEM_PROCESSOR=aarch64 -D CMAKE_ANDROID_ARCH_ABI=arm64-v8a -D CMAKE_ANDROID_NDK=$NDKPATH -D SWIFT_ANDROID_NDK_PATH=$NDKPATH
           - os: Android
             arch: armv7
             triple: 'armv7-unknown-linux-androideabi${{ inputs.ANDROID_API_LEVEL }}'
             triple_no_api_level: armv7-unknown-linux-androideabi
-            cc: $CLANG
-            cflags: '${{ inputs.ANDROID_CMAKE_C_FLAGS }} --sysroot=$NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot'
-            cxx: $CLANGXX
-            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
-            gnu-cc: $CLANG
-            gnu-cflags: '${{ inputs.ANDROID_CMAKE_C_FLAGS }} --sysroot=$NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot'
-            gnu-cxx: $CLANGXX
-            gnu-cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
-            gnu-linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
-            swiftflags: -Xclang-linker -target -Xclang-linker armv7-unknown-linux-androideabi${{ inputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/${{ inputs.ANDROID_CLANG_VERSION }} -g
-            extra_flags: -D CMAKE_SYSTEM_NAME=Android -D CMAKE_SYSTEM_PROCESSOR=armv7-a -D CMAKE_ANDROID_ARCH_ABI=armeabi-v7a -D CMAKE_ANDROID_NDK=$NDKPATH -D SWIFT_ANDROID_NDK_PATH=$NDKPATH
           - os: Android
             arch: i686
             triple: 'i686-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}'
             triple_no_api_level: i686-unknown-linux-android
-            cc: $CLANG
-            cflags: '${{ inputs.ANDROID_CMAKE_C_FLAGS }} --sysroot=$NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot'
-            cxx: $CLANGXX
-            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
-            gnu-cc: $CLANG
-            gnu-cflags: '${{ inputs.ANDROID_CMAKE_C_FLAGS }} --sysroot=$NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot'
-            gnu-cxx: $CLANGXX
-            gnu-cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
-            gnu-linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
-            swiftflags: -Xclang-linker -target -Xclang-linker i686-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/${{ inputs.ANDROID_CLANG_VERSION }} -g
-            extra_flags: -D CMAKE_SYSTEM_NAME=Android -D CMAKE_SYSTEM_PROCESSOR=i686 -D CMAKE_ANDROID_ARCH_ABI=x86 -D CMAKE_ANDROID_NDK=$NDKPATH -D SWIFT_ANDROID_NDK_PATH=$NDKPATH
           - os: Android
             arch: x86_64
             triple: 'x86_64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }}'
             triple_no_api_level: x86_64-unknown-linux-android
-            cc: $CLANG
-            cflags: '${{ inputs.ANDROID_CMAKE_C_FLAGS }} --sysroot=$NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot'
-            cxx: $CLANGXX
-            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
-            linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
-            gnu-cc: $CLANG
-            gnu-cflags: '${{ inputs.ANDROID_CMAKE_C_FLAGS }} --sysroot=$NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot'
-            gnu-cxx: $CLANGXX
-            gnu-cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
-            gnu-linker_flags: '-D CMAKE_EXE_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}" -D CMAKE_SHARED_LINKER_FLAGS="${{ inputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}"'
-            swiftflags: -Xclang-linker -target -Xclang-linker x86_64-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }} -Xclang-linker --sysroot -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker $NDKPATH/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/${{ inputs.ANDROID_CLANG_VERSION }} -g
-            extra_flags: -D CMAKE_SYSTEM_NAME=Android -D CMAKE_SYSTEM_PROCESSOR=x86_64 -D CMAKE_ANDROID_ARCH_ABI=x86_64 -D CMAKE_ANDROID_NDK=$NDKPATH -D SWIFT_ANDROID_NDK_PATH=$NDKPATH
-
+    
     name: ${{ matrix.os }} ${{ matrix.arch }} Experimental SDK
 
     steps:
@@ -2260,52 +2176,6 @@ jobs:
         with:
           ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
           local-cache: true
-
-      - name: Create vfs-overlay
-        if: matrix.os == 'Windows'
-        run: |
-          # Create the vfs-overlay file for Windows
-          $VfsOverlay = "${{ github.workspace }}/BinaryCache/swift/stdlib/windows-vfs-overlay.yaml"
-          $ModuleMapDir = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr/share
-          $Win10SdkRoot = Get-ItemPropertyValue `
-            -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots" `
-            -Name "KitsRoot10"
-          $Win10SdkRoot = cygpath -m ${Win10SdkRoot}
-          $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
-          $VsWhere = Join-Path "${InstallerLocation}" "vswhere.exe"
-          $VsInstallPath = (& "$VsWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
-          $VsInstallPath = cygpath -m ${VsInstallPath}
-
-          $ModuleMap = @"
-          version: 0
-          use-external-names: false
-          case-sensitive: false
-          roots:
-            - name: "${Win10SdkRoot}/Include/${env:UCRTVersion}/um"
-              type: directory
-              contents:
-                - name: module.modulemap
-                  type: file
-                  external-contents: "${ModuleMapDir}/winsdk.modulemap"
-            - name: "${Win10SdkRoot}/Include/${env:UCRTVersion}/ucrt"
-              type: directory
-              contents:
-                - name: module.modulemap
-                  type: file
-                  external-contents: "${ModuleMapDir}/ucrt.modulemap"
-            - name: "${VsInstallPath}/VC/Tools/MSVC/${env:VCToolsVersion}/include"
-              type: directory
-              contents:
-                - name: module.modulemap
-                  type: file
-                  external-contents: "${ModuleMapDir}/vcruntime.modulemap"
-                - name: vcruntime.apinotes
-                  type: file
-                  external-contents: "${ModuleMapDir}/vcruntime.apinotes"
-          "@
-          $VfsOverlayDir = Split-Path -Parent $VfsOverlay
-          New-Item -ItemType Directory -Path $VfsOverlayDir
-          Write-Output $ModuleMap | Out-File -FilePath $VfsOverlay -Encoding utf8
 
       - name: Run Resync
         if: matrix.os != 'Android' || inputs.build_android

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2706,7 +2706,7 @@ jobs:
               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
               'ENABLE_TESTING' = "NO";
               'FOUNDATION_BUILD_TOOLS' = "${{ matrix.os == 'Windows' && 'YES' || 'NO' }}";
-              'CURL_DIR' = "${{ github.workspace }}/BuildRoot/Library/curl-${{ inputs.curl_version }}/usr/lib/cmake/CURL \";
+              'CURL_DIR' = "${{ github.workspace }}/BuildRoot/Library/curl-${{ inputs.curl_version }}/usr/lib/cmake/CURL";
               'LibXml2_DIR' = "${{ github.workspace }}/BuildRoot/Library/libxml2-${{ inputs.libxml2_version }}/usr/lib/cmake/libxml2-${{ inputs.libxml2_version }}";
               'ZLIB_INCLUDE_DIR' = "${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr/include";
               'ZLIB_LIBRARY' = "${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr/lib/${{ matrix.os == 'Windows' && 'zlibstatic.lib' || 'libz.a' }}";
@@ -2715,7 +2715,7 @@ jobs:
               '_SwiftFoundation_SourceDIR' = "${{ github.workspace }}/SourceCache/swift-foundation";
               '_SwiftFoundationICU_SourceDIR' = "${{ github.workspace }}/SourceCache/swift-foundation-icu";
               '_SwiftCollections_SourceDIR' = "${{ github.workspace }}/SourceCache/swift-collections";
-              'SwiftFoundation_MACRO' = "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin"
+              'SwiftFoundation_MACRO' = "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin";
             }
       - name: Build Static Foundation
         if: matrix.os != 'Android' || inputs.build_android

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2525,39 +2525,32 @@ jobs:
 
       - name: Configure Experimental Observation
         if: matrix.os != 'Android' || inputs.build_android
-        run: |
-          $CLANG = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang.exe"
-          $CLANGXX = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang++.exe"
-          $CLANG_CL = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang-cl.exe"
-          $SWIFTC = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/swiftc.exe"
-          $SwiftFlags = "${{ matrix.swiftflags }}"
-
-          if ("${{ matrix.os }}" -eq "Android") {
-            # Used by matrix definitions.
-            $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          }
-
-          cmake -B ${{ github.workspace }}/BinaryCache/ExperimentalObservation `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_CXX_COMPILER=${{ matrix.gnu-cxx }} `
-                -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ matrix.gnu-cxxflags }}  -I${{ github.workspace }}/BinaryCache/ExperimentalRuntime/include" `
-                -D CMAKE_Swift_COMPILER=${SWIFTC} `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple_no_api_level }} `
-                -D CMAKE_Swift_FLAGS="${SwiftFlags}" `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_COMPILER_USE_OLD_DRIVER=YES `
-                -D BUILD_SHARED_LIBS=NO `
-                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr `
-                -D CMAKE_FIND_PACKAGE_PREFER_CONFIG=YES `
-                -D CMAKE_STATIC_LIBRARY_PREFIX_Swift="lib" `
-                ${{ matrix.gnu-linker_flags }} `
-                ${{ matrix.extra_flags }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/Observation `
-                -D SwiftCore_DIR=${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore `
-                -D SwiftOverlay_DIR=${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay
+        uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
+        with:
+          project-name: ExperimentalObservation
+          swift-version: ${{ inputs.swift_version }}
+          enable-caching: true
+          debug-info: ${{ inputs.debug_info }}
+          build-os: ${{ inputs.build_os }}
+          build-arch: ${{ inputs.build_arch }}
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+          src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/Observation
+          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalObservation
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
+          android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
+          ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
+          built-compilers: '@("CXX", "Swift")'
+          use-gnu-driver: true
+          cmake-defines: |
+            @{
+               'BUILD_SHARED_LIBS' = "NO";
+               'CMAKE_CXX_FLAGS' = "-I${{ github.workspace }}/BinaryCache/ExperimentalRuntime/include"
+               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
+               'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
+               'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay";
+            }
       - name: Build Experimental Observation
         if: matrix.os != 'Android' || inputs.build_android
         run: |

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2601,43 +2601,32 @@ jobs:
 
       - name: Configure Experimental Differentiation
         if: matrix.os != 'Android' || inputs.build_android
-        run: |
-          $CLANG = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang.exe"
-          $CLANGXX = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang++.exe"
-          $CLANG_CL = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang-cl.exe"
-          $SWIFTC = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/swiftc.exe"
-          $SwiftFlags = "${{ matrix.swiftflags }}"
-
-          if ("${{ matrix.os }}" -eq "Android") {
-            # Used by matrix definitions.
-            $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          }
-
-          cmake -B ${{ github.workspace }}/BinaryCache/ExperimentalDifferentiation `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=${{ matrix.gnu-cc }} `
-                -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ matrix.gnu-cflags }}" `
-                -D CMAKE_CXX_COMPILER=${{ matrix.gnu-cxx }} `
-                -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ matrix.gnu-cxxflags }}" `
-                -D CMAKE_Swift_COMPILER=${SWIFTC} `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple_no_api_level }} `
-                -D CMAKE_Swift_FLAGS="${SwiftFlags}" `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_COMPILER_USE_OLD_DRIVER=YES `
-                -D BUILD_SHARED_LIBS=NO `
-                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr `
-                -D CMAKE_FIND_PACKAGE_PREFER_CONFIG=YES `
-                -D CMAKE_STATIC_LIBRARY_PREFIX_Swift="lib" `
-                ${{ matrix.gnu-linker_flags }} `
-                ${{ matrix.extra_flags }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/Differentiation `
-                -D SwiftCore_DIR=${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore `
-                -D SwiftOverlay_DIR=${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay
+        uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
+        with:
+          project-name: ExperimentalDifferentiation
+          swift-version: ${{ inputs.swift_version }}
+          enable-caching: true
+          debug-info: ${{ inputs.debug_info }}
+          build-os: ${{ inputs.build_os }}
+          build-arch: ${{ inputs.build_arch }}
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+          src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/Differentiation
+          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalDifferentiation
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
+          android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
+          ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
+          built-compilers: '@("C", "CXX", "Swift")'
+          use-gnu-driver: true
+          cmake-defines: |
+            @{
+               'BUILD_SHARED_LIBS' = "NO";
+               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
+               'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
+               'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay";
+               'SwiftDifferentiation_ENABLE_LIBRARY_EVOLUTION' = "NO";
+            }
       - name: Build Experimental Differentiation
         if: matrix.os != 'Android' || inputs.build_android
         run: |

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2452,39 +2452,31 @@ jobs:
 
       - name: Configure Experimental Synchronization
         if: matrix.os != 'Android' || inputs.build_android
-        run: |
-          $CLANG = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang.exe"
-          $CLANGXX = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang++.exe"
-          $CLANG_CL = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang-cl.exe"
-          $SWIFTC = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/swiftc.exe"
-          $SwiftFlags = "${{ matrix.swiftflags }}"
-
-          if ("${{ matrix.os }}" -eq "Android") {
-            # Used by matrix definitions.
-            $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          }
-
-          cmake -B ${{ github.workspace }}/BinaryCache/ExperimentalSynchronization `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=${{ matrix.gnu-cc }} `
-                -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ matrix.gnu-cflags }}" `
-                -D CMAKE_Swift_COMPILER=${SWIFTC} `
-                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple_no_api_level }} `
-                -D CMAKE_Swift_FLAGS="${SwiftFlags}" `
-                -D CMAKE_Swift_COMPILER_WORKS=YES `
-                -D CMAKE_Swift_COMPILER_USE_OLD_DRIVER=YES `
-                -D BUILD_SHARED_LIBS=NO `
-                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr `
-                -D CMAKE_FIND_PACKAGE_PREFER_CONFIG=YES `
-                -D CMAKE_STATIC_LIBRARY_PREFIX_Swift="lib" `
-                ${{ matrix.gnu-linker_flags }} `
-                ${{ matrix.extra_flags }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/Synchronization `
-                -D SwiftCore_DIR=${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore `
-                -D SwiftOverlay_DIR=${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay
+        uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
+        with:
+          project-name: ExperimentalSynchronization
+          swift-version: ${{ inputs.swift_version }}
+          enable-caching: true
+          debug-info: ${{ inputs.debug_info }}
+          build-os: ${{ inputs.build_os }}
+          build-arch: ${{ inputs.build_arch }}
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+          src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Synchronization
+          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalSynchronization
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
+          android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
+          ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
+          built-compilers: '@("C", "Swift")'
+          use-gnu-driver: true
+          cmake-defines: |
+            @{
+               'BUILD_SHARED_LIBS' = "NO";
+               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
+               'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
+               'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay";
+            }
       - name: Build Experimental Synchronization
         if: matrix.os != 'Android' || inputs.build_android
         run: |

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2660,7 +2660,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("C", "CXX", "Swift")'
-          swift-sdk-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk
+          swift-sdk-path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk
           cmake-defines: |
             @{
                'BUILD_SHARED_LIBS' = "NO";
@@ -2696,7 +2696,7 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           built-compilers: '@("ASM","C", "CXX", "Swift")'
-          swift-sdk-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk
+          swift-sdk-path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "NO";

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2315,34 +2315,28 @@ jobs:
 
       - name: Configure Dispatch (C parts only)
         if: matrix.os != 'Android' || inputs.build_android
-        run: |
-          $CLANG = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang.exe"
-          $CLANGXX = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang++.exe"
-          $CLANG_CL = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang-cl.exe"
-          $SWIFTC = cygpath -m "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/swiftc.exe"
-
-          if ("${{ matrix.os }}" -eq "Android") {
-            # Used by matrix definitions.
-            $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
-          }
-
-          cmake -B ${{ github.workspace }}/BinaryCache/libdispatch-c `
-                -D BUILD_SHARED_LIBS=YES `
-                -D CMAKE_BUILD_TYPE=Release `
-                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
-                -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
-                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
-                -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
-                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
-                ${{ matrix.linker_flags }} `
-                ${{ matrix.extra_flags }} `
-                -G Ninja `
-                -S ${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch `
-                -D BUILD_TESTING=NO `
-                -D ENABLE_SWIFT=NO
+        uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
+        with:
+          project-name: libxml2
+          swift-version: ${{ inputs.swift_version }}
+          enable-caching: true
+          debug-info: ${{ inputs.debug_info }}
+          build-os: ${{ inputs.build_os }}
+          build-arch: ${{ inputs.build_arch }}
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+          src-dir: ${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch 
+          bin-dir: ${{ github.workspace }}/BinaryCache/libdispatch-c 
+          android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
+          android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
+          ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
+          msvc-compilers: '@("C", "CXX")'
+          cmake-defines: |
+            @{
+              'BUILD_SHARED_LIBS' = "YES";
+              'BUILD_TESTING' = "NO";
+              'ENABLE_SWIFT' = "NO";
+            }
       - name: Build Dispatch (C parts only)
         if: matrix.os != 'Android' || inputs.build_android
         run: |


### PR DESCRIPTION
Convert `experimental-sdk` job to use `configure-cmake-project`. Also fix a typo in the action when handling `use-gnu-driver` option

Successful downstream job: https://github.com/thebrowsercompany/swift-build/actions/runs/17390839011