### PR TITLE
Use Azure Trusted Signing when available

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -317,8 +317,7 @@ jobs:
           fi
 
           if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.signed }}" == "true" ]]; then
-            # FIXME(compnerd) enable this when requested
-            echo signed=false >> ${GITHUB_OUTPUT}
+            echo signed=true >> ${GITHUB_OUTPUT}
           else
             echo signed=false >> ${GITHUB_OUTPUT}
           fi

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -151,6 +151,14 @@ on:
         required: true
       R2_SECRET_ACCESS_KEY:
         required: true
+      AZURE_SP_CREDENTIALS:
+        required: false
+      TRUSTED_SIGNING_ACCOUNT:
+        required: false
+      TRUSTED_SIGNING_TEST_PROFILE:
+        required: false
+      TRUSTED_SIGNING_PROD_PROFILE:
+        required: false
 
 jobs:
   context:
@@ -626,6 +634,10 @@ jobs:
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      AZURE_SP_CREDENTIALS: ${{ secrets.AZURE_SP_CREDENTIALS }}
+      TRUSTED_SIGNING_ACCOUNT: ${{ secrets.TRUSTED_SIGNING_ACCOUNT }}
+      TRUSTED_SIGNING_TEST_PROFILE: ${{ secrets.TRUSTED_SIGNING_TEST_PROFILE }}
+      TRUSTED_SIGNING_PROD_PROFILE: ${{ secrets.TRUSTED_SIGNING_PROD_PROFILE }}
 
   mac-build:
     # TODO: Enable the mac build.

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -4177,7 +4177,7 @@ jobs:
           '{
             "Endpoint": "https://eus.codesigning.azure.net",
             "CodeSigningAccountName": "${{ secrets.TRUSTED_SIGNING_ACCOUNT }}",
-            "CertificateProfileName": "${{ secrets.TRUSTED_SIGNING_TEST_PROFILE }}",
+            "CertificateProfileName": "${{ secrets.TRUSTED_SIGNING_PROD_PROFILE }}",
             "ExcludeCredentials": [
               "ManagedIdentityCredential",
               "WorkloadIdentityCredential",
@@ -4795,7 +4795,7 @@ jobs:
           '{
             "Endpoint": "https://eus.codesigning.azure.net",
             "CodeSigningAccountName": "${{ secrets.TRUSTED_SIGNING_ACCOUNT }}",
-            "CertificateProfileName": "${{ secrets.TRUSTED_SIGNING_TEST_PROFILE }}",
+            "CertificateProfileName": "${{ secrets.TRUSTED_SIGNING_PROD_PROFILE }}",
             "ExcludeCredentials": [
               "ManagedIdentityCredential",
               "WorkloadIdentityCredential",
@@ -5128,7 +5128,7 @@ jobs:
           '{
             "Endpoint": "https://eus.codesigning.azure.net",
             "CodeSigningAccountName": "${{ secrets.TRUSTED_SIGNING_ACCOUNT }}",
-            "CertificateProfileName": "${{ secrets.TRUSTED_SIGNING_TEST_PROFILE }}",
+            "CertificateProfileName": "${{ secrets.TRUSTED_SIGNING_PROD_PROFILE }}",
             "ExcludeCredentials": [
               "ManagedIdentityCredential",
               "WorkloadIdentityCredential",
@@ -5310,7 +5310,7 @@ jobs:
           '{
             "Endpoint": "https://eus.codesigning.azure.net",
             "CodeSigningAccountName": "${{ secrets.TRUSTED_SIGNING_ACCOUNT }}",
-            "CertificateProfileName": "${{ secrets.TRUSTED_SIGNING_TEST_PROFILE }}",
+            "CertificateProfileName": "${{ secrets.TRUSTED_SIGNING_PROD_PROFILE }}",
             "ExcludeCredentials": [
               "ManagedIdentityCredential",
               "WorkloadIdentityCredential",

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -264,23 +264,6 @@ on:
 
 env:
   PINNED_BOOTSTRAP_TOOLCHAIN_VERSION: 6.1.2
-  TRUSTED_SIGNING_METADATA_JSON: |
-    {
-      "Endpoint": "https://eus.codesigning.azure.net",
-      "CodeSigningAccountName": "${{ secrets.TRUSTED_SIGNING_ACCOUNT }}",
-      "CertificateProfileName": "${{ secrets.TRUSTED_SIGNING_TEST_PROFILE }}",
-      "ExcludeCredentials": [
-        "ManagedIdentityCredential",
-        "WorkloadIdentityCredential",
-        "SharedTokenCacheCredential",
-        "VisualStudioCredential",
-        "VisualStudioCodeCredential",
-        "EnvironmentCredential",
-        "AzurePowerShellCredential",
-        "AzureDeveloperCliCredential",
-        "InteractiveBrowserCredential"
-      ]
-    }
 
   # Workaround to build the early swift-driver without the workaround for the MSVC version.
   WORKAROUND_WINDOWS_EARLY_SWIFT_DRIVER_TOOLCHAIN_REPO: thebrowsercompany/swift-build
@@ -4191,7 +4174,22 @@ jobs:
           echo "TRUSTED_SIGNING_DLL_PATH=$trustedSigningDllPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
 
           $metadataPath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath "metadata.json"
-          ${env:TRUSTED_SIGNING_METADATA_JSON} | Out-File -FilePath $metadataPath -Encoding utf8
+          '{
+            "Endpoint": "https://eus.codesigning.azure.net",
+            "CodeSigningAccountName": "${{ secrets.TRUSTED_SIGNING_ACCOUNT }}",
+            "CertificateProfileName": "${{ secrets.TRUSTED_SIGNING_TEST_PROFILE }}",
+            "ExcludeCredentials": [
+              "ManagedIdentityCredential",
+              "WorkloadIdentityCredential",
+              "SharedTokenCacheCredential",
+              "VisualStudioCredential",
+              "VisualStudioCodeCredential",
+              "EnvironmentCredential",
+              "AzurePowerShellCredential",
+              "AzureDeveloperCliCredential",
+              "InteractiveBrowserCredential"
+            ]
+          }' | Out-File -FilePath $metadataPath -Encoding utf8
           echo "TRUSTED_SIGNING_METADATA_PATH=$metadataPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
 
       - name: Package Build Tools (Asserts)
@@ -4794,7 +4792,22 @@ jobs:
           echo "TRUSTED_SIGNING_DLL_PATH=$trustedSigningDllPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
 
           $metadataPath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath "metadata.json"
-          ${env:TRUSTED_SIGNING_METADATA_JSON} | Out-File -FilePath $metadataPath -Encoding utf8
+          '{
+            "Endpoint": "https://eus.codesigning.azure.net",
+            "CodeSigningAccountName": "${{ secrets.TRUSTED_SIGNING_ACCOUNT }}",
+            "CertificateProfileName": "${{ secrets.TRUSTED_SIGNING_TEST_PROFILE }}",
+            "ExcludeCredentials": [
+              "ManagedIdentityCredential",
+              "WorkloadIdentityCredential",
+              "SharedTokenCacheCredential",
+              "VisualStudioCredential",
+              "VisualStudioCodeCredential",
+              "EnvironmentCredential",
+              "AzurePowerShellCredential",
+              "AzureDeveloperCliCredential",
+              "InteractiveBrowserCredential"
+            ]
+          }' | Out-File -FilePath $metadataPath -Encoding utf8
           echo "TRUSTED_SIGNING_METADATA_PATH=$metadataPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
 
       - name: Package Platform
@@ -5112,7 +5125,22 @@ jobs:
           echo "TRUSTED_SIGNING_DLL_PATH=$trustedSigningDllPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
 
           $metadataPath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath "metadata.json"
-          ${env:TRUSTED_SIGNING_METADATA_JSON} | Out-File -FilePath $metadataPath -Encoding utf8
+          '{
+            "Endpoint": "https://eus.codesigning.azure.net",
+            "CodeSigningAccountName": "${{ secrets.TRUSTED_SIGNING_ACCOUNT }}",
+            "CertificateProfileName": "${{ secrets.TRUSTED_SIGNING_TEST_PROFILE }}",
+            "ExcludeCredentials": [
+              "ManagedIdentityCredential",
+              "WorkloadIdentityCredential",
+              "SharedTokenCacheCredential",
+              "VisualStudioCredential",
+              "VisualStudioCodeCredential",
+              "EnvironmentCredential",
+              "AzurePowerShellCredential",
+              "AzureDeveloperCliCredential",
+              "InteractiveBrowserCredential"
+            ]
+          }' | Out-File -FilePath $metadataPath -Encoding utf8
           echo "TRUSTED_SIGNING_METADATA_PATH=$metadataPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
 
       - if: inputs.build_android
@@ -5279,7 +5307,22 @@ jobs:
           echo "TRUSTED_SIGNING_DLL_PATH=$trustedSigningDllPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
 
           $metadataPath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath "metadata.json"
-          ${env:TRUSTED_SIGNING_METADATA_JSON} | Out-File -FilePath $metadataPath -Encoding utf8
+          '{
+            "Endpoint": "https://eus.codesigning.azure.net",
+            "CodeSigningAccountName": "${{ secrets.TRUSTED_SIGNING_ACCOUNT }}",
+            "CertificateProfileName": "${{ secrets.TRUSTED_SIGNING_TEST_PROFILE }}",
+            "ExcludeCredentials": [
+              "ManagedIdentityCredential",
+              "WorkloadIdentityCredential",
+              "SharedTokenCacheCredential",
+              "VisualStudioCredential",
+              "VisualStudioCodeCredential",
+              "EnvironmentCredential",
+              "AzurePowerShellCredential",
+              "AzureDeveloperCliCredential",
+              "InteractiveBrowserCredential"
+            ]
+          }' | Out-File -FilePath $metadataPath -Encoding utf8
           echo "TRUSTED_SIGNING_METADATA_PATH=$metadataPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
 
       # The installer bundle needs the shared project for localization strings,

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -253,9 +253,34 @@ on:
         required: true
       R2_SECRET_ACCESS_KEY:
         required: true
+      AZURE_SP_CREDENTIALS:
+        required: false
+      TRUSTED_SIGNING_ACCOUNT:
+        required: false
+      TRUSTED_SIGNING_TEST_PROFILE:
+        required: false
+      TRUSTED_SIGNING_PROD_PROFILE:
+        required: false
 
 env:
   PINNED_BOOTSTRAP_TOOLCHAIN_VERSION: 6.1.2
+  TRUSTED_SIGNING_METADATA_JSON: |
+    {
+      "Endpoint": "https://eus.codesigning.azure.net",
+      "CodeSigningAccountName": "${{ secrets.TRUSTED_SIGNING_ACCOUNT }}",
+      "CertificateProfileName": "${{ secrets.TRUSTED_SIGNING_TEST_PROFILE }}",
+      "ExcludeCredentials": [
+        "ManagedIdentityCredential",
+        "WorkloadIdentityCredential",
+        "SharedTokenCacheCredential",
+        "VisualStudioCredential",
+        "VisualStudioCodeCredential",
+        "EnvironmentCredential",
+        "AzurePowerShellCredential",
+        "AzureDeveloperCliCredential",
+        "InteractiveBrowserCredential"
+      ]
+    }
 
   # Workaround to build the early swift-driver without the workaround for the MSVC version.
   WORKAROUND_WINDOWS_EARLY_SWIFT_DRIVER_TOOLCHAIN_REPO: thebrowsercompany/swift-build
@@ -3896,11 +3921,38 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.arch }}-debugging_tools
           path: ${{ github.workspace }}/BuildRoot/Library
 
+  # Determines whether we're using trusted signing in this repository. If so and we're signing, downloads the trusted signing DLL to reduce boilerplate in steps that use it.
+  # Setting an output is necessary because the `env` and `secrets` contexts are not always available in `if` clauses.
+  configure_signing:
+    if: inputs.build_os == 'Windows'
+    name: Configure signing
+    runs-on: ${{ inputs.default_build_runner }}
+    outputs:
+      uses_trusted_signing: ${{ steps.test_trusted_signing.outputs.uses_trusted_signing }}
+
+    steps:
+      - name: Test whether we're using trusted signing
+        id: test_trusted_signing
+        run: |
+          "uses_trusted_signing=${{ secrets.TRUSTED_SIGNING_ACCOUNT != ''}}" | Out-File -FilePath ${env:GITHUB_OUTPUT} -Encoding utf8 -Append
+      - uses: nuget/setup-nuget@v2
+        if: inputs.signed && steps.test_trusted_signing.outputs.uses_trusted_signing == 'true'
+      - run: |
+          nuget install -x -OutputDirectory ${{ github.workspace }} Microsoft.Trusted.Signing.Client
+        if: inputs.signed && steps.test_trusted_signing.outputs.uses_trusted_signing == 'true'
+      - uses: actions/upload-artifact@v4
+        if: inputs.signed && steps.test_trusted_signing.outputs.uses_trusted_signing == 'true'
+        with:
+          name: trusted-signing-dll
+          # We're unconditionally using x64 because there's no arm64 version of the DLL as of Sep 2025.
+          # TODO: Update with more info once we've filed a bug against Microsoft.
+          path: ${{ github.workspace }}/Microsoft.Trusted.Signing.Client/bin/x64
+
   package_tools:
     # TODO: Build this on macOS or make an equivalent Mac-only job
     if: inputs.build_os == 'Windows'
     name: Package Tools
-    needs: [compilers, macros, debugging_tools, devtools, stdlib, sdk]
+    needs: [compilers, macros, debugging_tools, devtools, stdlib, sdk, configure_signing]
     runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
@@ -4013,7 +4065,7 @@ jobs:
           Set-Content -Path $CertificatePath -Value '${{ secrets.CERTIFICATE }}'
           certutil.exe -decode $CertificatePath $PFXPath
           Write-Output CERTIFICATE=$PFXPath | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
-        if: ${{ inputs.signed }}
+        if: inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'false'
 
       - name: Install WixToolset.Sdk
         run: |
@@ -4040,7 +4092,7 @@ jobs:
           Set-Content -Path $CertificatePath -Value '${{ secrets.CERTIFICATE }}'
           certutil -decode $CertificatePath $PFXPath
           Echo CERTIFICATE=$PFXPath | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
-        if: ${{ inputs.signed }}
+        if: inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'false'
 
       - name: Install WixToolset.Sdk
         run: |
@@ -4116,6 +4168,32 @@ jobs:
             & "${{ github.workspace }}\SourceCache\mimalloc\bin\minject$BuildSuffix" -l "$Exe"
           }
 
+      - uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_SP_CREDENTIALS }}
+        if: inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'true'
+
+      - uses: actions/download-artifact@v4
+        if: inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'true'
+        with:
+          name: trusted-signing-dll
+          path: ${{ runner.temp }}/trusted-signing-dll
+
+      - name: Prepare trusted signing arguments
+        if: inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'true'
+        run: |
+          # We're unconditionally using x64 because there's no arm64 version of signtool.exe as of Sep 2025.
+          # TODO: Update with more info once we've filed a bug against Microsoft.
+          $signtoolPath = Join-Path -Path ${env:WindowsSdkVerBinPath} -ChildPath "x64/"
+          echo "SIGNTOOL_PATH=$signtoolPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+
+          $trustedSigningDllPath = Join-Path -Path ${env:RUNNER_TEMP}/trusted-signing-dll -ChildPath "Azure.CodeSigning.Dlib.dll"
+          echo "TRUSTED_SIGNING_DLL_PATH=$trustedSigningDllPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+
+          $metadataPath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath "metadata.json"
+          ${env:TRUSTED_SIGNING_METADATA_JSON} | Out-File -FilePath $metadataPath -Encoding utf8
+          echo "TRUSTED_SIGNING_METADATA_PATH=$metadataPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+
       - name: Package Build Tools (Asserts)
         run: |
           msbuild -nologo -restore -maxCpuCount `
@@ -4124,6 +4202,9 @@ jobs:
               -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:SignToolPath=${env:SIGNTOOL_PATH} `
+              -p:AzureSignMetadata=${env:TRUSTED_SIGNING_METADATA_PATH} `
+              -p:AzureSignDlib=${env:TRUSTED_SIGNING_DLL_PATH} `
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:WORKAROUND_MIMALLOC_ISSUE_997=false `
               -p:ProductVersion=${{ inputs.swift_version }} `
@@ -4138,6 +4219,9 @@ jobs:
               -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:SignToolPath=${env:SIGNTOOL_PATH} `
+              -p:AzureSignMetadata=${env:TRUSTED_SIGNING_METADATA_PATH} `
+              -p:AzureSignDlib=${env:TRUSTED_SIGNING_DLL_PATH} `
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:WORKAROUND_MIMALLOC_ISSUE_997=false `
               -p:ProductVersion=${{ inputs.swift_version }} `
@@ -4152,6 +4236,9 @@ jobs:
               -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:SignToolPath=${env:SIGNTOOL_PATH} `
+              -p:AzureSignMetadata=${env:TRUSTED_SIGNING_METADATA_PATH} `
+              -p:AzureSignDlib=${env:TRUSTED_SIGNING_DLL_PATH} `
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
@@ -4165,6 +4252,9 @@ jobs:
               -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:SignToolPath=${env:SIGNTOOL_PATH} `
+              -p:AzureSignMetadata=${env:TRUSTED_SIGNING_METADATA_PATH} `
+              -p:AzureSignDlib=${env:TRUSTED_SIGNING_DLL_PATH} `
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
@@ -4178,6 +4268,9 @@ jobs:
               -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:SignToolPath=${env:SIGNTOOL_PATH} `
+              -p:AzureSignMetadata=${env:TRUSTED_SIGNING_METADATA_PATH} `
+              -p:AzureSignDlib=${env:TRUSTED_SIGNING_DLL_PATH} `
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
@@ -4191,6 +4284,9 @@ jobs:
               -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:SignToolPath=${env:SIGNTOOL_PATH} `
+              -p:AzureSignMetadata=${env:TRUSTED_SIGNING_METADATA_PATH} `
+              -p:AzureSignDlib=${env:TRUSTED_SIGNING_DLL_PATH} `
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
@@ -4204,6 +4300,9 @@ jobs:
               -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:SignToolPath=${env:SIGNTOOL_PATH} `
+              -p:AzureSignMetadata=${env:TRUSTED_SIGNING_METADATA_PATH} `
+              -p:AzureSignDlib=${env:TRUSTED_SIGNING_DLL_PATH} `
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
@@ -4217,6 +4316,9 @@ jobs:
               -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:SignToolPath=${env:SIGNTOOL_PATH} `
+              -p:AzureSignMetadata=${env:TRUSTED_SIGNING_METADATA_PATH} `
+              -p:AzureSignDlib=${env:TRUSTED_SIGNING_DLL_PATH} `
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
@@ -4230,6 +4332,9 @@ jobs:
               -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:SignToolPath=${env:SIGNTOOL_PATH} `
+              -p:AzureSignMetadata=${env:TRUSTED_SIGNING_METADATA_PATH} `
+              -p:AzureSignDlib=${env:TRUSTED_SIGNING_DLL_PATH} `
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
@@ -4247,6 +4352,9 @@ jobs:
               -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:SignToolPath=${env:SIGNTOOL_PATH} `
+              -p:AzureSignMetadata=${env:TRUSTED_SIGNING_METADATA_PATH} `
+              -p:AzureSignDlib=${env:TRUSTED_SIGNING_DLL_PATH} `
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
@@ -4355,7 +4463,7 @@ jobs:
     # TODO: Build this on macOS or make an equivalent Mac-only job
     if: inputs.build_os == 'Windows'
     name: Package Windows SDK & Runtime
-    needs: [stdlib, sdk, experimental-sdk]
+    needs: [stdlib, sdk, experimental-sdk, configure_signing]
     runs-on: ${{ inputs.default_build_runner }}
     outputs:
       expected-dlls-amd64: ${{ steps.write-expectations.outputs.expected-dlls-amd64 }}
@@ -4642,7 +4750,7 @@ jobs:
           Set-Content -Path $CertificatePath -Value '${{ secrets.CERTIFICATE }}'
           certutil.exe -decode $CertificatePath $PFXPath
           Write-Output CERTIFICATE=$PFXPath | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
-        if: ${{ inputs.signed }}
+        if: inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'false'
 
       - name: Install WixToolset.Sdk
         run: |
@@ -4663,6 +4771,32 @@ jobs:
           Move-Item ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/WindowsExperimental.sdk/usr/lib/swift_static/_foundation_unicode ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/WindowsExperimental.sdk/usr/include/
           Move-Item ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/WindowsExperimental.sdk/usr/lib/swift_static/_FoundationCShims ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/WindowsExperimental.sdk/usr/include/
 
+      - uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_SP_CREDENTIALS }}
+        if: inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'true'
+
+      - uses: actions/download-artifact@v4
+        if: inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'true'
+        with:
+          name: trusted-signing-dll
+          path: ${{ runner.temp }}/trusted-signing-dll
+
+      - name: Prepare trusted signing arguments
+        if: inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'true'
+        run: |
+          # We're unconditionally using x64 because there's no arm64 version of signtool.exe as of Sep 2025.
+          # TODO: Update with more info once we've filed a bug against Microsoft.
+          $signtoolPath = Join-Path -Path ${env:WindowsSdkVerBinPath} -ChildPath "x64/"
+          echo "SIGNTOOL_PATH=$signtoolPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+
+          $trustedSigningDllPath = Join-Path -Path ${env:RUNNER_TEMP}/trusted-signing-dll -ChildPath "Azure.CodeSigning.Dlib.dll"
+          echo "TRUSTED_SIGNING_DLL_PATH=$trustedSigningDllPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+
+          $metadataPath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath "metadata.json"
+          ${env:TRUSTED_SIGNING_METADATA_JSON} | Out-File -FilePath $metadataPath -Encoding utf8
+          echo "TRUSTED_SIGNING_METADATA_PATH=$metadataPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+
       - name: Package Platform
         run: |
           msbuild -nologo -restore -maxCpuCount `
@@ -4671,6 +4805,9 @@ jobs:
               -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:SignToolPath=${env:SIGNTOOL_PATH} `
+              -p:AzureSignMetadata=${env:TRUSTED_SIGNING_METADATA_PATH} `
+              -p:AzureSignDlib=${env:TRUSTED_SIGNING_DLL_PATH} `
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ inputs.build_arch }} `
@@ -4792,7 +4929,7 @@ jobs:
   package_android_platform:
     # TODO: Build this on macOS or make an equivalent Mac-only job
     name: Package Android SDK & Runtime
-    needs: [stdlib, ds2, sdk, experimental-sdk]
+    needs: [stdlib, ds2, sdk, experimental-sdk, configure_signing]
     runs-on: ${{ inputs.default_build_runner }}
 
     steps:
@@ -4922,7 +5059,7 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
           show-progress: false
 
-      - if: inputs.build_android && inputs.signed
+      - if: inputs.build_android && inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'false'
         run: |
           $CertificatePath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath CodeSign.b64
           $PFXPath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath CodeSign.pfx
@@ -4952,6 +5089,32 @@ jobs:
           Move-Item ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Android.platform/Developer/SDKs/AndroidExperimental.sdk/usr/lib/swift_static/_foundation_unicode ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Android.platform/Developer/SDKs/AndroidExperimental.sdk/usr/include
           Move-Item ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Android.platform/Developer/SDKs/AndroidExperimental.sdk/usr/lib/swift_static/_FoundationCShims ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Android.platform/Developer/SDKs/AndroidExperimental.sdk/usr/include
 
+      - uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_SP_CREDENTIALS }}
+        if: inputs.build_android && inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'true'
+
+      - uses: actions/download-artifact@v4
+        if: inputs.build_android && inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'true'
+        with:
+          name: trusted-signing-dll
+          path: ${{ runner.temp }}/trusted-signing-dll
+
+      - name: Prepare trusted signing arguments
+        if: inputs.build_android && inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'true'
+        run: |
+          # We're unconditionally using x64 because there's no arm64 version of signtool.exe as of Sep 2025.
+          # TODO: Update with more info once we've filed a bug against Microsoft.
+          $signtoolPath = Join-Path -Path ${env:WindowsSdkVerBinPath} -ChildPath "x64/"
+          echo "SIGNTOOL_PATH=$signtoolPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+
+          $trustedSigningDllPath = Join-Path -Path ${env:RUNNER_TEMP}/trusted-signing-dll -ChildPath "Azure.CodeSigning.Dlib.dll"
+          echo "TRUSTED_SIGNING_DLL_PATH=$trustedSigningDllPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+
+          $metadataPath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath "metadata.json"
+          ${env:TRUSTED_SIGNING_METADATA_JSON} | Out-File -FilePath $metadataPath -Encoding utf8
+          echo "TRUSTED_SIGNING_METADATA_PATH=$metadataPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+
       - if: inputs.build_android
         name: Package SDK
         run: |
@@ -4962,6 +5125,9 @@ jobs:
               -p:ANDROID_INCLUDE_DS2=true `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:SignToolPath=${env:SIGNTOOL_PATH} `
+              -p:AzureSignMetadata=${env:TRUSTED_SIGNING_METADATA_PATH} `
+              -p:AzureSignDlib=${env:TRUSTED_SIGNING_DLL_PATH} `
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ inputs.build_arch }} `
@@ -4994,7 +5160,7 @@ jobs:
   installer:
     # TODO: Build this on macOS or make an equivalent Mac-only job
     if: inputs.build_os == 'Windows'
-    needs: [package_tools, package_windows_platform, package_android_platform]
+    needs: [package_tools, package_windows_platform, package_android_platform, configure_signing]
     runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
@@ -5087,7 +5253,34 @@ jobs:
           Set-Content -Path $CertificatePath -Value '${{ secrets.CERTIFICATE }}'
           certutil -decode $CertificatePath $PFXPath
           Echo CERTIFICATE=$PFXPath | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
-        if: ${{ inputs.signed }}
+        if: inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'false'
+
+      - name: Authenticate with Azure
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_SP_CREDENTIALS }}
+        if: inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'true'
+
+      - uses: actions/download-artifact@v4
+        if: inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'true'
+        with:
+          name: trusted-signing-dll
+          path: ${{ runner.temp }}/trusted-signing-dll
+
+      - name: Prepare trusted signing arguments
+        if: inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'true'
+        run: |
+          # We're unconditionally using x64 because there's no arm64 version of signtool.exe as of Sep 2025.
+          # TODO: Update with more info once we've filed a bug against Microsoft.
+          $signtoolPath = Join-Path -Path ${env:WindowsSdkVerBinPath} -ChildPath "x64/"
+          echo "SIGNTOOL_PATH=$signtoolPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+
+          $trustedSigningDllPath = Join-Path -Path ${env:RUNNER_TEMP}/trusted-signing-dll -ChildPath "Azure.CodeSigning.Dlib.dll"
+          echo "TRUSTED_SIGNING_DLL_PATH=$trustedSigningDllPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+
+          $metadataPath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath "metadata.json"
+          ${env:TRUSTED_SIGNING_METADATA_JSON} | Out-File -FilePath $metadataPath -Encoding utf8
+          echo "TRUSTED_SIGNING_METADATA_PATH=$metadataPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
 
       # The installer bundle needs the shared project for localization strings,
       # but it won't build the dependency on its own due to -p:BuildProjectReferences=false.
@@ -5099,6 +5292,9 @@ jobs:
               -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:SignToolPath=${env:SIGNTOOL_PATH} `
+              -p:AzureSignMetadata=${env:TRUSTED_SIGNING_METADATA_PATH} `
+              -p:AzureSignDlib=${env:TRUSTED_SIGNING_DLL_PATH} `
               -p:ProductArchitecture=${{ matrix.arch }} `
               -p:ProductVersion=${{ inputs.swift_version }}-${{ inputs.swift_tag }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/shared/shared.wixproj
@@ -5117,6 +5313,9 @@ jobs:
               -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:SignToolPath=${env:SIGNTOOL_PATH} `
+              -p:AzureSignMetadata=${env:TRUSTED_SIGNING_METADATA_PATH} `
+              -p:AzureSignDlib=${env:TRUSTED_SIGNING_DLL_PATH} `
               -p:BundleFlavor=offline `
               -p:Platforms="`"$($Platforms -Join ';')`"" `
               -p:AndroidArchitectures="`"aarch64;armv7;i686;x86_64`"" `
@@ -5163,6 +5362,9 @@ jobs:
               -p:SignOutput=${{ inputs.signed }} `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:SignToolPath=${env:SIGNTOOL_PATH} `
+              -p:AzureSignMetadata=${env:TRUSTED_SIGNING_METADATA_PATH} `
+              -p:AzureSignDlib=${env:TRUSTED_SIGNING_DLL_PATH} `
               -p:BundleFlavor=online `
               -p:BaseReleaseDownloadUrl=$BaseReleaseDownloadUrl `
               -p:Platforms="`"$($Platforms -Join ';')`"" `


### PR DESCRIPTION
🚨 Do not merge: Depends on https://github.com/swiftlang/swift-installer-scripts/pull/463 🚨

This change uses [Azure Trusted Signing](https://learn.microsoft.com/en-us/azure/trusted-signing/) to sign all WiX-based outputs if:
1. `inputs.signed` is true
2. The `TRUSTED_SIGNING_ACCOUNT` secret is set for the repository.

The following secrets are required:
- `AZURE_SP_CREDENTIALS`: [JSON credentials](https://github.com/Azure/login?tab=readme-ov-file#login-with-a-service-principal-secret) for an Azure Service Principal with [Trusted Signing Certificate Profile Signer](https://learn.microsoft.com/en-us/azure/trusted-signing/concept-trusted-signing-resources-roles#supported-roles) roles on the given trusted signing account and certificate profiles
- `TRUSTED_SIGNING_ACCOUNT`, an [Azure Trusted Signing Account](https://learn.microsoft.com/en-us/azure/trusted-signing/quickstart?tabs=registerrp-portal%2Caccount-portal%2Ccertificateprofile-portal%2Cdeleteresources-portal#create-a-trusted-signing-account) which owns `TRUSTED_SIGNING_PROD_PROFILE` (and `TRUSTED_SIGNING_TEST_PROFILE` when used)
- `TRUSTED_SIGNING_PROD_PROFILE`, a non-test [certificate profile](https://learn.microsoft.com/en-us/azure/trusted-signing/concept-trusted-signing-resources-roles#certificate-profiles)

and optionally
- `TRUSTED_SIGNING_TEST_PROFILE`, which isn't actively used in the workflow, but is helpful to have in development.
