### PR TITLE
Build online installer

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -145,7 +145,12 @@ on:
         required: true
       PASSPHRASE:
         required: true
-
+      R2_ACCOUNT_ID:
+        required: true
+      R2_ACCESS_KEY_ID:
+        required: true
+      R2_SECRET_ACCESS_KEY:
+        required: true
 
 jobs:
   context:
@@ -871,6 +876,9 @@ jobs:
       SYMBOL_SERVER_PAT: ${{ secrets.SYMBOL_SERVER_PAT }}
       CERTIFICATE: ${{ secrets.CERTIFICATE }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
 
   mac-build:
     # TODO: Enable the mac build.
@@ -955,6 +963,9 @@ jobs:
       SYMBOL_SERVER_PAT: ${{ secrets.SYMBOL_SERVER_PAT }}
       CERTIFICATE: ${{ secrets.CERTIFICATE }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
 
   snapshot:
     runs-on: ubuntu-latest
@@ -998,6 +1009,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # TODO: Upload the offline installer as well.
           branch_version_string=${{ inputs.swift_version || '0.0.0' }}
           if [[ $branch_version_string == "0.0.0" ]]; then
             latest="true"

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -1019,51 +1019,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # TODO: Upload the offline installer as well.
+          function Upload_File_To_Release([string]$InputFile, [string]$OutputName) {
+            mv "${InputFile}" "${OutputName}"
+            gh release upload ${{ needs.context.outputs.swift_tag }} "${OutputName}" -R ${{ github.repository }}
+            
+            shasum -a 256 "${OutputName}" > "${OutputName}.sha256"
+            gh release upload ${{ needs.context.outputs.swift_tag }} "${OutputName}.sha256" -R ${{ github.repository }}
+          }
+
           branch_version_string=${{ inputs.swift_version || '0.0.0' }}
           if [[ $branch_version_string == "0.0.0" ]]; then
             latest="true"
           else
             latest="false"
           fi
+          
           # Create Release
           gh release create ${{ needs.context.outputs.swift_tag }} -R ${{ github.repository }} --latest=${latest}
 
-          # AMD64
-          cd ${{ github.workspace }}/tmp/online/amd64
-
-          mv installer.exe installer-amd64.exe
-          gh release upload ${{ needs.context.outputs.swift_tag }} installer-amd64.exe -R ${{ github.repository }}
-
-          shasum -a 256 installer-amd64.exe > installer-amd64.exe.sha256
-          gh release upload ${{ needs.context.outputs.swift_tag }} installer-amd64.exe.sha256 -R ${{ github.repository }}
-
-          # ARM64
-          cd ${{ github.workspace }}/tmp/online/arm64
-
-          mv installer.exe installer-arm64.exe
-          gh release upload ${{ needs.context.outputs.swift_tag }} installer-arm64.exe -R ${{ github.repository }}
-
-          shasum -a 256 installer-arm64.exe > installer-arm64.exe.sha256
-          gh release upload ${{ needs.context.outputs.swift_tag }} installer-arm64.exe.sha256 -R ${{ github.repository }}
-
-          # AMD64
-          cd ${{ github.workspace }}/tmp/offline/amd64
-
-          mv installer.exe installer-offline-amd64.exe
-          gh release upload ${{ needs.context.outputs.swift_tag }} installer-offline-amd64.exe -R ${{ github.repository }}
-
-          shasum -a 256 installer-offline-amd64.exe > installer-offline-amd64.exe.sha256
-          gh release upload ${{ needs.context.outputs.swift_tag }} installer-offline-amd64.exe.sha256 -R ${{ github.repository }}
-
-          # ARM64
-          cd ${{ github.workspace }}/tmp/offline/arm64
-
-          mv installer.exe installer-offline-arm64.exe
-          gh release upload ${{ needs.context.outputs.swift_tag }} installer-offline-arm64.exe -R ${{ github.repository }}
-
-          shasum -a 256 installer-offline-arm64.exe > installer-offline-arm64.exe.sha256
-          gh release upload ${{ needs.context.outputs.swift_tag }} installer-offline-arm64.exe.sha256 -R ${{ github.repository }}
+          # Upload all installer variants
+          Upload_File_To_Release "${{ github.workspace }}/tmp/online/amd64/installer.exe" "installer-amd64.exe"
+          Upload_File_To_Release "${{ github.workspace }}/tmp/online/arm64/installer.exe" "installer-arm64.exe"
+          Upload_File_To_Release "${{ github.workspace }}/tmp/offline/amd64/installer.exe" "installer-offline-amd64.exe"
+          Upload_File_To_Release "${{ github.workspace }}/tmp/offline/arm64/installer.exe" "installer-offline-arm64.exe"
 
   binary-size:
     needs: [context, release]

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -997,14 +997,24 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: Windows-amd64-installer
-          path: ${{ github.workspace }}/tmp/amd64
+          name: Windows-amd64-installer-online
+          path: ${{ github.workspace }}/tmp/online/amd64
 
       - uses: actions/download-artifact@v4
         with:
-          name: Windows-arm64-installer
-          path: ${{ github.workspace }}/tmp/arm64
+          name: Windows-arm64-installer-online
+          path: ${{ github.workspace }}/tmp/online/arm64
+      
+      - uses: actions/download-artifact@v4
+        with:
+          name: Windows-amd64-installer-offline
+          path: ${{ github.workspace }}/tmp/offline/amd64
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: Windows-arm64-installer-offline
+          path: ${{ github.workspace }}/tmp/offline/arm64
+    
       - name: Create Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1020,7 +1030,7 @@ jobs:
           gh release create ${{ needs.context.outputs.swift_tag }} -R ${{ github.repository }} --latest=${latest}
 
           # AMD64
-          cd ${{ github.workspace }}/tmp/amd64
+          cd ${{ github.workspace }}/tmp/online/amd64
 
           mv installer.exe installer-amd64.exe
           gh release upload ${{ needs.context.outputs.swift_tag }} installer-amd64.exe -R ${{ github.repository }}
@@ -1029,10 +1039,42 @@ jobs:
           gh release upload ${{ needs.context.outputs.swift_tag }} installer-amd64.exe.sha256 -R ${{ github.repository }}
 
           # ARM64
-          cd ${{ github.workspace }}/tmp/arm64
+          cd ${{ github.workspace }}/tmp/online/arm64
 
           mv installer.exe installer-arm64.exe
           gh release upload ${{ needs.context.outputs.swift_tag }} installer-arm64.exe -R ${{ github.repository }}
 
           shasum -a 256 installer-arm64.exe > installer-arm64.exe.sha256
           gh release upload ${{ needs.context.outputs.swift_tag }} installer-arm64.exe.sha256 -R ${{ github.repository }}
+
+          # AMD64
+          cd ${{ github.workspace }}/tmp/offline/amd64
+
+          mv installer.exe installer-offline-amd64.exe
+          gh release upload ${{ needs.context.outputs.swift_tag }} installer-offline-amd64.exe -R ${{ github.repository }}
+
+          shasum -a 256 installer-offline-amd64.exe > installer-offline-amd64.exe.sha256
+          gh release upload ${{ needs.context.outputs.swift_tag }} installer-offline-amd64.exe.sha256 -R ${{ github.repository }}
+
+          # ARM64
+          cd ${{ github.workspace }}/tmp/offline/arm64
+
+          mv installer.exe installer-offline-arm64.exe
+          gh release upload ${{ needs.context.outputs.swift_tag }} installer-offline-arm64.exe -R ${{ github.repository }}
+
+          shasum -a 256 installer-offline-arm64.exe > installer-offline-arm64.exe.sha256
+          gh release upload ${{ needs.context.outputs.swift_tag }} installer-offline-arm64.exe.sha256 -R ${{ github.repository }}
+
+  binary-size:
+    needs: [context, release]
+    if: inputs.create_release == true
+    name: Record Swift Toolchain Binary Sizes
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/release-swift-toolchain-binary-sizes.yml
+    with:
+      toolchain_version: ${{ needs.context.outputs.swift_tag }}
+      dry_run: false
+    secrets:
+      SWIFT_TOOLCHAIN_UPLOADER_ROLE_ARN: ${{ secrets.SWIFT_TOOLCHAIN_UPLOADER_ROLE_ARN }}

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -1019,12 +1019,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          function Upload_File_To_Release([string]$InputFile, [string]$OutputName) {
-            mv "${InputFile}" "${OutputName}"
-            gh release upload ${{ needs.context.outputs.swift_tag }} "${OutputName}" -R ${{ github.repository }}
+          function upload_installer() {
+            local input_file=$1
+            local output_name=$2
             
-            shasum -a 256 "${OutputName}" > "${OutputName}.sha256"
-            gh release upload ${{ needs.context.outputs.swift_tag }} "${OutputName}.sha256" -R ${{ github.repository }}
+            mv "${input_file}" "${output_name}"
+            gh release upload ${{ needs.context.outputs.swift_tag }} "${output_name}" -R ${{ github.repository }}
+            
+            shasum -a 256 "${output_name}" > "${output_name}.sha256"
+            gh release upload ${{ needs.context.outputs.swift_tag }} "${output_name}.sha256" -R ${{ github.repository }}
           }
 
           branch_version_string=${{ inputs.swift_version || '0.0.0' }}
@@ -1038,21 +1041,7 @@ jobs:
           gh release create ${{ needs.context.outputs.swift_tag }} -R ${{ github.repository }} --latest=${latest}
 
           # Upload all installer variants
-          Upload_File_To_Release "${{ github.workspace }}/tmp/online/amd64/installer.exe" "installer-amd64.exe"
-          Upload_File_To_Release "${{ github.workspace }}/tmp/online/arm64/installer.exe" "installer-arm64.exe"
-          Upload_File_To_Release "${{ github.workspace }}/tmp/offline/amd64/installer.exe" "installer-offline-amd64.exe"
-          Upload_File_To_Release "${{ github.workspace }}/tmp/offline/arm64/installer.exe" "installer-offline-arm64.exe"
-
-  binary-size:
-    needs: [context, release]
-    if: inputs.create_release == true
-    name: Record Swift Toolchain Binary Sizes
-    permissions:
-      contents: read
-      id-token: write
-    uses: ./.github/workflows/release-swift-toolchain-binary-sizes.yml
-    with:
-      toolchain_version: ${{ needs.context.outputs.swift_tag }}
-      dry_run: false
-    secrets:
-      SWIFT_TOOLCHAIN_UPLOADER_ROLE_ARN: ${{ secrets.SWIFT_TOOLCHAIN_UPLOADER_ROLE_ARN }}
+          upload_installer "${{ github.workspace }}/tmp/online/amd64/installer.exe" "installer-amd64.exe"
+          upload_installer "${{ github.workspace }}/tmp/online/arm64/installer.exe" "installer-arm64.exe"
+          upload_installer "${{ github.workspace }}/tmp/offline/amd64/installer.exe" "installer-offline-amd64.exe"
+          upload_installer "${{ github.workspace }}/tmp/offline/arm64/installer.exe" "installer-offline-arm64.exe"

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -5134,7 +5134,7 @@ jobs:
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
               -p:BundleFlavor=online `
-              -p:BaseReleaseDownloadUrl=`"$BaseReleaseDownloadUrl`" `
+              -p:BaseReleaseDownloadUrl=$BaseReleaseDownloadUrl `
               -p:Platforms="`"$($Platforms -Join ';')`"" `
               -p:AndroidArchitectures="`"aarch64;armv7;i686;x86_64`"" `
               -p:WindowsArchitectures="`"aarch64;i686;x86_64`"" `

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -5111,10 +5111,10 @@ jobs:
     
       - name: Generate online installer download URL
         if: ${{ inputs.release }}
-        id: generate-base-release-download-prefix
+        id: generate-base-release-download-subcomponent
         run: |
-          $BaseReleaseDownloadUrlPrefix = "${{ inputs.swift_tag }}/${{ matrix.arch }}/${{ github.run_id }}"
-          echo "url_prefix=$BaseReleaseDownloadUrlPrefix" >> $env:GITHUB_OUTPUT
+          $BaseReleaseDownloadUrlSubcomponent = "${{ inputs.swift_tag }}/${{ matrix.arch }}/${{ github.run_id }}"
+          echo "url_subcomponent=$BaseReleaseDownloadUrlSubcomponent" >> $env:GITHUB_OUTPUT
 
       - name: Build installer bundle (online)
         if: ${{ inputs.release }}
@@ -5123,7 +5123,7 @@ jobs:
           if ("${{ inputs.build_android }}" -eq "true") {
             $Platforms=@("android") + $Platforms
           }
-          $BaseReleaseDownloadUrl = "https://swift-toolchain.thebrowserco.com/${{ steps.generate-base-release-download-prefix.outputs.url_prefix }}"
+          $BaseReleaseDownloadUrl = "https://swift-toolchain.thebrowserco.com/${{ steps.generate-base-release-download-subcomponent.outputs.url_subcomponent }}"
 
           msbuild -nologo -restore -maxCpuCount `
               /t:rebuild `
@@ -5177,7 +5177,7 @@ jobs:
         if: ${{ inputs.release }}
         env:
           SOURCE_DIR: ${{ steps.prepare-layout.outputs.LayoutDir }}
-          DESTINATION_PREFIX: ${{ steps.generate-base-release-download-prefix.outputs.url_prefix }}
+          DESTINATION_PREFIX: ${{ steps.generate-base-release-download-subcomponent.outputs.url_subcomponent }}
           R2_BUCKET: swift-toolchain
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2175,7 +2175,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}/SourceCache/swift/Runtimes
           cmake -P Resync.cmake
-          
+
       - name: Configure Dispatch (C parts only)
         if: matrix.os != 'Android' || inputs.build_android
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
@@ -5170,7 +5170,7 @@ jobs:
         if: ${{ inputs.release }}
         uses: actions/upload-artifact@v4
         with:
-          name: Windows-${{ matrix.arch }}-installer
+          name: Windows-${{ matrix.arch }}-installer-online
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/installer.exe
 
       - name: Upload msi's and cab's 
@@ -5191,10 +5191,12 @@ jobs:
     runs-on: ${{ inputs.default_build_runner }}
 
     steps:
-      - uses: actions/download-artifact@v4
+      - name: Download Swift SDK Installer (${{ inputs.release && 'online' || 'offline' }})
+        uses: actions/download-artifact@v4
         with:
-          name: Windows-${{ inputs.build_arch }}-installer-offline
+          name: Windows-${{ inputs.build_arch }}-installer-${{ inputs.release && 'online' || 'offline' }}
           path: ${{ github.workspace }}/tmp
+
 
       # TODO(compnerd): migrate this to compnerd/gha-setup-swift after the work that @mangini is doing is completed
       - run: |
@@ -5255,12 +5257,12 @@ jobs:
         arch: [ x86_64, aarch64 ]
 
     steps:
-      - name: Download Swift SDK
+      - name: Download Swift SDK Installer (${{ inputs.release && 'online' || 'offline' }})
         uses: actions/download-artifact@v4
         with:
-          name: Windows-${{ inputs.build_arch }}-installer-offline
+          name: Windows-${{ inputs.build_arch }}-installer-${{ inputs.release && 'online' || 'offline' }}
           path: ${{ github.workspace }}/tmp
-
+    
       # TODO(compnerd): migrate this to compnerd/gha-setup-swift after the work that @mangini is doing is completed
       - name: Install Swift SDK
         run: |

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -5175,14 +5175,19 @@ jobs:
 
       - name: Upload msi's and cab's 
         if: ${{ inputs.release }}
-        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c # v1.4
-        with:
-          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
-          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
-          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          r2-bucket: swift-toolchain
-          source-dir: ${{ steps.prepare-layout.outputs.LayoutDir }}
-          destination-dir: ${{ steps.generate-base-release-download-prefix.outputs.url_prefix }}
+        env:
+          SOURCE_DIR: ${{ steps.prepare-layout.outputs.LayoutDir }}
+          DESTINATION_PREFIX: ${{ steps.generate-base-release-download-prefix.outputs.url_prefix }}
+          R2_BUCKET: swift-toolchain
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ENDPOINT_URL: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+        run: |
+          aws s3 sync "${env:SOURCE_DIR}" "s3://${env:R2_BUCKET}/${env:DESTINATION_PREFIX}/" `
+            --endpoint-url "${env:R2_ENDPOINT_URL}" `
+            --no-progress `
+            --acl private
 
   smoke_test:
     # TODO: Build this on macOS or make an equivalent Mac-only job

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -283,6 +283,12 @@ on:
         required: true
       PASSPHRASE:
         required: true
+      R2_ACCOUNT_ID:
+        required: true
+      R2_ACCESS_KEY_ID:
+        required: true
+      R2_SECRET_ACCESS_KEY:
+        required: true
 
 env:
   PINNED_BOOTSTRAP_TOOLCHAIN_VERSION: 6.1.2
@@ -2169,7 +2175,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}/SourceCache/swift/Runtimes
           cmake -P Resync.cmake
-
+          
       - name: Configure Dispatch (C parts only)
         if: matrix.os != 'Android' || inputs.build_android
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
@@ -5068,7 +5074,7 @@ jobs:
               -p:ProductVersion=${{ inputs.swift_version }}-${{ inputs.swift_tag }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/shared/shared.wixproj
 
-      - name: Build installer bundle
+      - name: Build installer bundle (offline)
         run: |
           $Platforms=@("windows")
           if ("${{ inputs.build_android }}" -eq "true") {
@@ -5091,15 +5097,92 @@ jobs:
               -p:ToolchainVariants="`"asserts;noasserts`"" `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bundle/installer.wixproj
 
-      - if: ${{ inputs.release }}
+      - name: Generate Build Provenance (offline installer)
+        if: ${{ inputs.release }}
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/installer.exe
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload installer (offline)
+        uses: actions/upload-artifact@v4
+        with:
+          name: Windows-${{ matrix.arch }}-installer-offline
+          path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/installer.exe
+    
+      - name: Generate online installer download URL
+        if: ${{ inputs.release }}
+        id: generate-base-release-download-prefix
+        run: |
+          $BaseReleaseDownloadUrlPrefix = "${{ inputs.swift_tag }}/${{ matrix.arch }}/${{ github.run_id }}"
+          echo "url_prefix=$BaseReleaseDownloadUrlPrefix" >> $env:GITHUB_OUTPUT
+
+      - name: Build installer bundle (online)
+        if: ${{ inputs.release }}
+        run: |
+          $Platforms=@("windows")
+          if ("${{ inputs.build_android }}" -eq "true") {
+            $Platforms=@("android") + $Platforms
+          }
+          $BaseReleaseDownloadUrl = "https://pub-3a06d9ae9ab6469198a3cf59c7d6bdce.r2.dev/${{ steps.generate-base-release-download-prefix.outputs.url_prefix }}"
+
+          msbuild -nologo -restore -maxCpuCount `
+              /t:rebuild `
+              -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
+              -p:Configuration=Release `
+              -p:BuildProjectReferences=false `
+              -p:SignOutput=${{ inputs.signed }} `
+              -p:CERTIFICATE=${env:CERTIFICATE} `
+              -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:BundleFlavor=online `
+              -p:BaseReleaseDownloadUrl=`"$BaseReleaseDownloadUrl`" `
+              -p:Platforms="`"$($Platforms -Join ';')`"" `
+              -p:AndroidArchitectures="`"aarch64;armv7;i686;x86_64`"" `
+              -p:WindowsArchitectures="`"aarch64;i686;x86_64`"" `
+              -p:ProductArchitecture=${{ matrix.arch }} `
+              -p:ProductVersion=${{ inputs.swift_version }}-${{ inputs.swift_tag }} `
+              -p:ToolchainVariants="`"asserts;noasserts`"" `
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bundle/installer.wixproj
+
+      - name: Prepare layout for upload
+        id: prepare-layout
+        if: ${{ inputs.release }}
+        run: |
+          # Create the target folder.
+          $SourceDir = "${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}"
+          $LayoutDir = "${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/layout"
+          New-Item -ItemType Directory -Path $LayoutDir -Force | Out-Null
+
+          # Copy all .txt files from src to the filtered directory
+          Copy-Item -Path "$SourceDir/installer.exe" -Destination "$LayoutDir" -Force
+          Copy-Item -Path "$SourceDir/*.cab" -Destination "$LayoutDir" -Force
+          Copy-Item -Path "$SourceDir/*.msi" -Destination "$LayoutDir" -Force
+
+          echo "LayoutDir=$LayoutDir"
+          echo "LayoutDir=$LayoutDir" >> $env:GITHUB_OUTPUT
+
+      - name: Generate Build Provenance (online installer)
+        if: ${{ inputs.release }}
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/installer.exe
+
+      - name: Upload installer (online)
+        if: ${{ inputs.release }}
+        uses: actions/upload-artifact@v4
         with:
           name: Windows-${{ matrix.arch }}-installer
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/installer.exe
+
+      - name: Upload msi's and cab's 
+        if: ${{ inputs.release }}
+        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c # v1.4
+        with:
+          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          r2-bucket: swift-toolchain
+          source-dir: ${{ steps.prepare-layout.outputs.LayoutDir }}
+          destination-dir: ${{ steps.generate-base-release-download-prefix.outputs.url_prefix }}
 
   smoke_test:
     # TODO: Build this on macOS or make an equivalent Mac-only job
@@ -5110,7 +5193,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: Windows-${{ inputs.build_arch }}-installer
+          name: Windows-${{ inputs.build_arch }}-installer-offline
           path: ${{ github.workspace }}/tmp
 
       # TODO(compnerd): migrate this to compnerd/gha-setup-swift after the work that @mangini is doing is completed
@@ -5175,7 +5258,7 @@ jobs:
       - name: Download Swift SDK
         uses: actions/download-artifact@v4
         with:
-          name: Windows-${{ inputs.build_arch }}-installer
+          name: Windows-${{ inputs.build_arch }}-installer-offline
           path: ${{ github.workspace }}/tmp
 
       # TODO(compnerd): migrate this to compnerd/gha-setup-swift after the work that @mangini is doing is completed

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2627,6 +2627,7 @@ jobs:
         with:
           name: ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.static && 'static' || 'shared' }}-experimental-sdk
           path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform
+                ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
 
       - name: Upload PDBs to Azure
         if: matrix.os == 'Windows' && inputs.debug_info

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2627,7 +2627,6 @@ jobs:
         with:
           name: ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.static && 'static' || 'shared' }}-experimental-sdk
           path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform
-                ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
 
       - name: Upload PDBs to Azure
         if: matrix.os == 'Windows' && inputs.debug_info

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -5123,7 +5123,7 @@ jobs:
           if ("${{ inputs.build_android }}" -eq "true") {
             $Platforms=@("android") + $Platforms
           }
-          $BaseReleaseDownloadUrl = "https://pub-3a06d9ae9ab6469198a3cf59c7d6bdce.r2.dev/${{ steps.generate-base-release-download-prefix.outputs.url_prefix }}"
+          $BaseReleaseDownloadUrl = "https://swift-toolchain.thebrowserco.com/${{ steps.generate-base-release-download-prefix.outputs.url_prefix }}"
 
           msbuild -nologo -restore -maxCpuCount `
               /t:rebuild `
@@ -5197,7 +5197,6 @@ jobs:
           name: Windows-${{ inputs.build_arch }}-installer-${{ inputs.release && 'online' || 'offline' }}
           path: ${{ github.workspace }}/tmp
 
-
       # TODO(compnerd): migrate this to compnerd/gha-setup-swift after the work that @mangini is doing is completed
       - run: |
           function Update-EnvironmentVariables {
@@ -5262,7 +5261,7 @@ jobs:
         with:
           name: Windows-${{ inputs.build_arch }}-installer-${{ inputs.release && 'online' || 'offline' }}
           path: ${{ github.workspace }}/tmp
-    
+
       # TODO(compnerd): migrate this to compnerd/gha-setup-swift after the work that @mangini is doing is completed
       - name: Install Swift SDK
         run: |


### PR DESCRIPTION
This changes builds the online flavor of the installer and uploads the binaries to a public R2 storage bucket. The offline installer is still available. 

## Changes: 
- Build both online and offline installer
- upload cabs and msi files to R2 storage and use the url to build the installer
- Use the online installer for smoke testing
- Change name of payloads accordingly

## Testing
- testing the resulting installer localy
- smoke testing with the new installer

**Successful downstream job (https://github.com/thebrowsercompany/swift-build/actions/runs/17561511426) ** (Note: i still need to test changes to upload files on the release)