### PR TITLE
Add new smoke test for swift-issue-reporting

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -5575,6 +5575,13 @@ jobs:
           path: ${{ github.workspace }}/SourceCache/swift-win32
           show-progress: false
 
+      - uses: actions/checkout@v4.2.2
+        with:
+          repository: pointfreeco//swift-issue-reporting
+          ref: refs/heads/main
+          path: ${{ github.workspace }}/SourceCache/swift-issue-reporting
+          show-progress: false
+
       - name: Download Swift SDK Installer (${{ inputs.release && 'online' || 'offline' }})
         uses: actions/download-artifact@v4
         with:
@@ -5615,11 +5622,17 @@ jobs:
           echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
           Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
 
-      - run: swift build
+      - name: Smoke swift-win32
         working-directory: ${{ github.workspace }}/SourceCache/swift-win32
+        run: |
+          swift build
+          swift test -Xswiftc -DENABLE_TESTING
 
-      - run: swift test -Xswiftc -DENABLE_TESTING
-        working-directory: ${{ github.workspace }}/SourceCache/swift-win32
+      - name: Smoke swift-issue-reporting
+        working-directory: ${{ github.workspace }}/SourceCache/swift-issue-reporting
+        run: |
+          swift build -c release
+          swift test -c release
 
   # Ensures redistributables contain all expected DLLs.
   redistributable_smoke_test:

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -5577,7 +5577,7 @@ jobs:
 
       - uses: actions/checkout@v4.2.2
         with:
-          repository: pointfreeco//swift-issue-reporting
+          repository: pointfreeco/swift-issue-reporting
           ref: refs/heads/main
           path: ${{ github.workspace }}/SourceCache/swift-issue-reporting
           show-progress: false
@@ -5622,13 +5622,13 @@ jobs:
           echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
           Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
 
-      - name: Smoke swift-win32
+      - name: Build & Test compnerd/swift-win32
         working-directory: ${{ github.workspace }}/SourceCache/swift-win32
         run: |
           swift build
           swift test -Xswiftc -DENABLE_TESTING
 
-      - name: Smoke swift-issue-reporting
+      - name: Build & Test pointfreeco/swift-issue-reporting
         working-directory: ${{ github.workspace }}/SourceCache/swift-issue-reporting
         run: |
           swift build -c release


### PR DESCRIPTION
Add a new smoke test for https://github.com/pointfreeco/swift-issue-reporting. 

This caught the issue in https://github.com/swiftlang/swift-installer-scripts/pull/469

Passing downstream run: https://github.com/thebrowsercompany/swift-build/actions/runs/18328968588/job/52208026579