### PR TITLE
Smoke tests: Use the native build system for tests

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -6356,8 +6356,8 @@ jobs:
       - name: Build & Test pointfreeco/swift-issue-reporting
         working-directory: ${{ github.workspace }}/SourceCache/swift-issue-reporting
         run: |
-          swift build -c release
-          swift test -c release
+          swift build --build-system native -c release
+          swift test --build-system native -c release
 
   # Ensures redistributables contain all expected DLLs.
   redistributable_smoke_test:


### PR DESCRIPTION
The swift-build build system builds test binaries as `.exe` files, rather than as `.xctest` files. This breaks some test expectations in `swift-issue-reporting`. Build and run the tests with the native build system to work around the issue.

See swiftlang/swift-package-manager#9940 for details.