### PR TITLE
build_tools: Remove clang-pseudo-gen

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -744,14 +744,12 @@ jobs:
         run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target llvm-tblgen
       - name: Build clang-tblgen
         run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target clang-tblgen
+      - name: Build clang-tidy-confusable-chars-gen
+        run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target clang-tidy-confusable-chars-gen
       - name: Build lldb-tblgen
         run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target lldb-tblgen
       - name: Build llvm-config
         run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target llvm-config
-      - name: Build clang-pseudo-gen
-        run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target clang-pseudo-gen
-      - name: Build clang-tidy-confusable-chars-gen
-        run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target clang-tidy-confusable-chars-gen
       - name: Build swift-def-to-strings-converter
         run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target swift-def-to-strings-converter
       - name: Build swift-serialize-diagnostics
@@ -765,10 +763,9 @@ jobs:
           $Binaries = @(
             "llvm-tblgen",
             "clang-tblgen",
+            "clang-tidy-confusable-chars-gen",
             "lldb-tblgen",
             "llvm-config",
-            "clang-pseudo-gen",
-            "clang-tidy-confusable-chars-gen",
             "swift-def-to-strings-converter",
             "swift-serialize-diagnostics",
             "swift-compatibility-symbols"


### PR DESCRIPTION
The target no longer exists since the rebranch to 21.x. In addition, this re-orders the build_tools targets to follow the same order as build.ps1.