### PR TITLE
Restore missing SDK configure conditions when not building Android

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2827,6 +2827,7 @@ jobs:
           local-cache: true
 
       - name: Configure libdispatch
+        if: matrix.os != 'Android' || inputs.build_android
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
           project-name: libdispatch
@@ -2855,6 +2856,7 @@ jobs:
           cmake --build ${{ github.workspace }}/BinaryCache/libdispatch
 
       - name: Configure Foundation
+        if: matrix.os != 'Android' || inputs.build_android
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
           project-name: Foundation
@@ -2899,6 +2901,7 @@ jobs:
 
       # TODO(compnerd) correctly version XCTest
       - name: Configure XCTest
+        if: matrix.os != 'Android' || inputs.build_android
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
           project-name: XCTest
@@ -2932,6 +2935,7 @@ jobs:
           cmake --build ${{ github.workspace }}/BinaryCache/xctest
 
       - name: Configure Testing
+        if: matrix.os != 'Android' || inputs.build_android
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
           project-name: Testing


### PR DESCRIPTION
We lost these in a refactor in 699077c.