### PR TITLE
configure: Set cmake arch value to i686 for Windows

### DIFF
--- a/.github/actions/configure-cmake-project/action.yml
+++ b/.github/actions/configure-cmake-project/action.yml
@@ -128,7 +128,14 @@ runs:
         }
 
         $CMakeArch = switch ($OS) {
-          'Windows' { $Arch.ToUpperInvariant() }
+          'Windows' {
+            switch ($Arch) {
+              'arm64' { 'ARM64' }
+              'amd64' { 'AMD64' }
+              'x86' { 'i686' }
+              default { throw "Unsupported Windows architecture: $Arch" }
+            }
+          }
           'Android' {
             switch ($Arch) {
               'arm64' { 'aarch64' }


### PR DESCRIPTION
The upstream Swift repository sets the value to `i686`. While this is incorrect and CMake expects `X86`, this is used in a few projects so we update the value here to match upstream behavior.