### PR TITLE
Scaffold workflow for testing Azure symbol upload

### DIFF
--- a/.github/actions/publish-symbols-azure/action.yml
+++ b/.github/actions/publish-symbols-azure/action.yml
@@ -1,0 +1,39 @@
+name: 'Publish Symbols to Azure'
+description: 'PowerShell-based replacement for microsoft/action-publish-symbols. STUB — does not upload yet.'
+
+inputs:
+  accountName:
+    required: true
+    description: 'Azure DevOps account name'
+  personalAccessToken:
+    required: true
+    description: 'Azure DevOps PAT with build scope permission'
+  symbolsFolder:
+    required: false
+    description: 'Folder containing symbol files (defaults to GITHUB_WORKSPACE)'
+  searchPattern:
+    required: false
+    description: 'Glob pattern for symbol files'
+    default: '**/bin/**/*.pdb'
+  symbolServiceUrl:
+    required: false
+    description: 'Symbol server URL'
+    default: 'https://artifacts.dev.azure.com'
+
+runs:
+  using: composite
+  steps:
+    - name: Stub
+      shell: pwsh
+      env:
+        ACCOUNT_NAME: ${{ inputs.accountName }}
+        SYMBOLS_FOLDER: ${{ inputs.symbolsFolder }}
+        SEARCH_PATTERN: ${{ inputs.searchPattern }}
+        SYMBOL_SERVICE_URL: ${{ inputs.symbolServiceUrl }}
+      run: |
+        Write-Output "publish-symbols-azure stub invoked"
+        Write-Output "accountName       = $env:ACCOUNT_NAME"
+        Write-Output "symbolsFolder     = $env:SYMBOLS_FOLDER"
+        Write-Output "searchPattern     = $env:SEARCH_PATTERN"
+        Write-Output "symbolServiceUrl  = $env:SYMBOL_SERVICE_URL"
+        Write-Output "(stub: no upload performed)"

--- a/.github/workflows/test-publish-symbols.yml
+++ b/.github/workflows/test-publish-symbols.yml
@@ -1,0 +1,19 @@
+name: Test Publish Symbols
+
+# Manual-only. Will not fire on push, PR, or schedule.
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Invoke publish-symbols-azure
+        uses: ./.github/actions/publish-symbols-azure
+        with:
+          accountName: ${{ vars.SYMBOL_SERVER_ACCOUNT }}
+          personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
+          symbolsFolder: ${{ github.workspace }}
+          searchPattern: '**/*.pdb'


### PR DESCRIPTION
I want to iterate on a new action to replace `action-publish-symbols` but would prefer to iterate on it without doing a full build.

Prototyping in here vs a separate repo to avoid needing to set up secrets. Once this is solid, we can move it out.

Landing the scaffolding workflow because you can't run workflows that don't exist on `main`.