### PR TITLE
Include FallbackLibrarySearchPaths and Version in ToolchainInfo.plist

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1308,7 +1308,7 @@ jobs:
             now = datetime.now()
             info_plist = r'${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+${{ matrix.variant }}/ToolchainInfo.plist'
             with open(os.path.normpath(info_plist), 'wb') as plist:
-              plistlib.dump({ 'Identifier': 'org.compnerd.dt.toolchain.{0}.{1}-asserts'.format(now.strftime('%Y%m%d'), now.timetuple().tm_hour % 6) }, plist)
+              plistlib.dump({ 'Identifier': 'org.compnerd.dt.toolchain.{0}.{1}-asserts'.format(now.strftime('%Y%m%d'), now.timetuple().tm_hour % 6), 'FallbackLibrarySearchPaths': ['usr/bin'], 'Version': '${{ inputs.swift_version }}' }, plist)
 
       - name: Upload Compilers
         uses: thebrowsercompany/gha-upload-tar-artifact@e18c33b1cd416d0d96a91dc6dce06219f98e4e27 # main


### PR DESCRIPTION
Ports https://github.com/swiftlang/swift/pull/79426 to GHA.