### PR TITLE
Smoke tests: Use native build system

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -6351,7 +6351,7 @@ jobs:
         working-directory: ${{ github.workspace }}/SourceCache/vigil
         run: |
           $ExperimentalSDK = "$(Split-Path -Path ${env:SDKROOT} -Parent)/WindowsExperimental.sdk"
-          swift build --triple aarch64-unknown-windows-msvc -debug-info-format none -c release -Xswiftc -sdk -Xswiftc ${ExperimentalSDK} -Xswiftc -static-stdlib -Xlinker /WX
+          swift build --build-system native --triple aarch64-unknown-windows-msvc -debug-info-format none -c release -Xswiftc -sdk -Xswiftc ${ExperimentalSDK} -Xswiftc -static-stdlib -Xlinker /WX
 
       - name: Build & Test pointfreeco/swift-issue-reporting
         working-directory: ${{ github.workspace }}/SourceCache/swift-issue-reporting
@@ -6498,6 +6498,7 @@ jobs:
       - name: Build cassowary project
         run: |
           swift build `
+            --build-system native `
             --package-path ${{ github.workspace }}/SourceCache/cassowary `
             --triple ${{ matrix.arch }}-unknown-linux-android${{ inputs.ANDROID_API_LEVEL }} `
             --sdk "${{ steps.android-swift-env.outputs.sysroot }}" `


### PR DESCRIPTION
`swift build` now uses the xcode build system internally by default. The swift-build build system currently lacks support for custom SDKs, breaking our tests. Use `--build-system native` to work around this until the underlying issue is fixed.