### PR TITLE
Use built compilers since we are not isntalling pinned toolchain for this job

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2163,7 +2163,7 @@ jobs:
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          pinned-compilers: '@("C", "CXX")'
+          built-compilers: '@("C", "CXX")'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";


### PR DESCRIPTION
My change introduced a break on cirun machines for missing pinned compilers. so this change uses the built-compilers which seems to do the trick.

downstream job: https://github.com/thebrowsercompany/swift-build/actions/runs/17500660240/job/49716449757?pr=311