### PR TITLE
Update Android NDK to r28c to fix build failure

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -441,8 +441,8 @@ jobs:
           echo mac_build_runner=macos-latest >> ${GITHUB_OUTPUT}
 
           echo "ANDROID_API_LEVEL=${INPUT_ANDROID_API_LEVEL}" >> ${GITHUB_OUTPUT}
-          echo ANDROID_NDK_VERSION=r27c >> ${GITHUB_OUTPUT}
-          echo ANDROID_CLANG_VERSION=18 >> ${GITHUB_OUTPUT}
+          echo ANDROID_NDK_VERSION=r28c >> ${GITHUB_OUTPUT}
+          echo ANDROID_CLANG_VERSION=19 >> ${GITHUB_OUTPUT}
 
           # Set Python version used in the build
           echo python_version=3.10.1 >> ${GITHUB_OUTPUT}


### PR DESCRIPTION
Downstream test run https://github.com/thebrowsercompany/swift-build/actions/runs/24708239854/job/72363699464

Fix the build failure caused by https://github.com/swiftlang/swift-testing/pull/1546