### PR TITLE
Switch action-publish-symbols to thebrowsercompany fork

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1465,7 +1465,7 @@ jobs:
           path: ${{ github.workspace }}/BinaryCache/swift-syntax
 
       - name: Upload PDBs to Azure
-        uses: microsoft/action-publish-symbols@v2.1.6
+        uses: thebrowsercompany/action-publish-symbols@d5f4b06266463bf9a71ef6a4e3b0b8d79eaa82a4
         if: ${{ inputs.debug_info && matrix.os  == 'Windows' }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
@@ -1488,7 +1488,7 @@ jobs:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
 
       - name: Upload DLLs to Azure
-        uses: microsoft/action-publish-symbols@v2.1.6
+        uses: thebrowsercompany/action-publish-symbols@d5f4b06266463bf9a71ef6a4e3b0b8d79eaa82a4
         if: ${{ inputs.debug_info && matrix.os  == 'Windows' }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
@@ -1497,7 +1497,7 @@ jobs:
           searchPattern: '**/*.dll'
 
       - name: Upload EXEs to Azure
-        uses: microsoft/action-publish-symbols@v2.1.6
+        uses: thebrowsercompany/action-publish-symbols@d5f4b06266463bf9a71ef6a4e3b0b8d79eaa82a4
         if: ${{ inputs.debug_info && matrix.os  == 'Windows' }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
@@ -2264,7 +2264,7 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library
 
       - name: Upload PDBs to Azure
-        uses: microsoft/action-publish-symbols@v2.1.6
+        uses: thebrowsercompany/action-publish-symbols@d5f4b06266463bf9a71ef6a4e3b0b8d79eaa82a4
         if: ${{ inputs.debug_info && matrix.os == 'Windows' }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
@@ -2287,7 +2287,7 @@ jobs:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
 
       - name: Upload DLLs to Azure
-        uses: microsoft/action-publish-symbols@v2.1.6
+        uses: thebrowsercompany/action-publish-symbols@d5f4b06266463bf9a71ef6a4e3b0b8d79eaa82a4
         if: ${{ inputs.debug_info && matrix.os == 'Windows' }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
@@ -2441,7 +2441,7 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library
 
       - name: Upload PDBs to Azure
-        uses: microsoft/action-publish-symbols@v2.1.6
+        uses: thebrowsercompany/action-publish-symbols@d5f4b06266463bf9a71ef6a4e3b0b8d79eaa82a4
         if: ${{ inputs.debug_info }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
@@ -2464,7 +2464,7 @@ jobs:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
 
       - name: Upload DLLs to Azure
-        uses: microsoft/action-publish-symbols@v2.1.6
+        uses: thebrowsercompany/action-publish-symbols@d5f4b06266463bf9a71ef6a4e3b0b8d79eaa82a4
         if: ${{ inputs.debug_info }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
@@ -3292,7 +3292,7 @@ jobs:
 
       - name: Upload PDBs to Azure
         if: matrix.os == 'Windows' && inputs.debug_info
-        uses: microsoft/action-publish-symbols@v2.1.6
+        uses: thebrowsercompany/action-publish-symbols@d5f4b06266463bf9a71ef6a4e3b0b8d79eaa82a4
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -3315,7 +3315,7 @@ jobs:
 
       - name: Upload DLLs to Azure
         if: matrix.os == 'Windows' && inputs.debug_info
-        uses: microsoft/action-publish-symbols@v2.1.6
+        uses: thebrowsercompany/action-publish-symbols@d5f4b06266463bf9a71ef6a4e3b0b8d79eaa82a4
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
@@ -3781,7 +3781,7 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform
 
       - name: Upload PDBs to Azure
-        uses: microsoft/action-publish-symbols@v2.1.6
+        uses: thebrowsercompany/action-publish-symbols@d5f4b06266463bf9a71ef6a4e3b0b8d79eaa82a4
         if: ${{ inputs.debug_info && matrix.os == 'Windows' }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
@@ -3804,7 +3804,7 @@ jobs:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
 
       - name: Upload DLLs to Azure
-        uses: microsoft/action-publish-symbols@v2.1.6
+        uses: thebrowsercompany/action-publish-symbols@d5f4b06266463bf9a71ef6a4e3b0b8d79eaa82a4
         if: ${{ inputs.debug_info && matrix.os == 'Windows' }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
@@ -4730,7 +4730,7 @@ jobs:
           path: ${{ github.workspace }}/BinaryCache/swift-argument-parser
 
       - name: Upload PDBs to Azure
-        uses: microsoft/action-publish-symbols@v2.1.6
+        uses: thebrowsercompany/action-publish-symbols@d5f4b06266463bf9a71ef6a4e3b0b8d79eaa82a4
         if: ${{ inputs.debug_info }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
@@ -4753,7 +4753,7 @@ jobs:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
 
       - name: Upload DLLs to Azure
-        uses: microsoft/action-publish-symbols@v2.1.6
+        uses: thebrowsercompany/action-publish-symbols@d5f4b06266463bf9a71ef6a4e3b0b8d79eaa82a4
         if: ${{ inputs.debug_info }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
@@ -4762,7 +4762,7 @@ jobs:
           searchPattern: '**/*.dll'
 
       - name: Upload EXEs to Azure
-        uses: microsoft/action-publish-symbols@v2.1.6
+        uses: thebrowsercompany/action-publish-symbols@d5f4b06266463bf9a71ef6a4e3b0b8d79eaa82a4
         if: ${{ inputs.debug_info }}
         with:
           accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}


### PR DESCRIPTION
The upstream repo appears to be abandoned and not responsive to PRs or bugs. We need to [upgrade the Node version](https://github.com/microsoft/action-publish-symbols/pull/36) and to [add retry logic to symbol uploads](https://github.com/microsoft/action-publish-symbols/issues/33).

Just making the switch now to make sure it works OK with the changes planned as a follow-up.