### PR TITLE
Update gha-setup-swift to latest

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -330,6 +330,7 @@ runs:
       if: inputs.swift-version != '' && inputs.swift-repo == ''
       uses: compnerd/gha-setup-swift@main
       with:
+        source: 'swift.org'
         swift-version: ${{ steps.sanitize-input.outputs.swift-branch }}
         swift-build: ${{ steps.sanitize-input.outputs.swift-tag }}
 
@@ -337,6 +338,7 @@ runs:
       if: inputs.swift-version != '' && inputs.swift-repo != ''
       uses: compnerd/gha-setup-swift@main
       with:
+        source: 'custom'
         github-repo: ${{ inputs.swift-repo }}
         github-token: ${{ github.token }}
         release-asset-name: ${{ steps.sanitize-input.outputs.swift-release-asset }}


### PR DESCRIPTION
We are seeing failures installing swift (see [example](https://github.com/thebrowsercompany/swift-build/actions/runs/17976216297/job/51133301454)). newer versions of the action collect logs, so getting us to be on the cutting edge

Downstream run: https://github.com/thebrowsercompany/swift-build/actions/runs/17985190166