### PR TITLE
Add job to build res.msi

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -5977,10 +5977,118 @@ jobs:
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/python.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/python.cab
 
+  package_resources:
+    if: inputs.build_os == 'Windows'
+    name: Package Resources
+    needs: [configure_signing]
+    runs-on: ${{ inputs.default_build_runner }}
+
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          ref: ${{ inputs.ci_build_revision }}
+          path: ${{ github.workspace }}/SourceCache/ci-build
+          show-progress: false
+
+      - uses: ./SourceCache/ci-build/.github/actions/setup-build
+        with:
+          setup-vs-dev-env: true
+
+      - uses: actions/checkout@v4.2.2
+        with:
+          repository: swiftlang/swift-installer-scripts
+          ref: ${{ inputs.swift_installer_scripts_revision }}
+          path: ${{ github.workspace }}/SourceCache/swift-installer-scripts
+          show-progress: false
+
+      - run: |
+          $CertificatePath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath CodeSign.b64
+          $PFXPath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath CodeSign.pfx
+          Set-Content -Path $CertificatePath -Value '${{ secrets.CERTIFICATE }}'
+          certutil.exe -decode $CertificatePath $PFXPath
+          Write-Output CERTIFICATE=$PFXPath | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+        if: inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'false'
+
+      - name: Install WixToolset.Sdk
+        run: |
+          if ((Get-Package -Name WixToolset.Sdk -ErrorAction SilentlyContinue) -eq $null) {
+            Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
+          }
+
+      - uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_SP_CREDENTIALS }}
+        if: inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'true'
+
+      - uses: actions/download-artifact@v4
+        if: inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'true'
+        with:
+          name: trusted-signing-dll
+          path: ${{ runner.temp }}/trusted-signing-dll
+
+      - name: Prepare trusted signing arguments
+        if: inputs.signed && needs.configure_signing.outputs.uses_trusted_signing == 'true'
+        run: |
+          # We're unconditionally using x64 because there's no arm64 version of the DLL as of Oct 2025.
+          # TODO: Update with more info once we've filed a bug against Microsoft.
+          $signtoolPath = Join-Path -Path ${env:WindowsSdkVerBinPath} -ChildPath "x64/"
+          echo "SIGNTOOL_PATH=$signtoolPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+
+          $trustedSigningDllPath = Join-Path -Path ${env:RUNNER_TEMP}/trusted-signing-dll -ChildPath "Azure.CodeSigning.Dlib.dll"
+          echo "TRUSTED_SIGNING_DLL_PATH=$trustedSigningDllPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+
+          $metadataPath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath "metadata.json"
+          '{
+            "Endpoint": "https://eus.codesigning.azure.net",
+            "CodeSigningAccountName": "${{ secrets.TRUSTED_SIGNING_ACCOUNT }}",
+            "CertificateProfileName": "${{ secrets.TRUSTED_SIGNING_PROD_PROFILE }}",
+            "ExcludeCredentials": [
+              "ManagedIdentityCredential",
+              "WorkloadIdentityCredential",
+              "SharedTokenCacheCredential",
+              "VisualStudioCredential",
+              "VisualStudioCodeCredential",
+              "EnvironmentCredential",
+              "AzurePowerShellCredential",
+              "AzureDeveloperCliCredential",
+              "InteractiveBrowserCredential"
+            ]
+          }' | Out-File -FilePath $metadataPath -Encoding utf8
+          echo "TRUSTED_SIGNING_METADATA_PATH=$metadataPath" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+
+      - name: Package Resources
+        run: |
+          msbuild -nologo -restore -maxCpuCount `
+              -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
+              -p:Configuration=Release `
+              -p:SignOutput=${{ inputs.signed }} `
+              -p:CERTIFICATE=${env:CERTIFICATE} `
+              -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
+              -p:SignToolPath=${env:SIGNTOOL_PATH} `
+              -p:AzureSignMetadata=${env:TRUSTED_SIGNING_METADATA_PATH} `
+              -p:AzureSignDlib=${env:TRUSTED_SIGNING_DLL_PATH} `
+              -p:ProductVersion=${{ inputs.swift_version }} `
+              -p:ProductArchitecture=${{ inputs.build_arch }} `
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/res/res.wixproj
+
+      - if: ${{ inputs.release }}
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ inputs.build_arch }}/res.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ inputs.build_arch }}/res.cab
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Windows-res-msi
+          path: |
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ inputs.build_arch }}/res.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ inputs.build_arch }}/res.cab
+
   installer:
     # TODO: Build this on macOS or make an equivalent Mac-only job
     if: inputs.build_os == 'Windows'
-    needs: [package_tools, package_windows_platform, package_android_platform, package_python, configure_signing]
+    needs: [package_tools, package_windows_platform, package_android_platform, package_python, package_resources, configure_signing]
     runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
@@ -6046,6 +6154,11 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: Windows-${{ matrix.arch }}-python-msi
+          path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: Windows-res-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
 
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
Needed since https://github.com/swiftlang/swift-installer-scripts/commit/8630bc567e02cfa31052cf26f6b229953dff198a

Since this is just resources, build it once and use for all architectures.

Downstream run: https://github.com/thebrowsercompany/swift-build/actions/runs/25065096363/job/73438348116