### PR TITLE
Bootstrapping: Update configure-cmake-project

### DIFF
--- a/.github/actions/configure-cmake-project/action.ps1
+++ b/.github/actions/configure-cmake-project/action.ps1
@@ -597,7 +597,7 @@ switch ($OS) {
     }
 }
 
-# Note: On GHA, sccache is no longer supported.
+# Note: In build.ps1, sccache is no longer supported.
 if ($EnableCaching -and $OS -ne "Android") {
     if ($UseC) {
         Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_LAUNCHER "sccache"

--- a/.github/actions/configure-cmake-project/action.ps1
+++ b/.github/actions/configure-cmake-project/action.ps1
@@ -1,0 +1,698 @@
+# Configure a CMake project, mimicking `Build-CMakeProject` from the Swift
+# repository's `utils\build.ps1`. See `action.yml` for the documented list of
+# differences between this action and `build.ps1`.
+#
+# This script is invoked by `action.yml`. All inputs are passed via `INPUT_*`
+# environment variables (see `action.yml`), so that no GitHub Actions
+# `${{ }}` template syntax leaks into this file - GHA does not template `.ps1`
+# files, only the inline `run:` block in YAML.
+
+Remove-Item env:\SDKROOT -ErrorAction SilentlyContinue
+$ExeSuffix = if ($IsWindows) { ".exe" } else { "" }
+
+function ConvertTo-Bool([string]$Value) {
+    if ([string]::IsNullOrWhiteSpace($Value)) { return $false }
+    return [System.Convert]::ToBoolean($Value)
+}
+
+$ProjectName = $env:INPUT_PROJECT_NAME
+$SwiftVersion = $env:INPUT_SWIFT_VERSION
+$EnableCaching = ConvertTo-Bool $env:INPUT_ENABLE_CACHING
+$EnableCAS = ConvertTo-Bool $env:INPUT_ENABLE_CAS
+$DebugInfo = ConvertTo-Bool $env:INPUT_DEBUG_INFO
+$BuildOS = $env:INPUT_BUILD_OS
+$BuildArch = $env:INPUT_BUILD_ARCH
+$OS = $env:INPUT_OS
+$Arch = $env:INPUT_ARCH
+$SrcDir = $env:INPUT_SRC_DIR
+$BinDir = $env:INPUT_BIN_DIR
+$InstallDir = $env:INPUT_INSTALL_DIR
+$AndroidAPILevel = $env:INPUT_ANDROID_API_LEVEL
+$AndroidClangVersion = $env:INPUT_ANDROID_CLANG_VERSION
+$NDKPath = $env:INPUT_NDK_PATH
+$SwiftSDK = $env:INPUT_SWIFT_SDK_PATH
+$CacheScript = $env:INPUT_CACHE_SCRIPT
+$UseHostToolchain = ConvertTo-Bool $env:INPUT_USE_HOST_TOOLCHAIN
+$UseASM_MASM = ConvertTo-Bool $env:INPUT_USE_ASM_MASM
+
+# `cmake-defines` is a PowerShell hashtable literal (`@{ ... }`) authored at the
+# call site. Evaluate it to recover the hashtable; defaults to an empty one.
+$CMakeDefines = if ([string]::IsNullOrWhiteSpace($env:INPUT_CMAKE_DEFINES)) {
+    @{}
+} else {
+    Invoke-Expression $env:INPUT_CMAKE_DEFINES
+}
+
+function Add-KeyValueIfNew([hashtable]$Hashtable, [string]$Key, [string]$Value) {
+    if (-not $Hashtable.Contains($Key)) {
+        $Hashtable.Add($Key, $Value)
+    }
+}
+
+function Add-FlagsDefine([hashtable]$Defines, [string]$Name, [string[]]$Value) {
+    if ($Defines.Contains($Name)) {
+        $Defines[$name] = @($Defines[$name]) + $Value
+    } else {
+        $Defines.Add($Name, $Value)
+    }
+}
+
+enum DriverStyle {
+    CL
+    ClangCL
+    GNU
+    Swift
+}
+
+$Assemblers = @{
+    Pinned = @{
+        Executable       = "clang-cl.exe"
+        DriverStyle      = [DriverStyle]::ClangCL
+        Flags            = @()
+        DebugFlags       = { param([string] $Format)
+            if ($Format -eq "dwarf") { @("-clang:-gdwarf") } else { @("-clang:-gcodeview") }
+        }
+        AssumeFunctional = $false
+    }
+    Stage1 = @{
+        Executable       = [IO.Path]::Combine("${env:GITHUB_WORKSPACE}/BinaryCache/stage1/Library/Developer/Toolchains/${SwiftVersion}+Asserts/usr/bin/", "clang-cl${ExeSuffix}")
+        DriverStyle      = [DriverStyle]::ClangCL
+        Flags            = @()
+        DebugFlags       = { param([string] $Format)
+            if ($Format -eq "dwarf") { @("-clang:-gdwarf") } else { @("-clang:-gcodeview") }
+        }
+        AssumeFunctional = $true
+    }
+}
+
+$Compilers = @{
+    MSVC   = @{
+        C   = @{
+            Executable       = (Get-Command "cl.exe").Source
+            DriverStyle      = [DriverStyle]::CL
+            Flags            = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:preprocessor")
+            DebugFlags       = { param([string] $Format)
+                @()
+            }
+            AssumeFunctional = $false
+        }
+        CXX = @{
+            Executable       = (Get-Command "cl.exe").Source
+            DriverStyle      = [DriverStyle]::CL
+            Flags            = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:preprocessor", "/Zc:__cplusplus")
+            DebugFlags       = { param([string] $Format)
+                @()
+            }
+            AssumeFunctional = $false
+        }
+    }
+
+    Pinned = @{
+        C     = @{
+            Executable       = (Get-Command "clang-cl.exe").Source
+            DriverStyle      = [DriverStyle]::ClangCL
+            Flags            = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline")
+            DebugFlags       = { param([string] $Format)
+                if ($Format -eq "dwarf") { @("-clang:-gsplit-dwarf") } else { @() }
+            }
+            AssumeFunctional = $false
+        }
+        CXX   = @{
+            Executable       = (Get-Command "clang-cl.exe").Source
+            DriverStyle      = [DriverStyle]::ClangCL
+            Flags            = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:__cplusplus")
+            DebugFlags       = { param([string] $Format)
+                if ($Format -eq "dwarf") { @("-clang:-gsplit-dwarf") } else { @() }
+            }
+            AssumeFunctional = $false
+        }
+        Swift = @{
+            Executable       = (Get-Command "swiftc.exe").Source
+            DriverStyle      = [DriverStyle]::Swift
+            Flags            = @()
+            DebugFlags       = { param([string] $Format)
+                @("-g", "-debug-info-format=${Format}")
+            }
+            AssumeFunctional = $false
+        }
+    }
+
+    Stage0 = @{
+        C      = @{
+            Executable       = [IO.Path]::Combine("${env:GITHUB_WORKSPACE}/BinaryCache/stage0/Library/Developer/Toolchains/${SwiftVersion}+Asserts/usr/bin/", "clang-cl${ExeSuffix}")
+            DriverStyle      = [DriverStyle]::ClangCL
+            Flags            = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline")
+            DebugFlags       = { param([string] $Format)
+                if ($Format -eq "dwarf") { @("-clang:-gsplit-dwarf") } else { @() }
+            }
+            AssumeFunctional = $true
+        }
+        CXX    = @{
+            Executable       = [IO.Path]::Combine("${env:GITHUB_WORKSPACE}/BinaryCache/stage0/Library/Developer/Toolchains/${SwiftVersion}+Asserts/usr/bin/", "clang-cl${ExeSuffix}")
+            DriverStyle      = [DriverStyle]::ClangCL
+            Flags            = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:__cplusplus")
+            DebugFlags       = { param([string] $Format)
+                if ($Format -eq "dwarf") { @("-clang:-gsplit-dwarf") } else { @() }
+            }
+            AssumeFunctional = $true
+        }
+        GNUC   = @{
+            Executable       = [IO.Path]::Combine("${env:GITHUB_WORKSPACE}/BinaryCache/stage0/Library/Developer/Toolchains/${SwiftVersion}+Asserts/usr/bin/", "clang${ExeSuffix}")
+            DriverStyle      = [DriverStyle]::GNU
+            Flags            = @("-fno-stack-protector", "-ffunction-sections", "-fdata-sections", "-fomit-frame-pointer", "-finline-functions")
+            DebugFlags       = { param([string] $Format)
+                if ($Format -eq "dwarf") { @("-gsplit-dwarf") } else { @("-gcodeview") }
+            }
+            AssumeFunctional = $true
+        }
+        GNUCXX = @{
+            Executable       = [IO.Path]::Combine("${env:GITHUB_WORKSPACE}/BinaryCache/stage0/Library/Developer/Toolchains/${SwiftVersion}+Asserts/usr/bin/", "clang++${ExeSuffix}")
+            DriverStyle      = [DriverStyle]::GNU
+            Flags            = @("-fno-stack-protector", "-ffunction-sections", "-fdata-sections", "-fomit-frame-pointer", "-finline-functions")
+            DebugFlags       = { param([string] $Format)
+                if ($Format -eq "dwarf") { @("-gsplit-dwarf") } else { @("-gcodeview") }
+            }
+            AssumeFunctional = $true
+        }
+        Swift  = @{
+            Executable       = [IO.Path]::Combine("${env:GITHUB_WORKSPACE}/BinaryCache/stage0/Library/Developer/Toolchains/${SwiftVersion}+Asserts/usr/bin/", "swiftc${ExeSuffix}")
+            DriverStyle      = [DriverStyle]::Swift
+            Flags            = @()
+            DebugFlags       = { param([string] $Format)
+                @("-g", "-debug-info-format=${Format}")
+            }
+            AssumeFunctional = $true
+        }
+    }
+
+    Stage1 = @{
+        C      = @{
+            Executable       = [IO.Path]::Combine("${env:GITHUB_WORKSPACE}/BinaryCache/stage1/Library/Developer/Toolchains/${SwiftVersion}+Asserts/usr/bin/", "clang-cl${ExeSuffix}")
+            DriverStyle      = [DriverStyle]::ClangCL
+            Flags            = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline")
+            DebugFlags       = { param([string] $Format)
+                if ($Format -eq "dwarf") { @("-clang:-gsplit-dwarf") } else { @() }
+            }
+            AssumeFunctional = $true
+        }
+        CXX    = @{
+            Executable       = [IO.Path]::Combine("${env:GITHUB_WORKSPACE}/BinaryCache/stage1/Library/Developer/Toolchains/${SwiftVersion}+Asserts/usr/bin/", "clang-cl${ExeSuffix}")
+            DriverStyle      = [DriverStyle]::ClangCL
+            Flags            = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:__cplusplus")
+            DebugFlags       = { param([string] $Format)
+                if ($Format -eq "dwarf") { @("-clang:-gsplit-dwarf") } else { @() }
+            }
+            AssumeFunctional = $true
+        }
+        GNUC   = @{
+            Executable       = [IO.Path]::Combine("${env:GITHUB_WORKSPACE}/BinaryCache/stage1/Library/Developer/Toolchains/${SwiftVersion}+Asserts/usr/bin/", "clang${ExeSuffix}")
+            DriverStyle      = [DriverStyle]::GNU
+            Flags            = @("-fno-stack-protector", "-ffunction-sections", "-fdata-sections", "-fomit-frame-pointer", "-finline-functions")
+            DebugFlags       = { param([string] $Format)
+                if ($Format -eq "dwarf") { @("-gsplit-dwarf") } else { @("-gcodeview") }
+            }
+            AssumeFunctional = $true
+        }
+        GNUCXX = @{
+            Executable       = [IO.Path]::Combine("${env:GITHUB_WORKSPACE}/BinaryCache/stage1/Library/Developer/Toolchains/${SwiftVersion}+Asserts/usr/bin/", "clang++${ExeSuffix}")
+            DriverStyle      = [DriverStyle]::GNU
+            Flags            = @("-fno-stack-protector", "-ffunction-sections", "-fdata-sections", "-fomit-frame-pointer", "-finline-functions")
+            DebugFlags       = { param([string] $Format)
+                if ($Format -eq "dwarf") { @("-gsplit-dwarf") } else { @("-gcodeview") }
+            }
+            AssumeFunctional = $true
+        }
+        Swift  = @{
+            Executable       = [IO.Path]::Combine("${env:GITHUB_WORKSPACE}/BinaryCache/stage1/Library/Developer/Toolchains/${SwiftVersion}+Asserts/usr/bin/", "swiftc${ExeSuffix}")
+            DriverStyle      = [DriverStyle]::Swift
+            Flags            = @()
+            DebugFlags       = { param([string] $Format)
+                @("-g", "-debug-info-format=${Format}")
+            }
+            AssumeFunctional = $true
+        }
+    }
+}
+
+# Mirror `build.ps1`'s `$Compilers.Host` trick: a computed pseudo-set that
+# redirects to the host MSVC toolchain or the pinned toolchain depending on
+# `$UseHostToolchain`. This keeps the host-vs-pinned decision in one place so
+# call sites can simply select `Host.C` / `Host.CXX`. Note there is no
+# `Host.Swift`: Swift always comes from a real stage.
+$Compilers.Host = @{
+    C   = if ($UseHostToolchain) { $Compilers.MSVC.C } else { $Compilers.Pinned.C }
+    CXX = if ($UseHostToolchain) { $Compilers.MSVC.CXX } else { $Compilers.Pinned.CXX }
+}
+
+# Resolve a dotted selector (e.g. "Pinned.C", "Stage1.GNUCXX", "Host.CXX")
+# against a tool table. An empty selector means "tool not used" and resolves to
+# $null.
+function Resolve-Tool([hashtable]$Root, [string]$Selector) {
+    if ([string]::IsNullOrWhiteSpace($Selector)) { return $null }
+    $Node = $Root
+    foreach ($Part in $Selector.Split('.')) {
+        if (($null -eq $Node) -or (-not $Node.Contains($Part))) {
+            throw "Invalid tool selector '$Selector': no member '$Part'."
+        }
+        $Node = $Node[$Part]
+    }
+    return $Node
+}
+
+$Assembler = Resolve-Tool $Assemblers $env:INPUT_ASSEMBLER
+$CCompiler = Resolve-Tool $Compilers $env:INPUT_C_COMPILER
+$CXXCompiler = Resolve-Tool $Compilers $env:INPUT_CXX_COMPILER
+$SwiftCompiler = Resolve-Tool $Compilers $env:INPUT_SWIFT_COMPILER
+
+# Note: On GHA, we do not use the `$Platform` variable as in `build.ps1` so these values
+# have to be computed directly here.
+$CMakeArch = switch ($OS) {
+    'Windows' {
+        switch ($Arch) {
+            'arm64' { 'ARM64' }
+            'amd64' { 'AMD64' }
+            'x86' { 'i686' }
+            default { throw "Unsupported Windows architecture: $Arch" }
+        }
+    }
+    'Android' {
+        switch ($Arch) {
+            'arm64' { 'aarch64' }
+            'x86_64' { 'x86_64' }
+            'i686' { 'i686' }
+            'armv7' { 'armv7-a' }
+            default { throw "Unsupported Android architecture: $Arch" }
+        }
+    }
+    "Darwin" { $Arch }
+    default { throw "Unsupported OS: $OS" }
+}
+
+$Triple = switch ($OS) {
+    'Windows' {
+        switch ($Arch) {
+            'x86' { "i686-unknown-windows-msvc" }
+            'amd64' { "x86_64-unknown-windows-msvc" }
+            'arm64' { "aarch64-unknown-windows-msvc" }
+            default { throw "Unsupported Windows architecture: $Arch" }
+        }
+    }
+    'Android' {
+        switch ($Arch) {
+            'i686' { "i686-unknown-linux-android${AndroidAPILevel}" }
+            'x86_64' { "x86_64-unknown-linux-android${AndroidAPILevel}" }
+            'armv7' { "armv7-unknown-linux-androideabi${AndroidAPILevel}" }
+            'arm64' { "aarch64-unknown-linux-android${AndroidAPILevel}" }
+            default { throw "Unsupported Android architecture: $Arch" }
+        }
+    }
+    'Darwin' { "${Arch}-apple-macosx15.0" }
+    default { throw "Unsupported OS: $OS" }
+}
+
+$UseASM = $null -ne $Assembler
+$UseC = $null -ne $CCompiler
+$UseCXX = $null -ne $CXXCompiler
+$UseSwift = $null -ne $SwiftCompiler
+$PlatformDebugFormat = switch ($OS) {
+    'Windows' { "codeview" }
+    'Android' { "dwarf" }
+    default { throw "Unsupported OS: $OS" }
+}
+
+function Add-LinkerFlagsDefine([hashtable]$Defines, [string[]]$Value) {
+    $Value = $Value | ForEach-Object { "LINKER:$_" }
+    Add-FlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS $Value
+    Add-FlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS $Value
+}
+
+function Add-SharedLinkerFlagsDefine([hashtable]$Defines, [string[]]$Value) {
+    $Value = $Value | ForEach-Object { "LINKER:$_" }
+    Add-FlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS $Value
+    Add-FlagsDefine $Defines CMAKE_MODULE_LINKER_FLAGS $Value
+}
+
+# Add additional defines (unless already present)
+$Defines = $CMakeDefines.Clone()
+
+# Enable CMP0181: Link command-line fragment variables are parsed and re-quoted.
+Add-KeyValueIfNew $Defines CMAKE_POLICY_DEFAULT_CMP0181 NEW
+# Enable CMP0214: Honor CMAKE_EXE_LINKER_FLAGS for Swift executable targets.
+Add-KeyValueIfNew $Defines CMAKE_POLICY_DEFAULT_CMP0214 NEW
+# Enable CMP0215: Ninja generators emit Swift modules separately from compilation.
+Add-KeyValueIfNew $Defines CMAKE_POLICY_DEFAULT_CMP0215 NEW
+
+Add-KeyValueIfNew $Defines CMAKE_BUILD_TYPE Release
+
+# Avoid specifying `CMAKE_SYSTEM_NAME` and `CMAKE_SYSTEM_PROCESSOR` on
+# Windows and in the case that we are not cross-compiling.
+if ($OS -ne $BuildOS -or $Arch -ne $BuildArch) {
+    Add-KeyValueIfNew $Defines CMAKE_SYSTEM_NAME $OS
+    Add-KeyValueIfNew $Defines CMAKE_SYSTEM_PROCESSOR $CMakeArch
+}
+
+# Always prefer the CONFIG format for the packages so that we can build
+# against the build tree.
+Add-KeyValueIfNew $Defines CMAKE_FIND_PACKAGE_PREFER_CONFIG YES
+
+switch ($OS) {
+    'Windows' {
+        if ($UseASM) {
+            Add-KeyValueIfNew $Defines CMAKE_ASM_COMPILER $Assembler.Executable
+            Add-KeyValueIfNew $Defines CMAKE_ASM_FLAGS @("--target=$Triple")
+            Add-KeyValueIfNew $Defines CMAKE_ASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreadedDLL "/MD"
+
+            if ($DebugInfo) {
+                # CMake's MSVC_DEBUG_INFORMATION_FORMAT support also applies to ASM
+                # targets, but clang-cl-as-ASM does not get a built-in mapping for
+                # the Embedded format. Provide the mapping before setting the global
+                # CMAKE_MSVC_DEBUG_INFORMATION_FORMAT below.
+                Add-FlagsDefine $Defines CMAKE_ASM_COMPILE_OPTIONS_MSVC_DEBUG_INFORMATION_FORMAT_Embedded $(& $Assembler.DebugFlags $PlatformDebugFormat)
+            }
+        }
+
+        if ($UseASM_MASM) {
+            $ASM_MASM = if (${Arch} -eq "x86") {
+                "ml.exe"
+            } else {
+                "ml64.exe"
+            }
+
+            Add-KeyValueIfNew $Defines CMAKE_ASM_MASM_COMPILER $ASM_MASM
+            Add-KeyValueIfNew $Defines CMAKE_ASM_MASM_FLAGS @("/nologo" , "/quiet")
+        }
+
+        if ($UseC) {
+            Add-KeyValueIfNew $Defines CMAKE_C_COMPILER $CCompiler.Executable
+            Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_TARGET $Triple
+            Add-FlagsDefine $Defines CMAKE_C_FLAGS $CCompiler.Flags
+
+            if ($DebugInfo) {
+                Add-FlagsDefine $Defines CMAKE_C_FLAGS $(& $CCompiler.DebugFlags $PlatformDebugFormat)
+            }
+        }
+
+        if ($UseCXX) {
+            Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER $CXXCompiler.Executable
+            Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER_TARGET $Triple
+            Add-FlagsDefine $Defines CMAKE_CXX_FLAGS $CXXCompiler.Flags
+
+            # With clang-cl, CMake generates MSVC-style archive rules (/nologo /out:...).
+            # If llvm-lib.exe is not found next to clang-cl.exe, CMake can fall back to
+            # whatever 'ar' is on PATH (e.g. the installed toolchain's POSIX ar.exe),
+            # causing a flags mismatch.  Explicitly pin CMAKE_AR to llvm-lib.exe from
+            # the compiler bin directory so the right tool is always selected.
+            if ($CXXCompiler.DriverStyle -eq [DriverStyle]::ClangCL) {
+                $librarian = [IO.Path]::Combine([IO.Path]::GetDirectoryName($CXXCompiler.Executable), "llvm-lib.exe")
+                if (Test-Path $librarian) {
+                    Add-KeyValueIfNew $Defines CMAKE_AR $librarian
+                }
+            }
+
+            if ($DebugInfo) {
+                Add-FlagsDefine $Defines CMAKE_CXX_FLAGS $(& $CXXCompiler.DebugFlags $PlatformDebugFormat)
+            }
+        }
+
+        if ($UseSwift) {
+            if ($SwiftCompiler.AssumeFunctional) {
+                Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_WORKS "YES"
+            }
+
+            Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER $SwiftCompiler.Executable
+            Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_TARGET $Triple
+            # Skip compiler ID detection: avoids compiling+scanning a multi-MB test binary on every configure.
+            Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_ID "Apple"
+
+            Add-FlagsDefine $Defines CMAKE_Swift_FLAGS $SwiftCompiler.Flags
+            if ($SwiftSDK) {
+                Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @("-sdk", $SwiftSDK)
+            }
+            if ($DebugInfo) {
+                Add-FlagsDefine $Defines CMAKE_Swift_FLAGS $(& $SwiftCompiler.DebugFlags $PlatformDebugFormat)
+            } else {
+                Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @("-gnone")
+            }
+
+            # CMake 3.30+ passes all linker flags to Swift as the linker driver,
+            # including those from the internal CMake modules files, without
+            # a `-Xlinker` prefix. This causes build failures as Swift cannot
+            # parse linker flags.
+            # Overwrite the release linker flags to be empty to avoid this.
+            Add-KeyValueIfNew $Defines CMAKE_EXE_LINKER_FLAGS_RELEASE ""
+            Add-KeyValueIfNew $Defines CMAKE_SHARED_LINKER_FLAGS_RELEASE ""
+
+            # Workaround CMake 3.26+ enabling `-wmo` by default on release builds
+            Add-FlagsDefine $Defines CMAKE_Swift_FLAGS_RELEASE "-O"
+            Add-FlagsDefine $Defines CMAKE_Swift_FLAGS_RELWITHDEBINFO "-O"
+        }
+
+        Add-LinkerFlagsDefine $Defines @("/INCREMENTAL:NO", "/OPT:REF", "/OPT:ICF")
+        Add-SharedLinkerFlagsDefine $Defines @("/MANIFEST:NO")
+        Add-KeyValueIfNew $Defines CMAKE_USER_MAKE_RULES_OVERRIDE `
+            "${env:GITHUB_WORKSPACE}\SourceCache\ci-build\.github\actions\configure-cmake-project\windows-clang-overrides.cmake"
+
+        if ($DebugInfo) {
+            if ($UseASM -or $UseC -or $UseCXX) {
+                # Prefer `/Z7` over `/ZI`
+                # By setting the debug information format, the appropriate C/C++
+                # flags will be set for codeview debug information format so there
+                # is no need to set them explicitly above.
+                Add-KeyValueIfNew $Defines CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded
+                Add-KeyValueIfNew $Defines CMAKE_POLICY_DEFAULT_CMP0141 NEW
+                Add-LinkerFlagsDefine $Defines @("/DEBUG")
+            }
+        }
+    }
+
+    'Android' {
+        # Note: On GHA, we do not use the `$Platform` variable as in `build.ps1` so these values
+        # have to be computed directly here.
+        $AndroidArchABI = switch ($Arch) {
+            'i686' { "x86" }
+            'x86_64' { "x86_64" }
+            'armv7' { "armeabi-v7a" }
+            'arm64' { "arm64-v8a" }
+            default { throw "Unsupported architecture: $Arch" }
+        }
+        $AndroidArchLLVM = switch ($BuildArch) {
+            'amd64' { "x86_64" }
+            'arm64' { "aarch64" }
+            default { throw "Unsupported architecture: $BuildArch" }
+        }
+        $AndroidNDKPath = $NDKPath
+        $AndroidPrebuiltRoot = "$AndroidNDKPath\toolchains\llvm\prebuilt\$($BuildOS.ToLowerInvariant())-$($AndroidArchLLVM)"
+        $AndroidSysroot = "$AndroidPrebuiltRoot\sysroot"
+
+        Add-KeyValueIfNew $Defines CMAKE_ANDROID_API "$AndroidAPILevel"
+        Add-KeyValueIfNew $Defines CMAKE_ANDROID_ARCH_ABI "$AndroidArchABI"
+        Add-KeyValueIfNew $Defines CMAKE_ANDROID_NDK "$AndroidNDKPath"
+        Add-KeyValueIfNew $Defines CMAKE_SYSROOT "$AndroidSysroot"
+
+        if ($UseASM) {
+        }
+
+        if ($UseC) {
+            Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_TARGET $Triple
+            Add-FlagsDefine $Defines CMAKE_C_FLAGS $CCompiler.Flags
+            if ($DebugInfo) {
+                Add-FlagsDefine $Defines CMAKE_C_FLAGS $(& $CCompiler.DebugFlags $PlatformDebugFormat)
+            }
+        }
+
+        if ($UseCXX) {
+            Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER_TARGET $Triple
+            Add-FlagsDefine $Defines CMAKE_CXX_FLAGS $CXXCompiler.Flags
+            if ($DebugInfo) {
+                Add-FlagsDefine $Defines CMAKE_CXX_FLAGS $(& $CXXCompiler.DebugFlags $PlatformDebugFormat)
+            }
+        }
+
+        if ($UseSwift) {
+            if ($SwiftCompiler.AssumeFunctional) {
+                Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_WORKS "YES"
+            }
+
+            # FIXME(compnerd) remove this once the old runtimes build path is removed.
+            Add-KeyValueIfNew $Defines SWIFT_ANDROID_NDK_PATH "$AndroidNDKPath"
+
+            Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER $SwiftCompiler.Executable
+            Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_TARGET $Triple
+            # Skip compiler ID detection: avoids compiling+scanning a multi-MB test binary on every configure.
+            Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_ID "Apple"
+
+            Add-FlagsDefine $Defines CMAKE_Swift_FLAGS $SwiftCompiler.Flags
+            if ($SwiftSDK) {
+                # TODO: CMake does not yet have support for passing `CMAKE_SYSROOT`
+                # to the Swift compiler yet.  Once we have that, we can drop
+                # `-sysroot $AndroidSysroot` here.
+                Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @("-sdk", $SwiftSDK, "-sysroot", $AndroidSysroot)
+            }
+            if ($DebugInfo) {
+                Add-FlagsDefine $Defines CMAKE_Swift_FLAGS $(& $SwiftCompiler.DebugFlags $PlatformDebugFormat)
+            } else {
+                Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @("-gnone")
+            }
+
+            Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @(
+                "-Xclang-linker", "-target", "-Xclang-linker", $Triple,
+                "-Xclang-linker", "--sysroot", "-Xclang-linker", $AndroidSysroot,
+                "-Xclang-linker", "-resource-dir", "-Xclang-linker", "${AndroidPrebuiltRoot}\lib\clang\${AndroidClangVersion}"
+            )
+        }
+
+        if (($UseASM -and $Assembler.AssumeFunctional) -or ($UseC -and $CCompiler.AssumeFunctional) -or ($UseCXX -and $CXXCompiler.AssumeFunctional)) {
+            # Use a built lld linker as the Android's NDK linker might be too old
+            # and not support all required relocations needed by the Swift
+            # runtime.
+            $Executable = if ($UseC) {
+                $CCompiler.Executable
+            } elseif ($UseCXX) {
+                $CXXCompiler.Executable
+            } elseif ($UseASM) {
+                $Assembler.Executable
+            }
+            $ld = Join-Path -Path (Split-Path $Executable) -ChildPath "ld.lld"
+            if ($UseSwift) {
+                # The Android NDK injects `-Wl,<arg>` flags into
+                # `CMAKE_*_LINKER_FLAGS` via `CMAKE_*_LINKER_FLAGS_INIT` variables.
+                # CMake 3.30+ passes these to the Swift driver, which doesn't
+                # understand the `-Wl,` syntax. Pre-set the flags in a portable form
+                # (`-Xlinker <arg>`) from the command line as this takes precedence
+                # over the NDK's `*_INIT` mechanism.
+                #
+                # `--ld-path` and `-Qunused-arguments` are Clang driver flags,
+                # handled via `CMAKE_PROJECT_INCLUDE` with a `LINK_LANGUAGE` guard,
+                # so they do not affect Swift linking.
+                $AndroidLinkerFlags = @(
+                    "-Xlinker", "--build-id=sha1",
+                    "-Xlinker", "--no-rosegment",
+                    "-Xlinker", "--no-undefined-version",
+                    "-Xlinker", "--fatal-warnings",
+                    "-Xlinker", "--gc-sections",
+                    "-Xlinker", "--no-undefined"
+                )
+                Add-FlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS $AndroidLinkerFlags
+                Add-FlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS ($AndroidLinkerFlags + @("-Xlinker", "--gc-sections"))
+                Add-FlagsDefine $Defines CMAKE_MODULE_LINKER_FLAGS $AndroidLinkerFlags
+                Add-KeyValueIfNew $Defines SWIFT_ANDROID_LD_PATH $ld
+                Add-KeyValueIfNew $Defines CMAKE_PROJECT_INCLUDE `
+                    "${env:GITHUB_WORKSPACE}\SourceCache\ci-build\.github\actions\configure-cmake-project\android-overrides.cmake"
+            } else {
+                # Clang Runtime explicitly sets linker flags for every target,
+                # making the `add_link_options()` approach via
+                # `CMAKE_PROJECT_INCLUDE` not viable. Since the problem that the
+                # above block aims to solve only concerns projects that use Swift,
+                # we can get away with just overriding `CMAKE_*_LINKER_FLAGS` for
+                # non-Swift projects.
+                Add-FlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS "--ld-path=$ld"
+                Add-FlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS "--ld-path=$ld"
+            }
+        }
+
+        # TODO(compnerd) we should understand why CMake does not understand
+        # that the object file format is ELF when targeting Android on Windows.
+        # This indication allows it to understand that it can use `chrpath` to
+        # change the RPATH on the dynamic libraries.
+        Add-FlagsDefine $Defines CMAKE_EXECUTABLE_FORMAT "ELF"
+    }
+}
+
+# Android's compilers are from the NDK and do not support CAS.
+if ($EnableCAS -and $OS -ne "Android") {
+    if ($UseC -and $CCompiler.DriverStyle -ne [DriverStyle]::CL) {
+        Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_LAUNCHER `
+            (Join-Path -Path (Split-Path $CCompiler.Executable) -ChildPath "clang-cache.exe")
+    }
+
+    if ($UseCXX -and $CXXCompiler.DriverStyle -ne [DriverStyle]::CL) {
+        Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER_LAUNCHER `
+            (Join-Path -Path (Split-Path $CXXCompiler.Executable) -ChildPath "clang-cache.exe")
+    }
+
+    if ($UseSwift) {
+        $CasPath = "${env:GITHUB_WORKSPACE}\cas"
+        Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @(
+            "-explicit-module-build",
+            "-cache-compile-job",
+            "-cas-path", $CasPath,
+            "-incremental-dependency-scan"
+        )
+    }
+}
+
+# Note: On GHA, sccache is no longer supported.
+if ($EnableCaching -and $OS -ne "Android") {
+    if ($UseC) {
+        Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_LAUNCHER "sccache"
+    }
+
+    if ($UseCXX) {
+        Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER_LAUNCHER "sccache"
+    }
+}
+
+if ($InstallDir) {
+    Add-KeyValueIfNew $Defines CMAKE_INSTALL_PREFIX $InstallDir
+}
+
+# Generate the project
+$cmakeGenerateArgs = @("-B", $BinDir, "-S", $SrcDir, "-G", "Ninja")
+if ($CacheScript) {
+    $cmakeGenerateArgs += @("-C", $CacheScript)
+}
+
+foreach ($Define in ($Defines.GetEnumerator() | Sort-Object Name)) {
+    # The quoting gets tricky to support defines containing compiler flags args,
+    # some of which can contain spaces, for example `-D` `Flags=-flag "C:/Program Files"`
+    # Avoid backslashes since they are going into CMakeCache.txt,
+    # where they are interpreted as escapes.
+    if ($Define.Value -is [string]) {
+        # Single token value, no need to quote spaces, the splat operator does the right thing.
+        $Value = $Define.Value.Replace("\", "/")
+    } else {
+        # Flags array, multiple tokens, quoting needed for tokens containing spaces
+        $Value = ""
+        foreach ($Arg in $Define.Value) {
+            if ($Value.Length -gt 0) {
+                $Value += " "
+            }
+
+            $ArgWithForwardSlashes = $Arg.Replace("\", "/")
+            if ($ArgWithForwardSlashes.Contains(" ")) {
+                # Escape the quote so it makes it through. PowerShell 5 and Core
+                # handle quotes differently, so we need to check the version.
+                $quote = if ($PSEdition -eq "Core") { '"' } else { '\"' }
+                $Value += "$quote$ArgWithForwardSlashes$quote"
+            } else {
+                $Value += $ArgWithForwardSlashes
+            }
+        }
+    }
+
+    $cmakeGenerateArgs += @("-D", "$($Define.Key)=$Value")
+}
+
+# Note: On GHA, we do a "pretty-print" of the cmake command for
+# debugging purposes and call cmake directly.
+Write-Host "ℹ️ Configuring project ${ProjectName}:"
+Write-Host 'cmake `'
+for ($i = 0; $i -lt $cmakeGenerateArgs.Length; $i += 1) {
+    $Arg = $cmakeGenerateArgs[$i]
+    if ($Arg -match '\s') {
+        Write-Host "  `'$Arg`'" -NoNewline
+    } else {
+        Write-Host "  $Arg" -NoNewline
+    }
+
+    if ((-not ($Arg -match '^-')) -and ($i -lt ($cmakeGenerateArgs.Length - 1))) {
+        # Write a newline for non-option arguments.
+        Write-Host " ``"
+    }
+}
+Write-Host "`n"
+
+& cmake @cmakeGenerateArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "CMake generation failed for project ${ProjectName} with exit code $LASTEXITCODE."
+}

--- a/.github/actions/configure-cmake-project/action.ps1
+++ b/.github/actions/configure-cmake-project/action.ps1
@@ -18,7 +18,6 @@ function ConvertTo-Bool([string]$Value) {
 $ProjectName = $env:INPUT_PROJECT_NAME
 $SwiftVersion = $env:INPUT_SWIFT_VERSION
 $EnableCaching = ConvertTo-Bool $env:INPUT_ENABLE_CACHING
-$EnableCAS = ConvertTo-Bool $env:INPUT_ENABLE_CAS
 $DebugInfo = ConvertTo-Bool $env:INPUT_DEBUG_INFO
 $BuildOS = $env:INPUT_BUILD_OS
 $BuildArch = $env:INPUT_BUILD_ARCH
@@ -32,7 +31,7 @@ $AndroidClangVersion = $env:INPUT_ANDROID_CLANG_VERSION
 $NDKPath = $env:INPUT_NDK_PATH
 $SwiftSDK = $env:INPUT_SWIFT_SDK_PATH
 $CacheScript = $env:INPUT_CACHE_SCRIPT
-$UseHostToolchain = ConvertTo-Bool $env:INPUT_USE_HOST_TOOLCHAIN
+$UseMSVCHostToolchain = ConvertTo-Bool $env:INPUT_USE_MSVC_HOST_TOOLCHAIN
 $UseASM_MASM = ConvertTo-Bool $env:INPUT_USE_ASM_MASM
 
 # `cmake-defines` is a PowerShell hashtable literal (`@{ ... }`) authored at the
@@ -236,12 +235,12 @@ $Compilers = @{
 
 # Mirror `build.ps1`'s `$Compilers.Host` trick: a computed pseudo-set that
 # redirects to the host MSVC toolchain or the pinned toolchain depending on
-# `$UseHostToolchain`. This keeps the host-vs-pinned decision in one place so
+# `$UseMSVCHostToolchain`. This keeps the host-vs-pinned decision in one place so
 # call sites can simply select `Host.C` / `Host.CXX`. Note there is no
 # `Host.Swift`: Swift always comes from a real stage.
 $Compilers.Host = @{
-    C   = if ($UseHostToolchain) { $Compilers.MSVC.C } else { $Compilers.Pinned.C }
-    CXX = if ($UseHostToolchain) { $Compilers.MSVC.CXX } else { $Compilers.Pinned.CXX }
+    C   = if ($UseMSVCHostToolchain) { $Compilers.MSVC.C } else { $Compilers.Pinned.C }
+    CXX = if ($UseMSVCHostToolchain) { $Compilers.MSVC.CXX } else { $Compilers.Pinned.CXX }
 }
 
 # Resolve a dotted selector (e.g. "Pinned.C", "Stage1.GNUCXX", "Host.CXX")
@@ -595,29 +594,6 @@ switch ($OS) {
         # This indication allows it to understand that it can use `chrpath` to
         # change the RPATH on the dynamic libraries.
         Add-FlagsDefine $Defines CMAKE_EXECUTABLE_FORMAT "ELF"
-    }
-}
-
-# Android's compilers are from the NDK and do not support CAS.
-if ($EnableCAS -and $OS -ne "Android") {
-    if ($UseC -and $CCompiler.DriverStyle -ne [DriverStyle]::CL) {
-        Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_LAUNCHER `
-            (Join-Path -Path (Split-Path $CCompiler.Executable) -ChildPath "clang-cache.exe")
-    }
-
-    if ($UseCXX -and $CXXCompiler.DriverStyle -ne [DriverStyle]::CL) {
-        Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER_LAUNCHER `
-            (Join-Path -Path (Split-Path $CXXCompiler.Executable) -ChildPath "clang-cache.exe")
-    }
-
-    if ($UseSwift) {
-        $CasPath = "${env:GITHUB_WORKSPACE}\cas"
-        Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @(
-            "-explicit-module-build",
-            "-cache-compile-job",
-            "-cas-path", $CasPath,
-            "-incremental-dependency-scan"
-        )
     }
 }
 

--- a/.github/actions/configure-cmake-project/action.yml
+++ b/.github/actions/configure-cmake-project/action.yml
@@ -29,16 +29,12 @@ inputs:
     description: Enable sccache.
     required: false
     default: false
-  enable-cas:
-    description: Enable cas.
-    required: false
-    default: false
   debug-info:
     description: Enable debug information in the build.
     required: false
     default: false
   build-os:
-    description: Build operating system (e.g., "Windows", "Darwin").
+    description: Build operating system (e.g., "Windows").
     required: true
   build-arch:
     description: Build architecture (e.g., "x86_64", "arm64").
@@ -100,10 +96,10 @@ inputs:
       (e.g. "Pinned.Swift", "Stage1.Swift"). Empty means no Swift compiler.
     required: false
     default: ''
-  use-host-toolchain:
+  use-msvc-host-toolchain:
     description: |
-      When true, the `Host.*` compiler selectors resolve to the host MSVC
-      toolchain; otherwise they resolve to the pinned toolchain.
+      When true, the `Host.*` compiler selectors resolve to the MSVC toolchain;
+      otherwise they resolve to the pinned toolchain.
     required: false
     default: false
   use-asm-masm:
@@ -134,7 +130,6 @@ runs:
         INPUT_PROJECT_NAME: ${{ inputs.project-name }}
         INPUT_SWIFT_VERSION: ${{ inputs.swift-version }}
         INPUT_ENABLE_CACHING: ${{ inputs.enable-caching }}
-        INPUT_ENABLE_CAS: ${{ inputs.enable-cas }}
         INPUT_DEBUG_INFO: ${{ inputs.debug-info }}
         INPUT_BUILD_OS: ${{ inputs.build-os }}
         INPUT_BUILD_ARCH: ${{ inputs.build-arch }}
@@ -153,7 +148,7 @@ runs:
         INPUT_C_COMPILER: ${{ inputs.c-compiler }}
         INPUT_CXX_COMPILER: ${{ inputs.cxx-compiler }}
         INPUT_SWIFT_COMPILER: ${{ inputs.swift-compiler }}
-        INPUT_USE_HOST_TOOLCHAIN: ${{ inputs.use-host-toolchain }}
+        INPUT_USE_MSVC_HOST_TOOLCHAIN: ${{ inputs.use-msvc-host-toolchain }}
         INPUT_USE_ASM_MASM: ${{ inputs.use-asm-masm }}
       run: |
         & "${env:GITHUB_WORKSPACE}\SourceCache\ci-build\.github\actions\configure-cmake-project\action.ps1"

--- a/.github/actions/configure-cmake-project/action.yml
+++ b/.github/actions/configure-cmake-project/action.yml
@@ -12,8 +12,6 @@ description: |
     - This action does not modify the environment. Notably, the `SDKROOT` and
       `NDKPATH` environment variables are not set as these are set up by other
       steps in the `swift-toolchain` workflow.
-    - The only Debug information format supported on Windows is `codeview`,
-      `dwarf` is not supported.
     - On Android, we build with `-gsplit-dwarf` for debug information.
       This is not supported by `sccache`, so caching is disabled when building
       for Android.
@@ -31,12 +29,16 @@ inputs:
     description: Enable sccache.
     required: false
     default: false
+  enable-cas:
+    description: Enable cas.
+    required: false
+    default: false
   debug-info:
     description: Enable debug information in the build.
     required: false
     default: false
   build-os:
-    description: Build operating system (e.g., "Windows").
+    description: Build operating system (e.g., "Windows", "Darwin").
     required: true
   build-arch:
     description: Build architecture (e.g., "x86_64", "arm64").
@@ -73,31 +75,48 @@ inputs:
     description: Path to the Swift SDK.
     required: false
     default: ''
-  msvc-compilers:
-    description: List of languages to build with the MSVC compilers (e.g. "C", "CXX", "ASM_MASM").
-    required: false
-    default: '@()'
-  built-compilers:
+
+  assembler:
     description: |
-      List of languages to build with the built compilers (e.g. "C", "CXX", "ASM", "Swift").
+      Assembler selector, resolved against the script's `$Assemblers` table
+      (e.g. "Pinned", "Stage1"). Empty means no assembler.
     required: false
-    default: '@()'
-  pinned-compilers:
+    default: ''
+  c-compiler:
     description: |
-      List of languages to build with the pinned compilers (e.g. "C", "CXX", "ASM", "Swift").
+      C compiler selector, resolved against the script's `$Compilers` table
+      (e.g. "Pinned.C", "Stage1.C", "Host.C"). Empty means no C compiler.
     required: false
-    default: '@()'
-  use-gnu-driver:
-    description: Use the GNU driver for building the project.
+    default: ''
+  cxx-compiler:
+    description: |
+      C++ compiler selector, resolved against the script's `$Compilers` table
+      (e.g. "Pinned.CXX", "Stage1.CXX", "Host.CXX"). Empty means no C++ compiler.
+    required: false
+    default: ''
+  swift-compiler:
+    description: |
+      Swift compiler selector, resolved against the script's `$Compilers` table
+      (e.g. "Pinned.Swift", "Stage1.Swift"). Empty means no Swift compiler.
+    required: false
+    default: ''
+  use-host-toolchain:
+    description: |
+      When true, the `Host.*` compiler selectors resolve to the host MSVC
+      toolchain; otherwise they resolve to the pinned toolchain.
     required: false
     default: false
+  use-asm-masm:
+    description: Whether to configure the ASMMASM assembler.
+    required: false
+    default: false
+
   cache-script:
     description: Optional path to a CMake Cache file.
     required: false
     default: ''
   cmake-defines:
-    description: |
-      Additional CMake definitions to pass to the build system (e.g. "CMAKE_BUILD_TYPE=Release").
+    description: Additional CMake definitions to pass to the build system (e.g. "CMAKE_BUILD_TYPE=Release").
     required: false
     default: '@{}'
 
@@ -106,9 +125,17 @@ runs:
   steps:
     - name: Configure ${{ inputs.project-name }}
       shell: pwsh
+      # All inputs are forwarded as `INPUT_*` environment variables. The script
+      # reads them directly; no `${{ }}` expressions are interpolated into
+      # PowerShell code (GHA does not template `.ps1` files anyway). The four
+      # tool inputs are plain-string selectors (e.g. "Host.C", "Stage1.GNUCXX")
+      # that the script resolves against its `$Assemblers` / `$Compilers` tables.
       env:
         INPUT_PROJECT_NAME: ${{ inputs.project-name }}
         INPUT_SWIFT_VERSION: ${{ inputs.swift-version }}
+        INPUT_ENABLE_CACHING: ${{ inputs.enable-caching }}
+        INPUT_ENABLE_CAS: ${{ inputs.enable-cas }}
+        INPUT_DEBUG_INFO: ${{ inputs.debug-info }}
         INPUT_BUILD_OS: ${{ inputs.build-os }}
         INPUT_BUILD_ARCH: ${{ inputs.build-arch }}
         INPUT_OS: ${{ inputs.os }}
@@ -121,471 +148,12 @@ runs:
         INPUT_NDK_PATH: ${{ inputs.ndk-path }}
         INPUT_SWIFT_SDK_PATH: ${{ inputs.swift-sdk-path }}
         INPUT_CACHE_SCRIPT: ${{ inputs.cache-script }}
+        INPUT_CMAKE_DEFINES: ${{ inputs.cmake-defines }}
+        INPUT_ASSEMBLER: ${{ inputs.assembler }}
+        INPUT_C_COMPILER: ${{ inputs.c-compiler }}
+        INPUT_CXX_COMPILER: ${{ inputs.cxx-compiler }}
+        INPUT_SWIFT_COMPILER: ${{ inputs.swift-compiler }}
+        INPUT_USE_HOST_TOOLCHAIN: ${{ inputs.use-host-toolchain }}
+        INPUT_USE_ASM_MASM: ${{ inputs.use-asm-masm }}
       run: |
-        Remove-Item env:\SDKROOT -ErrorAction SilentlyContinue
-        $ExeSuffix = if ($IsWindows) { ".exe" } else { "" }
-
-        $ProjectName = $env:INPUT_PROJECT_NAME
-        $SwiftVersion = $env:INPUT_SWIFT_VERSION
-        $EnableCaching = ${{ inputs.enable-caching == 'true' && '$True' || '$False' }}
-        $DebugInfo = ${{ inputs.debug-info == 'true' && '$True' || '$False' }}
-        $BuildOS = $env:INPUT_BUILD_OS
-        $BuildArch = $env:INPUT_BUILD_ARCH
-        $OS = $env:INPUT_OS
-        $Arch = $env:INPUT_ARCH
-        $SrcDir = $env:INPUT_SRC_DIR
-        $BinDir = $env:INPUT_BIN_DIR
-        $InstallDir = $env:INPUT_INSTALL_DIR
-        $AndroidAPILevel = $env:INPUT_ANDROID_API_LEVEL
-        $AndroidClangVersion = $env:INPUT_ANDROID_CLANG_VERSION
-        $NDKPath = $env:INPUT_NDK_PATH
-        $SwiftSDK = $env:INPUT_SWIFT_SDK_PATH
-        $UseMSVCCompilers = ${{ inputs.msvc-compilers }}
-        $UseBuiltCompilers = ${{ inputs.built-compilers }}
-        $UsePinnedCompilers = ${{ inputs.pinned-compilers }}
-        $UseGNUDriver = ${{ inputs.use-gnu-driver == 'true' && '$True' || '$False' }}
-        $CacheScript = $env:INPUT_CACHE_SCRIPT
-        $CMakeDefines = ${{ inputs.cmake-defines }}
-
-        function Add-KeyValueIfNew([hashtable]$Hashtable, [string]$Key, [string]$Value) {
-          if (-not $Hashtable.Contains($Key)) {
-            $Hashtable.Add($Key, $Value)
-          }
-        }
-
-        function Add-FlagsDefine([hashtable]$Defines, [string]$Name, [string[]]$Value) {
-          if ($Defines.Contains($Name)) {
-            $Defines[$name] = @($Defines[$name]) + $Value
-          } else {
-            $Defines.Add($Name, $Value)
-          }
-        }
-
-        # Note: On GHA, we do not use the `$Platform` variable as in `build.ps1` so these values
-        # have to be computed directly here.
-        $CMakeArch = switch ($OS) {
-          'Windows' {
-            switch ($Arch) {
-              'arm64' { 'ARM64' }
-              'amd64' { 'AMD64' }
-              'x86' { 'i686' }
-              default { throw "Unsupported Windows architecture: $Arch" }
-            }
-          }
-          'Android' {
-            switch ($Arch) {
-              'arm64' { 'aarch64' }
-              'x86_64' { 'x86_64' }
-              'i686' { 'i686' }
-              'armv7' { 'armv7-a' }
-              default { throw "Unsupported Android architecture: $Arch" }
-            } 
-          }
-          default { throw "Unsupported OS: $OS" }
-        }
-
-        $Triple = switch ($OS) {
-          'Windows' {
-            switch ($Arch) {
-              'x86' { "i686-unknown-windows-msvc" }
-              'amd64' { "x86_64-unknown-windows-msvc" }
-              'arm64' { "aarch64-unknown-windows-msvc" }
-              default { throw "Unsupported Windows architecture: $Arch" }
-            }
-          }
-          'Android' {
-            switch ($Arch) {
-              'i686' { "i686-unknown-linux-android${AndroidAPILevel}" }
-              'x86_64' { "x86_64-unknown-linux-android${AndroidAPILevel}" }
-              'armv7' { "armv7-unknown-linux-androideabi${AndroidAPILevel}" }
-              'arm64' { "aarch64-unknown-linux-android${AndroidAPILevel}" }
-              default { throw "Unsupported Android architecture: $Arch" }
-            }
-          }
-          default { throw "Unsupported OS: $OS" }
-        }
-
-        $UseASM = $UseBuiltCompilers.Contains("ASM") -or $UsePinnedCompilers.Contains("ASM")
-        $UseASM_MASM = $UseMSVCCompilers.Contains("ASM_MASM")
-        $UseC = $UseBuiltCompilers.Contains("C") -or $UseMSVCCompilers.Contains("C") -or $UsePinnedCompilers.Contains("C")
-        $UseCXX = $UseBuiltCompilers.Contains("CXX") -or $UseMSVCCompilers.Contains("CXX") -or $UsePinnedCompilers.Contains("CXX")
-        $UseSwift = $UseBuiltCompilers.Contains("Swift") -or $UsePinnedCompilers.Contains("Swift")
-
-        # Add additional defines (unless already present)
-        $Defines = $CMakeDefines.Clone()
-
-        Add-KeyValueIfNew $Defines CMAKE_BUILD_TYPE Release
-
-        # Avoid specifying `CMAKE_SYSTEM_NAME` and `CMAKE_SYSTEM_PROCESSOR` on
-        # Windows and in the case that we are not cross-compiling.
-        if ($OS -ne $BuildOS -or $Arch -ne $BuildArch) {
-          Add-KeyValueIfNew $Defines CMAKE_SYSTEM_NAME $OS
-          Add-KeyValueIfNew $Defines CMAKE_SYSTEM_PROCESSOR $CMakeArch
-        }
-
-        # Always prefer the CONFIG format for the packages so that we can build
-        # against the build tree.
-        Add-KeyValueIfNew $Defines CMAKE_FIND_PACKAGE_PREFER_CONFIG YES
-
-        switch ($OS) {
-          'Windows' {
-            if ($UseASM) {
-              $Driver = $(if ($UseGNUDriver) { "clang.exe" } else { "clang-cl.exe" })
-              $ASM = if ($UseBuiltCompilers.Contains("ASM")) {
-                "${env:GITHUB_WORKSPACE}/BinaryCache/Library/Developer/Toolchains/${SwiftVersion}+Asserts/usr/bin/${Driver}"
-              } elseif ($UsePinnedCompilers.Contains("ASM")) {
-                # Note: On GHA, the pinned toolchain is already in the path.
-                $Driver
-              }
-
-              Add-KeyValueIfNew $Defines CMAKE_ASM_COMPILER $ASM
-              Add-KeyValueIfNew $Defines CMAKE_ASM_FLAGS @("--target=$Triple")
-              Add-KeyValueIfNew $Defines CMAKE_ASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreadedDLL "/MD"
-
-              if ($DebugInfo) {
-                # Note: On GHA, we do not support the "dwarf" format.
-                $ASMDebugFlags = if ($UseGNUDriver) { @("-gcodeview") } else { @("-clang:-gcodeview") }
-
-                # CMake does not set a default value for the ASM compiler debug
-                # information format flags with non-MSVC compilers, so we explicitly
-                # set a default here.
-                Add-FlagsDefine $Defines CMAKE_ASM_COMPILE_OPTIONS_MSVC_DEBUG_INFORMATION_FORMAT_Embedded $ASMDebugFlags
-              }
-            }
-
-            if ($UseASM_MASM) {
-              $ASM_MASM = if (${Arch} -eq "x86") {
-                "ml.exe"
-              } else {
-                "ml64.exe"
-              }
-
-              Add-KeyValueIfNew $Defines CMAKE_ASM_MASM_COMPILER $ASM_MASM
-              Add-KeyValueIfNew $Defines CMAKE_ASM_MASM_FLAGS @("/nologo" , "/quiet")
-            }
-
-            if ($UseC) {
-              $CC = if ($UseMSVCCompilers.Contains("C")) {
-                "cl.exe"
-              } else {
-                $Driver = $(if ($UseGNUDriver) { "clang.exe" } else { "clang-cl.exe" })
-                if ($UseBuiltCompilers.Contains("C")) {
-                  "${env:GITHUB_WORKSPACE}/BinaryCache/Library/Developer/Toolchains/${SwiftVersion}+Asserts/usr/bin/${Driver}"
-                } elseif ($UsePinnedCompilers.Contains("C")) {
-                  # Note: On GHA, the pinned toolchain is already in the path.
-                  $Driver
-                }
-              }
-
-              Add-KeyValueIfNew $Defines CMAKE_C_COMPILER $CC
-              Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_TARGET $Triple
-
-              $CFLAGS = if ($UseGNUDriver) {
-                # TODO(compnerd) we should consider enabling stack protector usage for standard libraries.
-                @("-fno-stack-protector", "-ffunction-sections", "-fdata-sections", "-fomit-frame-pointer")
-              } elseif ($UseMSVCCompilers.Contains("C")) {
-                @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:preprocessor", "/Zc:inline")
-              } else {
-                # clang-cl does not support the /Zc:preprocessor flag.
-                @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline")
-              }
-
-              # Note: On GHA, we do not support the "dwarf" format.
-              # if ($CDebugFormat -eq "dwarf") { ... }
-
-              Add-FlagsDefine $Defines CMAKE_C_FLAGS $CFLAGS
-            }
-
-            if ($UseCXX) {
-              $CXX = if ($UseMSVCCompilers.Contains("CXX")) {
-                "cl.exe"
-              } else {
-                $Driver = $(if ($UseGNUDriver) { "clang++.exe" } else { "clang-cl.exe" })
-                if ($UseBuiltCompilers.Contains("CXX")) {
-                  "${env:GITHUB_WORKSPACE}/BinaryCache/Library/Developer/Toolchains/${SwiftVersion}+Asserts/usr/bin/${Driver}"
-                } elseif ($UsePinnedCompilers.Contains("CXX")) {
-                  # Note: On GHA, the pinned toolchain is already in the path.
-                  $Driver
-                }
-              }
-
-              Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER $CXX
-              Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER_TARGET $Triple
-
-              $CXXFLAGS = if ($UseGNUDriver) {
-                # TODO(compnerd) we should consider enabling stack protector usage for standard libraries.
-                @("-fno-stack-protector", "-ffunction-sections", "-fdata-sections", "-fomit-frame-pointer")
-              } elseif ($UseMSVCCompilers.Contains("CXX")) {
-                @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:preprocessor", "/Zc:inline", "/Zc:__cplusplus")
-              } else {
-                # clang-cl does not support the /Zc:preprocessor flag.
-                @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:__cplusplus")
-              }
-
-              # Note: On GHA, we do not support the "dwarf" format.
-              # if ($CDebugFormat -eq "dwarf") { ... }
-
-              Add-FlagsDefine $Defines CMAKE_CXX_FLAGS $CXXFLAGS
-            }
-
-            if ($UseSwift) {
-              if ($UseBuiltCompilers.Contains("Swift")) {
-                Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_WORKS "YES"
-              }
-
-              $SWIFTC = if ($UseBuiltCompilers.Contains("Swift")) {
-                "${env:GITHUB_WORKSPACE}/BinaryCache/Library/Developer/Toolchains/${SwiftVersion}+Asserts/usr/bin/swiftc.exe"
-              } elseif ($UsePinnedCompilers.Contains("Swift")) {
-                # Note: On GHA, the pinned toolchain is already in the path.
-                "swiftc.exe"
-              }
-
-              Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER $SWIFTC
-              Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_TARGET $Triple
-
-              # Skip compiler ID detection: avoids compiling+scanning a multi-MB test binary on every configure.
-              Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_ID "Apple"
-
-              [string[]] $SwiftFlags = @();
-
-              $SwiftFlags += if ($SwiftSDK) {
-                @("-sdk", $SwiftSDK)
-              } else {
-                @()
-              }
-
-              $SwiftFlags += if ($DebugInfo) {
-                # Note: On GHA, we do not support the "dwarf" format.
-                @("-g", "-debug-info-format=codeview", "-Xlinker", "/DEBUG")
-              } else {
-                @("-gnone")
-              }
-
-              # Disable EnC as that introduces padding in the conformance tables
-              $SwiftFlags += @("-Xlinker", "/INCREMENTAL:NO")
-              # Swift requires COMDAT folding and de-duplication
-              $SwiftFlags += @("-Xlinker", "/OPT:REF", "-Xlinker", "/OPT:ICF")
-
-              Add-FlagsDefine $Defines CMAKE_Swift_FLAGS $SwiftFlags
-              # Workaround CMake 3.26+ enabling `-wmo` by default on release builds
-              Add-FlagsDefine $Defines CMAKE_Swift_FLAGS_RELEASE "-O"
-              Add-FlagsDefine $Defines CMAKE_Swift_FLAGS_RELWITHDEBINFO "-O"
-            }
-
-            $LinkerFlags = if ($UseGNUDriver) {
-              @("-Xlinker", "/INCREMENTAL:NO", "-Xlinker", "/OPT:REF", "-Xlinker", "/OPT:ICF")
-            } else {
-              @("/INCREMENTAL:NO", "/OPT:REF", "/OPT:ICF")
-            }
-
-            if ($DebugInfo) {
-              if ($UseASM -or $UseC -or $UseCXX) {
-                # Prefer `/Z7` over `/ZI`
-                # By setting the debug information format, the appropriate C/C++
-                # flags will be set for codeview debug information format so there
-                # is no need to set them explicitly above.
-                Add-KeyValueIfNew $Defines CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded
-                Add-KeyValueIfNew $Defines CMAKE_POLICY_DEFAULT_CMP0141 NEW
-
-                $LinkerFlags += if ($UseGNUDriver) {
-                  @("-Xlinker", "/DEBUG")
-                } else {
-                  @("/DEBUG")
-                }
-
-                # Note: On GHA, we do not support the "dwarf" format.
-                # if ($SwiftDebugFormat -eq "dwarf") { ... }
-              }
-            }
-
-            Add-FlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS $LinkerFlags
-            Add-FlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS $LinkerFlags
-          }
-
-          'Android' {
-            # Note: On GHA, we do not use the `$Platform` variable as in `build.ps1` so these values
-            # have to be computed directly here.
-            $AndroidArchABI = switch ($Arch) {
-              'i686' { "x86" }
-              'x86_64' { "x86_64" }
-              'armv7' { "armeabi-v7a" }
-              'arm64' { "arm64-v8a" }
-              default { throw "Unsupported architecture: $Arch" }
-            }
-            $AndroidArchLLVM = switch ($BuildArch) {
-              'amd64' { "x86_64" }
-              'arm64' { "aarch64" }
-              default { throw "Unsupported architecture: $Arch" }
-            }
-            $AndroidNDKPath = $NDKPath
-            $AndroidPrebuiltRoot = "$AndroidNDKPath\toolchains\llvm\prebuilt\$($BuildOS.ToLowerInvariant())-$($AndroidArchLLVM)"
-            $AndroidSysroot = "$AndroidPrebuiltRoot\sysroot"
-
-            Add-KeyValueIfNew $Defines CMAKE_ANDROID_API "$AndroidAPILevel"
-            Add-KeyValueIfNew $Defines CMAKE_ANDROID_ARCH_ABI "$AndroidArchABI"
-            Add-KeyValueIfNew $Defines CMAKE_ANDROID_NDK "$AndroidNDKPath"
-            Add-KeyValueIfNew $Defines CMAKE_SYSROOT "$AndroidSysroot"
-
-            if ($UseASM) {
-            }
-
-            if ($UseC) {
-              Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_TARGET $Triple
-
-              $CFLAGS = @("-ffunction-sections", "-fdata-sections")
-              if ($DebugInfo) {
-                # Note: On GHA, we build Android with `-gsplit-dwarf`.
-                $CFLAGS += @("-g", "-gsplit-dwarf")
-              }
-              Add-FlagsDefine $Defines CMAKE_C_FLAGS $CFLAGS
-            }
-
-            if ($UseCXX) {
-              Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER_TARGET $Triple
-
-              $CXXFLAGS = @("-ffunction-sections", "-fdata-sections")
-              if ($DebugInfo) {
-                # Note: On GHA, we build Android with `-gsplit-dwarf`.
-                $CXXFLAGS += @("-g", "-gsplit-dwarf")
-              }
-              Add-FlagsDefine $Defines CMAKE_CXX_FLAGS $CXXFLAGS
-            }
-
-            if ($UseSwift) {
-              if ($UseBuiltCompilers.Contains("Swift")) {
-                Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_WORKS "YES"
-              }
-
-              # FIXME(compnerd) remove this once the old runtimes build path is removed.
-              Add-KeyValueIfNew $Defines SWIFT_ANDROID_NDK_PATH "$AndroidNDKPath"
-
-              $SWIFTC = if ($UseBuiltCompilers.Contains("Swift")) {
-                "${Env:GITHUB_WORKSPACE}/BinaryCache/Library/Developer/Toolchains/${SwiftVersion}+Asserts/usr/bin/swiftc.exe"
-              } else {
-                # Note: On GHA, the pinned toolchain is already in the path.
-                "swiftc.exe"
-              }
-              Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER $SWIFTC
-              Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_TARGET $Triple
-
-              # Skip compiler ID detection: avoids compiling+scanning a multi-MB test binary on every configure.
-              Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_ID "Apple"
-
-              [string[]] $SwiftFlags = @()
-
-              $SwiftFlags += if ($SwiftSDK) {
-                @("-sdk", $SwiftSDK, "-sysroot", $AndroidSysroot)
-              } else {
-                @()
-              }
-
-              $SwiftFlags += @(
-                "-Xclang-linker", "-target", "-Xclang-linker", $Triple,
-                "-Xclang-linker", "--sysroot", "-Xclang-linker", $AndroidSysroot,
-                "-Xclang-linker", "-resource-dir", "-Xclang-linker", "${AndroidPrebuiltRoot}\lib\clang\${AndroidClangVersion}"
-              )
-
-              $SwiftFlags += if ($DebugInfo) { @("-g") } else { @("-gnone") }
-
-              Add-FlagsDefine $Defines CMAKE_Swift_FLAGS $SwiftFlags
-              # Workaround CMake 3.26+ enabling `-wmo` by default on release builds
-              Add-FlagsDefine $Defines CMAKE_Swift_FLAGS_RELEASE "-O"
-              Add-FlagsDefine $Defines CMAKE_Swift_FLAGS_RELWITHDEBINFO "-O"
-            }
-
-            $UseBuiltASMCompiler = $UseBuiltCompilers.Contains("ASM")
-            $UseBuiltCCompiler = $UseBuiltCompilers.Contains("C")
-            $UseBuiltCXXCompiler = $UseBuiltCompilers.Contains("CXX")
-
-            if ($UseBuiltASMCompiler -or $UseBuiltCCompiler -or $UseBuiltCXXCompiler) {
-              # Use a built lld linker as the Android's NDK linker might be too old
-              # and not support all required relocations needed by the Swift
-              # runtime.
-              $ld = "${Env:GITHUB_WORKSPACE}/BinaryCache/Library/Developer/Toolchains/${SwiftVersion}+Asserts/usr/bin/ld.lld"
-              Add-FlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS "--ld-path=$ld"
-              Add-FlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS "--ld-path=$ld"
-            }
-
-            # TODO(compnerd) we should understand why CMake does not understand
-            # that the object file format is ELF when targeting Android on Windows.
-            # This indication allows it to understand that it can use `chrpath` to
-            # change the RPATH on the dynamic libraries.
-            Add-FlagsDefine $Defines CMAKE_EXECUTABLE_FORMAT "ELF"
-          }
-        }
-
-        # Note: On GHA, we build Android with `-gsplit-dwarf`, which is not supported by sccache.
-        if ($EnableCaching -and $OS -ne "Android") {
-          if ($UseC) {
-            Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_LAUNCHER "sccache"
-          }
-
-          if ($UseCXX) {
-            Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER_LAUNCHER "sccache"
-          }
-        }
-
-        if ($InstallDir) {
-          Add-KeyValueIfNew $Defines CMAKE_INSTALL_PREFIX $InstallDir
-        }
-
-        # Generate the project
-        $cmakeGenerateArgs = @("-B", $BinDir, "-S", $SrcDir, "-G", "Ninja")
-        if ($CacheScript) {
-          $cmakeGenerateArgs += @("-C", $CacheScript)
-        }
-
-        foreach ($Define in ($Defines.GetEnumerator() | Sort-Object Name)) {
-          # The quoting gets tricky to support defines containing compiler flags args,
-          # some of which can contain spaces, for example `-D` `Flags=-flag "C:/Program Files"`
-          # Avoid backslashes since they are going into CMakeCache.txt,
-          # where they are interpreted as escapes.
-          if ($Define.Value -is [string]) {
-            # Single token value, no need to quote spaces, the splat operator does the right thing.
-            $Value = $Define.Value.Replace("\", "/")
-          } else {
-            # Flags array, multiple tokens, quoting needed for tokens containing spaces
-            $Value = ""
-            foreach ($Arg in $Define.Value) {
-              if ($Value.Length -gt 0) {
-                $Value += " "
-              }
-
-              $ArgWithForwardSlashes = $Arg.Replace("\", "/")
-              if ($ArgWithForwardSlashes.Contains(" ")) {
-                # Escape the quote so it makes it through. PowerShell 5 and Core
-                # handle quotes differently, so we need to check the version.
-                $quote = if ($PSEdition  -eq "Core") { '"' } else { '\"' }
-                $Value += "$quote$ArgWithForwardSlashes$quote"
-              } else {
-                $Value += $ArgWithForwardSlashes
-              }
-            }
-          }
-
-          $cmakeGenerateArgs += @("-D", "$($Define.Key)=$Value")
-        }
-
-        # Note: On GHA, we do a "pretty-print" of the cmake command for
-        # debugging purposes and call cmake directly.
-        Write-Host "ℹ️ Configuring project ${ProjectName}:"
-        Write-Host 'cmake `'
-        for ($i = 0; $i -lt $cmakeGenerateArgs.Length; $i += 1) {
-          $Arg = $cmakeGenerateArgs[$i]
-          if ($Arg -match '\s') {
-            Write-Host "  `'$Arg`'" -NoNewline
-          } else {
-            Write-Host "  $Arg" -NoNewline
-          }
-
-          if ((-not ($Arg -match '^-')) -and ($i -lt ($cmakeGenerateArgs.Length - 1))) {
-            # Write a newline for non-option arguments.
-            Write-Host " ``"
-          }
-        }
-        Write-Host "`n"
-
-        & cmake @cmakeGenerateArgs
-        if ($LASTEXITCODE -ne 0) {
-          throw "CMake generation failed for project ${ProjectName} with exit code $LASTEXITCODE."
-        }
+        & "${env:GITHUB_WORKSPACE}\SourceCache\ci-build\.github\actions\configure-cmake-project\action.ps1"

--- a/.github/actions/configure-cmake-project/android-overrides.cmake
+++ b/.github/actions/configure-cmake-project/android-overrides.cmake
@@ -1,0 +1,24 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+# Included via CMAKE_PROJECT_INCLUDE for Android builds that use Swift.
+#
+# Handles Clang-only driver flags that Swift doesn't understand:
+# - --ld-path: specifies the linker binary (Clang driver flag)
+# - -Qunused-arguments: suppresses Clang warnings about unused flags
+#
+# The NDK's -Wl,<arg> linker flags are handled in build.ps1 by pre-setting
+# CMAKE_*_LINKER_FLAGS with -Xlinker <arg> form before CMake runs.
+
+# --ld-path for using the built lld instead of the NDK linker.
+if(SWIFT_ANDROID_LD_PATH)
+  add_link_options($<$<LINK_LANGUAGE:C,CXX,ASM>:--ld-path=${SWIFT_ANDROID_LD_PATH}>)
+endif()
+
+# Clang-only driver flag, not understood by Swift.
+add_link_options($<$<LINK_LANGUAGE:C,CXX,ASM>:-Qunused-arguments>)

--- a/.github/actions/configure-cmake-project/windows-clang-overrides.cmake
+++ b/.github/actions/configure-cmake-project/windows-clang-overrides.cmake
@@ -1,0 +1,29 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+# Included via CMAKE_USER_MAKE_RULES_OVERRIDE for Windows builds.  CMake can
+# add an explicit /MANIFEST:EMBED to compiler-driver shared-library rules.  The
+# build script passes /MANIFEST:NO for shared/module links so linker-generated
+# RT_MANIFEST #2 resources do not poison private SxS activation; strip the
+# explicit embed spelling so it cannot override that flag.
+
+foreach(lang IN ITEMS C CXX Swift)
+  foreach(rule IN ITEMS
+      CMAKE_${lang}_CREATE_SHARED_LIBRARY
+      CMAKE_${lang}_CREATE_SHARED_MODULE)
+    if(DEFINED ${rule})
+      string(REPLACE " --manifests " " " ${rule} "${${rule}}")
+      string(REPLACE " -Xlinker /MANIFEST:EMBED" "" ${rule} "${${rule}}")
+      string(REPLACE "-Xlinker /MANIFEST:EMBED " "" ${rule} "${${rule}}")
+      string(REPLACE "-Xlinker /MANIFEST:EMBED" "" ${rule} "${${rule}}")
+      string(REPLACE " /MANIFEST:EMBED" "" ${rule} "${${rule}}")
+      string(REPLACE "/MANIFEST:EMBED " "" ${rule} "${${rule}}")
+      string(REPLACE "/MANIFEST:EMBED" "" ${rule} "${${rule}}")
+    endif()
+  endforeach()
+endforeach()

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -317,7 +317,7 @@ on:
 
 env:
   PINNED_BOOTSTRAP_TOOLCHAIN_VERSION: DEVELOPMENT-SNAPSHOT-2026-03-16-a
-  CMAKE_VERSION: 4.4.0
+  CMAKE_VERSION: 4.4.1
 
 defaults:
   run:
@@ -431,7 +431,7 @@ jobs:
           setup-vs-dev-env: true
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
 
@@ -538,7 +538,7 @@ jobs:
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
 
@@ -652,7 +652,7 @@ jobs:
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
 
@@ -736,7 +736,7 @@ jobs:
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
 
@@ -895,7 +895,7 @@ jobs:
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
 
@@ -1041,7 +1041,7 @@ jobs:
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
 
@@ -1402,7 +1402,7 @@ jobs:
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
 
@@ -1495,7 +1495,7 @@ jobs:
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
 
@@ -1589,7 +1589,7 @@ jobs:
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
 
@@ -1779,7 +1779,7 @@ jobs:
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
 
@@ -1883,7 +1883,7 @@ jobs:
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
 
@@ -2103,7 +2103,7 @@ jobs:
           setup-vs-dev-env: true
           host-arch: ${{ matrix.arch }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
 
@@ -2313,7 +2313,7 @@ jobs:
           setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
           host-arch: ${{ matrix.arch }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
 
@@ -3175,7 +3175,7 @@ jobs:
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
 
@@ -3611,7 +3611,7 @@ jobs:
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
 
@@ -4553,7 +4553,7 @@ jobs:
           setup-vs-dev-env: true
           host-arch: ${{ matrix.arch }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
 
@@ -6667,7 +6667,7 @@ jobs:
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
 

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -397,7 +397,7 @@ jobs:
           install-dir: ${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
-          use-host-toolchain: ${{ inputs.use_host_toolchain }}
+          use-msvc-host-toolchain: ${{ inputs.use_host_toolchain }}
           c-compiler: 'Host.C'
           cmake-defines: |
             @{
@@ -487,7 +487,7 @@ jobs:
           arch: ${{ inputs.build_arch }}
           src-dir: ${{ github.workspace }}/SourceCache/ds2/Tools/RegsGen2
           bin-dir: ${{ github.workspace }}/BinaryCache/RegsGen2
-          use-host-toolchain: ${{ inputs.use_host_toolchain }}
+          use-msvc-host-toolchain: ${{ inputs.use_host_toolchain }}
           c-compiler: 'Host.C'
           cxx-compiler: 'Host.CXX'
           cache-script: ${{ github.workspace }}/SourceCache/ds2/cmake/caches/MSVCWarnings.cmake
@@ -697,7 +697,7 @@ jobs:
           src-dir: ${{ github.workspace }}/SourceCache/cmark-gfm
           bin-dir: ${{ github.workspace }}/BinaryCache/cmark-gfm-${{ inputs.swift_cmark_version }}
           install-dir: ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr
-          use-host-toolchain: ${{ inputs.use_host_toolchain }}
+          use-msvc-host-toolchain: ${{ inputs.use_host_toolchain }}
           c-compiler: 'Host.C'
           cxx-compiler: 'Host.CXX'
           cmake-defines: |
@@ -796,7 +796,7 @@ jobs:
           arch: ${{ matrix.arch }}
           src-dir: ${{ github.workspace }}/SourceCache/llvm-project/llvm
           bin-dir: ${{ github.workspace }}/BinaryCache/BuildTools
-          use-host-toolchain: ${{ inputs.use_host_toolchain }}
+          use-msvc-host-toolchain: ${{ inputs.use_host_toolchain }}
           c-compiler: 'Host.C'
           cxx-compiler: 'Host.CXX'
           use-asm-masm: ${{ inputs.use_host_toolchain }}
@@ -1220,7 +1220,7 @@ jobs:
           src-dir: ${{ github.workspace }}/SourceCache/llvm-project/llvm
           bin-dir: ${{ github.workspace }}/BinaryCache/1
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+${{ matrix.variant }}/usr
-          use-host-toolchain: ${{ inputs.use_host_toolchain }}
+          use-msvc-host-toolchain: ${{ inputs.use_host_toolchain }}
           c-compiler: 'Host.C'
           cxx-compiler: 'Host.CXX'
           swift-compiler: 'Pinned.Swift'

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -317,6 +317,7 @@ on:
 
 env:
   PINNED_BOOTSTRAP_TOOLCHAIN_VERSION: DEVELOPMENT-SNAPSHOT-2026-03-16-a
+  CMAKE_VERSION: 4.4.0
 
 defaults:
   run:
@@ -347,6 +348,10 @@ jobs:
           setup-vs-dev-env: true
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: ssrobins/install-cmake@da13ba26f50a41d3b03cfe8ca7265903f04a8932 # v1
+        with:
+          version: ${{ env.CMAKE_VERSION }}
 
       - name: Compute workspace hash
         id: workspace_hash
@@ -392,12 +397,11 @@ jobs:
           install-dir: ${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
-          msvc-compilers: ${{ inputs.use_host_toolchain && '@("C")' || '@()' }}
-          pinned-compilers: ${{ inputs.use_host_toolchain && '@()' || '@("C")' }}
+          use-host-toolchain: ${{ inputs.use_host_toolchain }}
+          c-compiler: 'Host.C'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "NO";
-              'CMAKE_C_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
             }
       - name: Build SQLite
         run: cmake --build ${{ github.workspace }}/BinaryCache/sqlite-${{ inputs.swift_toolchain_sqlite_version }}
@@ -426,6 +430,10 @@ jobs:
         with:
           setup-vs-dev-env: true
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        with:
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
 
       - name: Compute workspace hash
         if: inputs.build_android
@@ -479,14 +487,10 @@ jobs:
           arch: ${{ inputs.build_arch }}
           src-dir: ${{ github.workspace }}/SourceCache/ds2/Tools/RegsGen2
           bin-dir: ${{ github.workspace }}/BinaryCache/RegsGen2
-          msvc-compilers: ${{ inputs.use_host_toolchain && '@("C", "CXX")' || '@()' }}
-          pinned-compilers: ${{ inputs.use_host_toolchain && '@()' || '@("C", "CXX")' }}
+          use-host-toolchain: ${{ inputs.use_host_toolchain }}
+          c-compiler: 'Host.C'
+          cxx-compiler: 'Host.CXX'
           cache-script: ${{ github.workspace }}/SourceCache/ds2/cmake/caches/MSVCWarnings.cmake
-          cmake-defines: |
-            @{
-              'CMAKE_C_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
-              'CMAKE_CXX_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
-            }
       - name: Build RegsGen2
         if: inputs.build_android
         run: cmake --build ${{ github.workspace }}/BinaryCache/RegsGen2 --config Release
@@ -533,6 +537,10 @@ jobs:
           setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        with:
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
 
       - name: Compute workspace hash
         if: inputs.build_android
@@ -603,7 +611,8 @@ jobs:
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          pinned-compilers: '@("C", "CXX")'
+          c-compiler: 'Stage1.GNUC'
+          cxx-compiler: 'Stage1.GNUCXX'
           cmake-defines: |
             @{
               'DS2_REGSGEN2' = "${{ github.workspace }}/BinaryCache/RegsGen2/regsgen2.exe";
@@ -642,6 +651,11 @@ jobs:
           setup-vs-dev-env: true
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        with:
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
+
       - name: Compute workspace hash
         id: workspace_hash
         run: |
@@ -683,15 +697,14 @@ jobs:
           src-dir: ${{ github.workspace }}/SourceCache/cmark-gfm
           bin-dir: ${{ github.workspace }}/BinaryCache/cmark-gfm-${{ inputs.swift_cmark_version }}
           install-dir: ${{ github.workspace }}/BuildRoot/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr
-          msvc-compilers: ${{ inputs.use_host_toolchain && '@("C", "CXX")' || '@()' }}
-          pinned-compilers: ${{ inputs.use_host_toolchain && '@()' || '@("C", "CXX")' }}
+          use-host-toolchain: ${{ inputs.use_host_toolchain }}
+          c-compiler: 'Host.C'
+          cxx-compiler: 'Host.CXX'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";
               'BUILD_TESTING' = "NO";
               'CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP' = "YES";
-              'CMAKE_C_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
-              'CMAKE_CXX_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
             }
       - name: Build cmark-gfm
         run: cmake --build ${{ github.workspace }}/BinaryCache/cmark-gfm-${{ inputs.swift_cmark_version }}
@@ -722,6 +735,11 @@ jobs:
           setup-vs-dev-env: true
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        with:
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
+
       - name: Compute workspace hash
         id: workspace_hash
         run: |
@@ -777,9 +795,11 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
           src-dir: ${{ github.workspace }}/SourceCache/llvm-project/llvm
-          bin-dir: ${{ github.workspace }}/BinaryCache/0
-          msvc-compilers: ${{ inputs.use_host_toolchain && '@("ASM_MASM", "C", "CXX")' || '@()' }}
-          pinned-compilers: ${{ inputs.use_host_toolchain && '@()' || '@("ASM_MASM", "C", "CXX")' }}
+          bin-dir: ${{ github.workspace }}/BinaryCache/BuildTools
+          use-host-toolchain: ${{ inputs.use_host_toolchain }}
+          c-compiler: 'Host.C'
+          cxx-compiler: 'Host.CXX'
+          use-asm-masm: ${{ inputs.use_host_toolchain }}
           cmake-defines: |
             @{
               'CMAKE_CROSSCOMPILING' = "NO";
@@ -809,25 +829,23 @@ jobs:
               'SWIFT_INCLUDE_DOCS' = "NO";
               'SWIFT_INCLUDE_TESTS' = "NO";
               'cmark-gfm_DIR' = "${{ github.workspace }}/BuildRoot/Library/cmark-gfm-${{ inputs.swift_cmark_version }}/usr/lib/cmake";
-              'CMAKE_C_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
-              'CMAKE_CXX_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
             }
       - name: Build llvm-tblgen
-        run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target llvm-tblgen
+        run: cmake --build ${{ github.workspace }}/BinaryCache/BuildTools --target llvm-tblgen
       - name: Build clang-tblgen
-        run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target clang-tblgen
+        run: cmake --build ${{ github.workspace }}/BinaryCache/BuildTools --target clang-tblgen
       - name: Build clang-tidy-confusable-chars-gen
-        run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target clang-tidy-confusable-chars-gen
+        run: cmake --build ${{ github.workspace }}/BinaryCache/BuildTools --target clang-tidy-confusable-chars-gen
       - name: Build lldb-tblgen
-        run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target lldb-tblgen
+        run: cmake --build ${{ github.workspace }}/BinaryCache/BuildTools --target lldb-tblgen
       - name: Build llvm-config
-        run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target llvm-config
+        run: cmake --build ${{ github.workspace }}/BinaryCache/BuildTools --target llvm-config
       - name: Build swift-def-to-strings-converter
-        run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target swift-def-to-strings-converter
+        run: cmake --build ${{ github.workspace }}/BinaryCache/BuildTools --target swift-def-to-strings-converter
       - name: Build swift-serialize-diagnostics
-        run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target swift-serialize-diagnostics
+        run: cmake --build ${{ github.workspace }}/BinaryCache/BuildTools --target swift-serialize-diagnostics
       - name: Build swift-compatibility-symbols
-        run: cmake --build ${{ github.workspace }}/BinaryCache/0 --target swift-compatibility-symbols
+        run: cmake --build ${{ github.workspace }}/BinaryCache/BuildTools --target swift-compatibility-symbols
 
       - name: Copy binaries
         run: |
@@ -846,7 +864,7 @@ jobs:
           # Create the target folder.
           New-Item -ItemType Directory -Path "${{ github.workspace }}/BuildRoot/bin" -Force | Out-Null
           foreach ($Binary in $Binaries) {
-            Copy-Item -Path "${{ github.workspace }}/BinaryCache/0/bin/${Binary}${Suffix}" -Destination "${{ github.workspace }}/BuildRoot/bin/${Binary}${Suffix}" -Force
+            Copy-Item -Path "${{ github.workspace }}/BinaryCache/BuildTools/bin/${Binary}${Suffix}" -Destination "${{ github.workspace }}/BuildRoot/bin/${Binary}${Suffix}" -Force
           }
 
       - uses: thebrowsercompany/gha-upload-tar-artifact@e18c33b1cd416d0d96a91dc6dce06219f98e4e27 # main
@@ -876,6 +894,10 @@ jobs:
           setup-vs-dev-env: true
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        with:
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
 
       - name: Compute workspace hash
         id: workspace_hash
@@ -958,7 +980,9 @@ jobs:
           src-dir: ${{ github.workspace }}/SourceCache/swift-driver
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-driver
           swift-sdk-path: ${{ steps.setup-context.outputs.sdkroot }}
-          pinned-compilers: '@("C", "CXX", "Swift")'
+          c-compiler: 'Pinned.C'
+          cxx-compiler: 'Pinned.CXX'
+          swift-compiler: 'Pinned.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "NO";
@@ -967,8 +991,8 @@ jobs:
               # TODO(compnerd) - remove `-Xfrontend -use-static-resource-dir` - this is inferred by the `-static-stdlib`.
               'CMAKE_Swift_FLAGS' = @("-static-stdlib", "-Xfrontend", "-use-static-resource-dir");
               'SWIFT_DRIVER_BUILD_TOOLS' = "NO";
-              'SQLite3_INCLUDE_DIR' = "${{ github.workspace }}/BinaryCache/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/include";
-              'SQLite3_LIBRARY' = "${{ github.workspace }}/BinaryCache/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/lib/SQLite3.lib";
+              'SQLite3_INCLUDE_DIR' = "${{ github.workspace }}/BinaryCache/Library/stage0-sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/include";
+              'SQLite3_LIBRARY' = "${{ github.workspace }}/BinaryCache/Library/stage0-sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/lib/SQLite3.lib";
             }
 
       - name: Build early swift-driver
@@ -1016,6 +1040,10 @@ jobs:
           setup-vs-dev-env: true
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        with:
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
 
       - name: Compute workspace hash
         id: workspace_hash
@@ -1192,9 +1220,10 @@ jobs:
           src-dir: ${{ github.workspace }}/SourceCache/llvm-project/llvm
           bin-dir: ${{ github.workspace }}/BinaryCache/1
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+${{ matrix.variant }}/usr
-          swift-sdk-path: ${{ steps.setup-context.outputs.sdkroot }}
-          msvc-compilers: ${{ inputs.use_host_toolchain && '@("C", "CXX")' || '@()' }}
-          pinned-compilers: ${{ inputs.use_host_toolchain && '@("Swift")' || '@("C", "CXX", "Swift")' }}
+          use-host-toolchain: ${{ inputs.use_host_toolchain }}
+          c-compiler: 'Host.C'
+          cxx-compiler: 'Host.CXX'
+          swift-compiler: 'Pinned.Swift'
           cache-script: ${{ github.workspace }}/SourceCache/swift/cmake/caches/${{ matrix.os }}-${{ matrix.cpu }}.cmake
           cmake-defines: |
             @{
@@ -1251,9 +1280,6 @@ jobs:
               'LLVM_VERSION_SUFFIX' = "";
               'LLVM_PARALLEL_LINK_JOBS' = "${{ steps.setup-context.outputs.link-jobs }}";
               'SWIFT_PARALLEL_LINK_JOBS' = "${{ steps.setup-context.outputs.link-jobs }}";
-              'CMAKE_C_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
-              'CMAKE_CXX_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
-              'CMAKE_Swift_FLAGS' = "${{ !inputs.use_host_toolchain && '-use-ld=lld' || '' }}";
             }
 
       - name: Build Compiler Distribution
@@ -1375,6 +1401,11 @@ jobs:
           setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        with:
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
+
       - name: Compute workspace hash
         id: workspace_hash
         run: |
@@ -1414,7 +1445,7 @@ jobs:
         with:
           project-name: zlib
           swift-version: ${{ inputs.swift_version }}
-          enable-caching: ${{ inputs.use_host_toolchain }}
+          enable-caching: false
           debug-info: ${{ inputs.debug_info }}
           build-os: ${{ inputs.build_os }}
           build-arch: ${{ inputs.build_arch }}
@@ -1426,13 +1457,12 @@ jobs:
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          msvc-compilers: ${{ inputs.use_host_toolchain && '@("C")' || '@()' }}
-          pinned-compilers: ${{ inputs.use_host_toolchain && '@()' || '@("C")' }}
+          c-compiler: ${{ matrix.os == 'Windows' && 'Stage1.C' || 'Stage1.GNUC' }}
+          cxx-compiler: ${{ matrix.os == 'Windows' && 'Stage1.CXX' || 'Stage1.GNUCXX' }}
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "NO";
               'CMAKE_POSITION_INDEPENDENT_CODE' = "YES";
-              'CMAKE_C_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
             }
       - name: Build zlib
         run: cmake --build ${{ github.workspace }}/BinaryCache/zlib-${{ inputs.zlib_version }}
@@ -1459,12 +1489,16 @@ jobs:
           ref: ${{ inputs.ci_build_revision }}
           path: ${{ github.workspace }}/SourceCache/ci-build
           show-progress: false
-
       - uses: ./SourceCache/ci-build/.github/actions/setup-build
         with:
           setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        with:
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
+
       - name: Compute workspace hash
         id: workspace_hash
         run: |
@@ -1504,7 +1538,7 @@ jobs:
         with:
           project-name: brotli
           swift-version: ${{ inputs.swift_version }}
-          enable-caching: ${{ inputs.use_host_toolchain }}
+          enable-caching: false
           debug-info: ${{ inputs.debug_info }}
           build-os: ${{ inputs.build_os }}
           build-arch: ${{ inputs.build_arch }}
@@ -1516,13 +1550,11 @@ jobs:
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          msvc-compilers: ${{ inputs.use_host_toolchain && '@("C")' || '@()' }}
-          pinned-compilers: ${{ inputs.use_host_toolchain && '@()' || '@("C")' }}
+          c-compiler: ${{ matrix.os == 'Windows' && 'Stage1.C' || 'Stage1.GNUC' }}
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "NO";
               'CMAKE_POSITION_INDEPENDENT_CODE' = "YES";
-              'CMAKE_C_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
             }
       - name: Build brotli
         run: cmake --build ${{ github.workspace }}/BinaryCache/brotli-${{ inputs.brotli_version }}
@@ -1556,6 +1588,11 @@ jobs:
           setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        with:
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
+
       - name: Compute workspace hash
         id: workspace_hash
         run: |
@@ -1617,8 +1654,7 @@ jobs:
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          msvc-compilers: ${{ inputs.use_host_toolchain && '@("C")' || '@()' }}
-          pinned-compilers: ${{ inputs.use_host_toolchain && '@()' || '@("C")' }}
+          c-compiler: ${{ matrix.os == 'Windows' && 'Stage1.C' || 'Stage1.GNUC' }}
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "NO";
@@ -1711,7 +1747,6 @@ jobs:
               'USE_WIN32_LDAP' = "NO";
               'ZLIB_ROOT' = "${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr";
               'ZLIB_LIBRARY' = "${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr/lib/zlibstatic.lib";
-              'CMAKE_C_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
             }
       - name: Build curl
         run: cmake --build ${{ github.workspace }}/BinaryCache/curl-${{ inputs.curl_version }}
@@ -1743,6 +1778,11 @@ jobs:
           setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        with:
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
+
       - name: Compute workspace hash
         id: workspace_hash
         shell: pwsh
@@ -1784,7 +1824,7 @@ jobs:
         with:
           project-name: libxml2
           swift-version: ${{ inputs.swift_version }}
-          enable-caching: ${{ inputs.use_host_toolchain }}
+          enable-caching: false
           debug-info: ${{ inputs.debug_info }}
           build-os: ${{ inputs.build_os }}
           build-arch: ${{ inputs.build_arch }}
@@ -1796,8 +1836,8 @@ jobs:
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          msvc-compilers: ${{ inputs.use_host_toolchain && '@("C", "CXX")' || '@()' }}
-          pinned-compilers: ${{ inputs.use_host_toolchain && '@()' || '@("C", "CXX")' }}
+          c-compiler: ${{ matrix.os == 'Windows' && 'Stage1.C' || 'Stage1.GNUC' }}
+          cxx-compiler: ${{ matrix.os == 'Windows' && 'Stage1.CXX' || 'Stage1.GNUCXX' }}
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "NO";
@@ -1809,8 +1849,6 @@ jobs:
               'LIBXML2_WITH_TESTS' = "NO";
               'LIBXML2_WITH_THREADS' = "YES";
               'LIBXML2_WITH_ZLIB' = "NO";
-              'CMAKE_C_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
-              'CMAKE_CXX_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
             }
       - name: Build libxml2
         run: cmake --build ${{ github.workspace }}/BinaryCache/libxml2-${{ inputs.libxml2_version }}
@@ -1844,6 +1882,11 @@ jobs:
           setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        with:
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
+
       - name: Compute workspace hash
         if: matrix.os != 'Android' || inputs.build_android
         id: workspace_hash
@@ -1929,13 +1972,14 @@ jobs:
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
+          c-compiler: 'Stage1.C'
+          cxx-compiler: 'Stage1.CXX'
+          swift-compiler: 'Stage1.Swift'
           msvc-compilers: ${{ inputs.use_host_toolchain && '@("C", "CXX")' || '@()' }}
           pinned-compilers: ${{ inputs.use_host_toolchain && '@()' || '@("C", "CXX")' }}
           cmake-defines: |
             @{
               'LLVM_HOST_TRIPLE' = "${{ matrix.triple }}";
-              'CMAKE_C_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
-              'CMAKE_CXX_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
              }
 
       # build.ps1: Build-Runtime
@@ -1957,7 +2001,9 @@ jobs:
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          built-compilers: '@("C", "CXX", "Swift")'
+          c-compiler: 'Stage1.C'
+          cxx-compiler: 'Stage1.CXX'
+          swift-compiler: 'Stage1.Swift'
           cache-script: ${{ github.workspace }}/SourceCache/swift/cmake/caches/Runtime-${{ matrix.os }}-${{ matrix.cpu }}.cmake
           cmake-defines: |
             @{
@@ -2056,10 +2102,10 @@ jobs:
         with:
           setup-vs-dev-env: true
           host-arch: ${{ matrix.arch }}
-      # FIXME(compnerd): workaround CMake 3.30+ issue
-      - uses: lukka/get-cmake@aa1df13cce8c30d2cb58efa871271c5a764623f8 # main
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
         with:
-          cmakeVersion: 3.29.9
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
 
       - name: Download Compilers
         uses: thebrowsercompany/gha-download-tar-artifact@59992d91335d4ecba543c8535f7d07238e42125d # main
@@ -2125,7 +2171,7 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-foundation-macros
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("Swift")'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'SwiftSyntax_DIR' = "${{ github.workspace }}/BinaryCache/swift-syntax/cmake/modules";
@@ -2150,7 +2196,7 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-testing-macros
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("Swift")'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'SwiftSyntax_DIR' = "${{ github.workspace }}/BinaryCache/swift-syntax/cmake/modules";
@@ -2266,10 +2312,10 @@ jobs:
         with:
           setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
           host-arch: ${{ matrix.arch }}
-      # FIXME(compnerd): workaround CMake 3.30+ issue
-      - uses: lukka/get-cmake@aa1df13cce8c30d2cb58efa871271c5a764623f8 # main
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
         with:
-          cmakeVersion: 3.29.9
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
 
       - uses: actions/setup-python@v5
         with:
@@ -2433,7 +2479,8 @@ jobs:
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          built-compilers: '@("C", "CXX")'
+          c-compiler: ${{ matrix.os == 'Windows' && 'Stage1.C' || 'Stage1.GNUC' }}
+          cxx-compiler: ${{ matrix.os == 'Windows' && 'Stage1.CXX' || 'Stage1.GNUCXX' }}
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";
@@ -2445,12 +2492,12 @@ jobs:
         run: |
           cmake --build ${{ github.workspace }}/BinaryCache/libdispatch-c
 
-      # build.ps1: Build-ExperimentalRuntime
-      - name: Configure Experimental Runtime
+      # build.ps1: Build-SDK
+      - name: Configure Runtime
         if: matrix.os != 'Android' || inputs.build_android
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
-          project-name: ExperimentalRuntime
+          project-name: Runtime
           swift-version: ${{ inputs.swift_version }}
           enable-caching: ${{ inputs.use_host_toolchain }}
           debug-info: ${{ inputs.debug_info }}
@@ -2459,15 +2506,18 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
           src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Core
-          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalRuntime 
-          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          bin-dir: ${{ github.workspace }}/BinaryCache/Runtime 
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          built-compilers: '@("C", "CXX", "Swift")'
-          use-gnu-driver: true
+          c-compiler: 'Stage1.GNUC'
+          cxx-compiler: 'Stage1.GNUCXX'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
+              'SWIFT_PUBLIC_KEY_TOKEN' = "0000000000000000";
+              'SWIFT_ASSEMBLY_VERSION' = "${{ inputs.swift_version }}";
               'BUILD_SHARED_LIBS' = "${{ matrix.static && 'NO' || 'YES' }}";
               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
               'dispatch_DIR' = "${{ github.workspace }}/BinaryCache/libdispatch-c/cmake/modules";
@@ -2484,21 +2534,21 @@ jobs:
               # this should be enabled when building the dynamic runtime.
               'SwiftCore_ENABLE_LIBRARY_EVOLUTION' = "NO";
             }
-      - name: Build Experimental Runtime
+      - name: Build Runtime
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalRuntime
-      - name: Install Experimental Runtime
+          cmake --build ${{ github.workspace }}/BinaryCache/Runtime
+      - name: Install Runtime
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalRuntime --target install
+          cmake --build ${{ github.workspace }}/BinaryCache/Runtime --target install
 
-      # build.ps1: Build-ExperimentalRuntime
-      - name: Configure Experimental Overlay
+      # build.ps1: Build-SDK
+      - name: Configure Overlay
         if: matrix.os != 'Android' || inputs.build_android
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
-          project-name: ExperimentalOverlay
+          project-name: Overlay
           swift-version: ${{ inputs.swift_version }}
           enable-caching: ${{ inputs.use_host_toolchain }}
           debug-info: ${{ inputs.debug_info }}
@@ -2507,38 +2557,41 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
           src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Overlay
-          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalOverlay
-          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          bin-dir: ${{ github.workspace }}/BinaryCache/Overlay
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          built-compilers: '@("C", "CXX", "Swift")'
-          use-gnu-driver: true
+          c-compiler: 'Stage1.GNUC'
+          cxx-compiler: 'Stage1.GNUCXX'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
+              'SWIFT_PUBLIC_KEY_TOKEN' = "0000000000000000";
+              'SWIFT_ASSEMBLY_VERSION' = "${{ inputs.swift_version }}";
               'BUILD_SHARED_LIBS' = "${{ matrix.static && 'NO' || 'YES' }}";
               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
-              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
+              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/Runtime/cmake/SwiftCore";
               # FIXME(compnerd) this currently causes a build failure on Windows, but
               # this should be enabled when building the dynamic runtime.
               'SwiftOverlay_ENABLE_LIBRARY_EVOLUTION' = "NO";
               'SwiftOverlay_ENABLE_CXX_INTEROP' = "YES";
             }
-      - name: Build Experimental Overlay
+      - name: Build Overlay
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalOverlay
-      - name: Install Experimental Overlay
+          cmake --build ${{ github.workspace }}/BinaryCache/Overlay
+      - name: Install Overlay
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalOverlay --target install
+          cmake --build ${{ github.workspace }}/BinaryCache/Overlay --target install
 
-      # build.ps1: Build-ExperimentalRuntime
-      - name: Configure Experimental String Processing
+      # build.ps1: Build-SDK
+      - name: Configure String Processing
         if: matrix.os != 'Android' || inputs.build_android
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
-          project-name: ExperimentalStringProcessing
+          project-name: StringProcessing
           swift-version: ${{ inputs.swift_version }}
           enable-caching: ${{ inputs.use_host_toolchain }}
           debug-info: ${{ inputs.debug_info }}
@@ -2547,37 +2600,40 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
           src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/StringProcessing
-          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalStringProcessing
-          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          bin-dir: ${{ github.workspace }}/BinaryCache/StringProcessing
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          built-compilers: '@("C", "Swift")'
-          use-gnu-driver: true
+          c-compiler: 'Stage1.GNUC'
+          cxx-compiler: 'Stage1.GNUCXX'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
+              'SWIFT_PUBLIC_KEY_TOKEN' = "0000000000000000";
+              'SWIFT_ASSEMBLY_VERSION' = "${{ inputs.swift_version }}";
               'BUILD_SHARED_LIBS' = "${{ matrix.static && 'NO' || 'YES' }}";
               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
-              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
+              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/Runtime/cmake/SwiftCore";
               # FIXME(compnerd) this currently causes a build failure on Windows, but
               # this should be enabled when building the dynamic runtime.
               'SwiftStringProcessing_ENABLE_LIBRARY_EVOLUTION' = "NO";
             }
-      - name: Build Experimental String Processing
+      - name: Build String Processing
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalStringProcessing
-      - name: Install Experimental String Processing
+          cmake --build ${{ github.workspace }}/BinaryCache/StringProcessing
+      - name: Install String Processing
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalStringProcessing --target install
+          cmake --build ${{ github.workspace }}/BinaryCache/StringProcessing --target install
 
-      # build.ps1: Build-ExperimentalRuntime
-      - name: Configure Experimental Synchronization
+      # build.ps1: Build-SDK
+      - name: Configure Synchronization
         if: matrix.os != 'Android' || inputs.build_android
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
-          project-name: ExperimentalSynchronization
+          project-name: Synchronization
           swift-version: ${{ inputs.swift_version }}
           enable-caching: ${{ inputs.use_host_toolchain }}
           debug-info: ${{ inputs.debug_info }}
@@ -2586,38 +2642,40 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
           src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/Synchronization
-          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalSynchronization
-          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          bin-dir: ${{ github.workspace }}/BinaryCache/Synchronization
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          built-compilers: '@("C", "Swift")'
-          use-gnu-driver: true
+          c-compiler: 'Stage1.GNUC'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
+              'SWIFT_PUBLIC_KEY_TOKEN' = "0000000000000000";
+              'SWIFT_ASSEMBLY_VERSION' = "${{ inputs.swift_version }}";
               'BUILD_SHARED_LIBS' = "${{ matrix.static && 'NO' || 'YES' }}";
               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
-              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
-              'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay";
+              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/Runtime/cmake/SwiftCore";
+              'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/Overlay/cmake/SwiftOverlay";
               # FIXME(compnerd) this currently causes a build failure on Windows, but
               # this should be enabled when building the dynamic runtime.
               'SwiftSynchronization_ENABLE_LIBRARY_EVOLUTION' = "NO";
             }
-      - name: Build Experimental Synchronization
+      - name: Build Synchronization
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalSynchronization
-      - name: Install Experimental Synchronization
+          cmake --build ${{ github.workspace }}/BinaryCache/Synchronization
+      - name: Install Synchronization
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalSynchronization --target install
+          cmake --build ${{ github.workspace }}/BinaryCache/Synchronization --target install
 
-      # build.ps1: Build-ExperimentalRuntime
-      - name: Configure Experimental Distributed
+      # build.ps1: Build-SDK
+      - name: Configure Distributed
         if: matrix.os != 'Android' || inputs.build_android
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
-          project-name: ExperimentalDistributed
+          project-name: Distributed
           swift-version: ${{ inputs.swift_version }}
           enable-caching: ${{ inputs.use_host_toolchain }}
           debug-info: ${{ inputs.debug_info }}
@@ -2626,39 +2684,42 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
           src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/Distributed 
-          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalDistributed
-          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          bin-dir: ${{ github.workspace }}/BinaryCache/Distributed
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          built-compilers: '@("C", "CXX", "Swift")'
-          use-gnu-driver: true
+          c-compiler: 'Stage1.GNUC'
+          cxx-compiler: 'Stage1.GNUCXX'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
+              'SWIFT_PUBLIC_KEY_TOKEN' = "0000000000000000";
+              'SWIFT_ASSEMBLY_VERSION' = "${{ inputs.swift_version }}";
               'BUILD_SHARED_LIBS' = "${{ matrix.static && 'NO' || 'YES' }}";
-              'CMAKE_CXX_FLAGS' = "-I${{ github.workspace }}/BinaryCache/ExperimentalRuntime/include";
+              'CMAKE_CXX_FLAGS' = "-I${{ github.workspace }}/BinaryCache/Runtime/include";
               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
-              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
-              'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay";
+              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/Runtime/cmake/SwiftCore";
+              'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/Overlay/cmake/SwiftOverlay";
               # FIXME(compnerd) this currently causes a build failure on Windows, but
               # this should be enabled when building the dynamic runtime.
               'SwiftDistributed_ENABLE_LIBRARY_EVOLUTION' = "NO";
             }
-      - name: Build Experimental Distributed
+      - name: Build Distributed
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalDistributed
-      - name: Install Experimental Distributed
+          cmake --build ${{ github.workspace }}/BinaryCache/Distributed
+      - name: Install Distributed
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalDistributed --target install
+          cmake --build ${{ github.workspace }}/BinaryCache/Distributed --target install
 
-      # build.ps1: Build-ExperimentalRuntime
-      - name: Configure Experimental Observation
+      # build.ps1: Build-SDK
+      - name: Configure Observation
         if: matrix.os != 'Android' || inputs.build_android
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
-          project-name: ExperimentalObservation
+          project-name: Observation
           swift-version: ${{ inputs.swift_version }}
           enable-caching: ${{ inputs.use_host_toolchain }}
           debug-info: ${{ inputs.debug_info }}
@@ -2667,40 +2728,42 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
           src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/Observation
-          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalObservation
-          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          bin-dir: ${{ github.workspace }}/BinaryCache/Observation
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          built-compilers: '@("CXX", "Swift")'
-          use-gnu-driver: true
+          cxx-compiler: 'Stage1.GNUCXX'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
+              'SWIFT_PUBLIC_KEY_TOKEN' = "0000000000000000";
+              'SWIFT_ASSEMBLY_VERSION' = "${{ inputs.swift_version }}";
               'BUILD_SHARED_LIBS' = "${{ matrix.static && 'NO' || 'YES' }}";
                # FIXME(#83449): avoid using `SwiftCMakeConfig.h`
-              'CMAKE_CXX_FLAGS' = "-I${{ github.workspace }}/BinaryCache/ExperimentalRuntime/include"
+              'CMAKE_CXX_FLAGS' = "-I${{ github.workspace }}/BinaryCache/Runtime/include"
               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
-              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
-              'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay";
+              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/Runtime/cmake/SwiftCore";
+              'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/Overlay/cmake/SwiftOverlay";
               # FIXME(compnerd) this currently causes a build failure on Windows, but
               # this should be enabled when building the dynamic runtime.
               'SwiftObservation_ENABLE_LIBRARY_EVOLUTION' = "NO";
             }
-      - name: Build Experimental Observation
+      - name: Build Observation
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalObservation
-      - name: Install Experimental Observation
+          cmake --build ${{ github.workspace }}/BinaryCache/Observation
+      - name: Install Observation
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalObservation --target install
+          cmake --build ${{ github.workspace }}/BinaryCache/Observation --target install
 
-      # build.ps1: Build-ExperimentalRuntime
-      - name: Configure Experimental Differentiation
+      # build.ps1: Build-SDK
+      - name: Configure Differentiation
         if: matrix.os != 'Android' || inputs.build_android
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
-          project-name: ExperimentalDifferentiation
+          project-name: Differentiation
           swift-version: ${{ inputs.swift_version }}
           enable-caching: ${{ inputs.use_host_toolchain }}
           debug-info: ${{ inputs.debug_info }}
@@ -2709,38 +2772,41 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
           src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/Differentiation
-          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalDifferentiation
-          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          bin-dir: ${{ github.workspace }}/BinaryCache/Differentiation
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          built-compilers: '@("C", "CXX", "Swift")'
-          use-gnu-driver: true
+          c-compiler: 'Stage1.GNUC'
+          cxx-compiler: 'Stage1.GNUCXX'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
+              'SWIFT_PUBLIC_KEY_TOKEN' = "0000000000000000";
+              'SWIFT_ASSEMBLY_VERSION' = "${{ inputs.swift_version }}";
               'BUILD_SHARED_LIBS' = "${{ matrix.static && 'NO' || 'YES' }}";
               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
-              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
-              'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay";
+              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/Runtime/cmake/SwiftCore";
+              'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/Overlay/cmake/SwiftOverlay";
               # FIXME(compnerd) this currently causes a build failure on Windows, but
               # this should be enabled when building the dynamic runtime.
               'SwiftDifferentiation_ENABLE_LIBRARY_EVOLUTION' = "NO";
             }
-      - name: Build Experimental Differentiation
+      - name: Build Differentiation
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalDifferentiation
-      - name: Install Experimental Differentiation
+          cmake --build ${{ github.workspace }}/BinaryCache/Differentiation
+      - name: Install Differentiation
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalDifferentiation --target install
+          cmake --build ${{ github.workspace }}/BinaryCache/Differentiation --target install
 
-      # build.ps1: Build-ExperimentalRuntime
-      - name: Configure Experimental Volatile
+      # build.ps1: Build-SDK
+      - name: Configure Volatile
         if: matrix.os != 'Android' || inputs.build_android
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
-          project-name: ExperimentalVolatile
+          project-name: Volatile
           swift-version: ${{ inputs.swift_version }}
           enable-caching: ${{ inputs.use_host_toolchain }}
           debug-info: ${{ inputs.debug_info }}
@@ -2749,39 +2815,42 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
           src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/Volatile
-          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalVolatile
-          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          bin-dir: ${{ github.workspace }}/BinaryCache/Volatile
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          built-compilers: '@("C", "Swift")'
-          use-gnu-driver: true
+          c-compiler: 'Stage1.GNUC'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
+              'SWIFT_PUBLIC_KEY_TOKEN' = "0000000000000000";
+              'SWIFT_ASSEMBLY_VERSION' = "${{ inputs.swift_version }}";
               'BUILD_SHARED_LIBS' = "${{ matrix.static && 'NO' || 'YES' }}";
               'CMAKE_FIND_PACKAGE_PREFER_CONFIG' = "YES";
               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
-              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
-              'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay";
+              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/Runtime/cmake/SwiftCore";
+              'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/Overlay/cmake/SwiftOverlay";
               # FIXME(compnerd) this currently causes a build failure on Windows, but
               # this should be enabled when building the dynamic runtime.
               'SwiftVolatile_ENABLE_LIBRARY_EVOLUTION' = "NO";
             }
-      - name: Build Experimental Volatile
+      - name: Build Volatile
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalVolatile
-      - name: Install Experimental Volatile
+          cmake --build ${{ github.workspace }}/BinaryCache/Volatile
+      - name: Install Volatile
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalVolatile --target install
+          cmake --build ${{ github.workspace }}/BinaryCache/Volatile --target install
 
-      # build.ps1: Build-ExperimentalRuntime
-      - name: Configure Experimental RuntimeModule
+
+      # build.ps1: Build-SDK
+      - name: Configure RuntimeModule
         if: matrix.os != 'Android' # Disabled for Android https://github.com/swiftlang/swift/issues/87445
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
-          project-name: ExperimentalRuntimeModule
+          project-name: RuntimeModule
           swift-version: ${{ inputs.swift_version }}
           enable-caching: ${{ inputs.use_host_toolchain }}
           debug-info: ${{ inputs.debug_info }}
@@ -2790,44 +2859,47 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
           src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/Runtime
-          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalRuntimeModule
-          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          bin-dir: ${{ github.workspace }}/BinaryCache/RuntimeModule
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          built-compilers: '@("C", "CXX", "Swift")'
-          use-gnu-driver: true
+          c-compiler: 'Stage1.GNUC'
+          cxx-compiler: 'Stage1.GNUCXX'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
+              'SWIFT_PUBLIC_KEY_TOKEN' = "0000000000000000";
+              'SWIFT_ASSEMBLY_VERSION' = "${{ inputs.swift_version }}";
               'BUILD_SHARED_LIBS' = "${{ matrix.static && 'NO' || 'YES' }}";
               'CMAKE_FIND_PACKAGE_PREFER_CONFIG' = "YES";
               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
-              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
-              'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay";
-              'SwiftCxxOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/Cxx/cmake/SwiftCxxOverlay";
+              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/Runtime/cmake/SwiftCore";
+              'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/Overlay/cmake/SwiftOverlay";
+              'SwiftCxxOverlay_DIR' = "${{ github.workspace }}/BinaryCache/Overlay/Cxx/cmake/SwiftCxxOverlay";
               # FIXME(compnerd) this currently causes a build failure on Windows, but
               # this should be enabled when building the dynamic runtime.
-              'SwiftVolatile_ENABLE_LIBRARY_EVOLUTION' = "NO";
+              'SwiftRuntime_ENABLE_LIBRARY_EVOLUTION' = "NO";
               'SwiftRuntime_ENABLE_BACKTRACING' = "YES";
             }
-      - name: Build Experimental RuntimeModule
+      - name: Build RuntimeModule
         if: matrix.os != 'Android' # Disabled for Android https://github.com/swiftlang/swift/issues/87445
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalRuntimeModule
-      - name: Install Experimental RuntimeModule
+          cmake --build ${{ github.workspace }}/BinaryCache/RuntimeModule
+      - name: Install RuntimeModule
         if: matrix.os != 'Android' # Disabled for Android https://github.com/swiftlang/swift/issues/87445
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalRuntimeModule --target install
+          cmake --build ${{ github.workspace }}/BinaryCache/RuntimeModule --target install
 
-      # build.ps1: Build-ExperimentalRuntime
-      - name: Configure Experimental Backtrace
+      # build.ps1: Build-SDK
+      - name: Configure Backtrace
         # NOTE: we only build this if static variants are enabled to ensure that we
         # can statically link the runtime.
         # Disabled for Windows x86 https://github.com/swiftlang/swift/issues/87499
         if: matrix.static && matrix.os == 'Windows' && matrix.arch != 'x86'
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
-          project-name: ExperimentalRuntimeBacktrace
+          project-name: RuntimeBacktrace
           swift-version: ${{ inputs.swift_version }}
           enable-caching: ${{ inputs.use_host_toolchain }}
           debug-info: ${{ inputs.debug_info }}
@@ -2836,42 +2908,44 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
           src-dir: ${{ github.workspace }}/SourceCache/swift/Runtimes/Supplemental/StackWalker
-          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalRuntimeBacktrace
-          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          bin-dir: ${{ github.workspace }}/BinaryCache/RuntimeBacktrace
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          built-compilers: '@("CXX", "Swift")'
-          use-gnu-driver: true
+          cxx-compiler: 'Stage1.GNUCXX'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
+              'SWIFT_PUBLIC_KEY_TOKEN' = "0000000000000000";
+              'SWIFT_ASSEMBLY_VERSION' = "${{ inputs.swift_version }}";
               'CMAKE_Swift_FLAGS' = @("-static-stdlib");
-              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntime/cmake/SwiftCore";
-              'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/cmake/SwiftOverlay";
-              'SwiftCxxOverlay_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalOverlay/Cxx/cmake/SwiftCxxOverlay";
-              'SwiftRuntime_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalRuntimeModule/cmake/SwiftRuntime";
+              'SwiftCore_DIR' = "${{ github.workspace }}/BinaryCache/Runtime/cmake/SwiftCore";
+              'SwiftOverlay_DIR' = "${{ github.workspace }}/BinaryCache/Overlay/cmake/SwiftOverlay";
+              'SwiftCxxOverlay_DIR' = "${{ github.workspace }}/BinaryCache/Overlay/Cxx/cmake/SwiftCxxOverlay";
+              'SwiftRuntime_DIR' = "${{ github.workspace }}/BinaryCache/RuntimeModule/cmake/SwiftRuntime";
             }
-      - name: Build Experimental Runtime Backtrace
+      - name: Build Runtime Backtrace
         # NOTE: we only build this if static variants are enabled to ensure that we
         # can statically link the runtime.
         # Disabled for Windows x86 https://github.com/swiftlang/swift/issues/87499
         if: matrix.static && matrix.os == 'Windows' && matrix.arch != 'x86'
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalRuntimeBacktrace
-      - name: Install Experimental Runtime Backtrace
+          cmake --build ${{ github.workspace }}/BinaryCache/RuntimeBacktrace
+      - name: Install Runtime Backtrace
         # NOTE: we only build this if static variants are enabled to ensure that we
         # can statically link the runtime.
         # Disabled for Windows x86 https://github.com/swiftlang/swift/issues/87499
         if: matrix.static && matrix.os == 'Windows' && matrix.arch != 'x86'
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalRuntimeBacktrace --target install
+          cmake --build ${{ github.workspace }}/BinaryCache/RuntimeBacktrace --target install
 
-      # build.ps1: Build-ExperimentalSDK
-      - name: Configure Experimental Dispatch
+      # build.ps1: Build-SDK
+      - name: Configure Dispatch
         if: matrix.os != 'Android' || inputs.build_android
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
-          project-name: ExperimentalDispatch
+          project-name: Dispatch
           swift-version: ${{ inputs.swift_version }}
           enable-caching: ${{ inputs.use_host_toolchain }}
           debug-info: ${{ inputs.debug_info }}
@@ -2880,35 +2954,40 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
           src-dir: ${{ github.workspace }}/SourceCache/swift-corelibs-libdispatch
-          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalDispatch
-          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          bin-dir: ${{ github.workspace }}/BinaryCache/Dispatch
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          built-compilers: '@("C", "CXX", "Swift")'
-          swift-sdk-path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk
+          c-compiler: 'Stage1.GNUC'
+          cxx-compiler: 'Stage1.GNUCXX'
+          swift-compiler: 'Stage1.Swift'
+          swift-sdk-path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
           cmake-defines: |
             @{
                'BUILD_SHARED_LIBS' = "${{ matrix.static && 'NO' || 'YES' }}";
+               'BUILD_TESTING' = "NO";
+               'CMAKE_FIND_PACKAGE_PREFER_CONFIG' = "YES";
                'CMAKE_Swift_FLAGS' = ${{ matrix.static && '@("-static-stdlib", "-Xfrontend", "-use-static-resource-dir")' || '@()' }};
                'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
                'ENABLE_SWIFT' = "YES";
+               'dispatch_INSTALL_ARCH_SUBDIR' = "YES";
               }
-      - name: Build Experimental Dispatch
+      - name: Build Dispatch
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalDispatch
-      - name: Install Experimental Dispatch
+          cmake --build ${{ github.workspace }}/BinaryCache/Dispatch
+      - name: Install Dispatch
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalDispatch --target install
+          cmake --build ${{ github.workspace }}/BinaryCache/Dispatch --target install
 
-      # build.ps1: Build-ExperimentalSDK
-      - name: Configure Experimental Foundation
+      # build.ps1: Build-SDK
+      - name: Configure Foundation
         if: matrix.os != 'Android' || inputs.build_android
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
-          project-name: ExperimentalFoundation
+          project-name: Foundation
           swift-version: ${{ inputs.swift_version }}
           enable-caching: ${{ inputs.use_host_toolchain }}
           debug-info: ${{ inputs.debug_info }}
@@ -2917,13 +2996,15 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
           src-dir: ${{ github.workspace }}/SourceCache/swift-corelibs-foundation
-          bin-dir: ${{ github.workspace }}/BinaryCache/ExperimentalFoundation
-          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk/usr
+          bin-dir: ${{ github.workspace }}/BinaryCache/Foundation
+          install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk/usr
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          built-compilers: '@("ASM","C", "CXX", "Swift")'
-          swift-sdk-path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}Experimental.sdk
+          c-compiler: 'Stage1.GNUC'
+          cxx-compiler: 'Stage1.GNUCXX'
+          swift-compiler: 'Stage1.Swift'
+          swift-sdk-path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "${{ matrix.static && 'NO' || 'YES' }}";
@@ -2933,23 +3014,27 @@ jobs:
               'ENABLE_TESTING' = "NO";
               'FOUNDATION_BUILD_TOOLS' = "${{ matrix.static && matrix.os == 'Windows' && 'YES' || 'NO' }}";
               'CURL_DIR' = "${{ github.workspace }}/BuildRoot/Library/curl-${{ inputs.curl_version }}/usr/lib/cmake/CURL";
+              'BROTLI_INCLUDE_DIR' = "${{ github.workspace }}/BuildRoot/Library/brotli-${{ inputs.brotli_version }}/usr/include";
+              'BROTLICOMMON_LIBRARY' = "${{ github.workspace }}/BuildRoot/Library/brotli-${{ inputs.brotli_version }}/usr/lib/$(if ("${{ matrix.os }}" -eq "Windows") { "brotlicommon.lib" } else { "libbrotlicommon.a" })";
+              'BROTLIDEC_LIBRARY' = "${{ github.workspace }}/BuildRoot/Library/brotli-${{ inputs.brotli_version }}/usr/lib/$(if ("${{ matrix.os }}" -eq "Windows") { "brotlidec.lib" } else { "libbrotlidec.a" })";
               'LibXml2_DIR' = "${{ github.workspace }}/BuildRoot/Library/libxml2-${{ inputs.libxml2_version }}/usr/lib/cmake/libxml2-${{ inputs.libxml2_version }}";
               'ZLIB_INCLUDE_DIR' = "${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr/include";
               'ZLIB_LIBRARY' = "${{ github.workspace }}/BuildRoot/Library/zlib-${{ inputs.zlib_version }}/usr/lib/${{ matrix.os == 'Windows' && 'zlibstatic.lib' || 'libz.a' }}";
-              'dispatch_DIR' = "${{ github.workspace }}/BinaryCache/ExperimentalDispatch/cmake/modules";
+              'dispatch_DIR' = "${{ github.workspace }}/BinaryCache/Dispatch/cmake/modules";
               '_SwiftFoundation_SourceDIR' = "${{ github.workspace }}/SourceCache/swift-foundation";
               '_SwiftFoundationICU_SourceDIR' = "${{ github.workspace }}/SourceCache/swift-foundation-icu";
               '_SwiftCollections_SourceDIR' = "${{ github.workspace }}/SourceCache/swift-collections";
               'SwiftFoundation_MACRO' = "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin";
             }
-      - name: Build Experimental Foundation
+      - name: Build Foundation
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalFoundation
-      - name: Install Experimental Foundation
+          cmake --build ${{ github.workspace }}/BinaryCache/Foundation
+      - name: Install Foundation
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/ExperimentalFoundation --target install
+          cmake --build ${{ github.workspace }}/BinaryCache/Foundation --target install
+
 
       - uses: actions/setup-python@v5
       - uses: jannekem/run-python-script-action@v1
@@ -3089,6 +3174,10 @@ jobs:
           setup-vs-dev-env: ${{ matrix.os == 'Windows' }}
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        with:
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
 
       - name: Compute workspace hash
         id: workspace_hash
@@ -3243,7 +3332,9 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("C", "CXX", "Swift")'
+          c-compiler: 'Stage1.GNUC'
+          cxx-compiler: 'Stage1.GNUCXX'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'ENABLE_SWIFT' = "YES";
@@ -3273,7 +3364,9 @@ jobs:
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("C", "CXX", "Swift")'
+          c-compiler: 'Stage1.GNUC'
+          cxx-compiler: 'Stage1.GNUCXX'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";
@@ -3317,27 +3410,26 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
           src-dir: ${{ github.workspace }}/SourceCache/swift-testing
-          bin-dir: ${{ github.workspace }}/BinaryCache/testing
+          bin-dir: ${{ github.workspace }}/BinaryCache/Testing
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/Testing-${{ inputs.swift_version }}/usr
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("CXX", "Swift")'
+          cxx-compiler: 'Stage1.GNUCXX'
+          swift-compiler: 'Stage1.Swift'
+          swift-sdk-path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";
-              'CMAKE_INSTALL_BINDIR' = "${{ matrix.bindir }}";
+              'CMAKE_INSTALL_BINDIR' = "${{ (matrix.arch == 'amd64' || matrix.arch == 'x86_64') && 'bin64' || matrix.arch == 'arm64' && 'bin64a' || matrix.arch == 'armv7' && 'bin32a' || 'bin32' }}";
+              'CMAKE_Swift_FLAGS' = ${{ (matrix.os == 'Android') && format('@("-I{0}/BuildRoot/Library/Developer/Platforms/{1}.platform/Developer/SDKs/{1}.sdk/usr/include")', github.workspace, matrix.os) || '@()' }};
               'SwiftTesting_MACRO' = "${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/TestingMacros.dll";
               'SwiftTesting_INSTALL_NESTED_SUBDIR' = "YES";
-              # build.ps1: These are not passed in the original script, but are necessary on GHA.
-              'dispatch_DIR' = "${{ github.workspace }}/BinaryCache/libdispatch/cmake/modules";
-              'Foundation_DIR' = "${{ github.workspace }}/BinaryCache/foundation/cmake/modules";
             }
       - name: Build Testing
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/testing
+          cmake --build ${{ github.workspace }}/BinaryCache/Testing
 
       # build.ps1: Build-XCTest
       # TODO(compnerd) correctly version XCTest
@@ -3354,36 +3446,35 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
           src-dir: ${{ github.workspace }}/SourceCache/swift-corelibs-xctest
-          bin-dir: ${{ github.workspace }}/BinaryCache/xctest
+          bin-dir: ${{ github.workspace }}/BinaryCache/XCTest
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/Library/XCTest-${{ inputs.swift_version }}/usr
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("Swift")'
+          swift-compiler: 'Stage1.Swift'
+          swift-sdk-path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";
-              'CMAKE_INSTALL_BINDIR' = "${{ matrix.bindir }}";
+              'CMAKE_INSTALL_BINDIR' = "${{ (matrix.arch == 'amd64' || matrix.arch == 'x86_64') && 'bin64' || matrix.arch == 'arm64' && 'bin64a' || matrix.arch == 'armv7' && 'bin32a' || 'bin32' }}";
+              'CMAKE_Swift_FLAGS' = ${{ (matrix.os == 'Android') && format('@("-I{0}/BuildRoot/Library/Developer/Platforms/{1}.platform/Developer/SDKs/{1}.sdk/usr/include")', github.workspace, matrix.os) || '@()' }};
               'ENABLE_TESTING' = "NO";
-              'dispatch_DIR' = "${{ github.workspace }}/BinaryCache/libdispatch/cmake/modules";
-              'Foundation_DIR' = "${{ github.workspace }}/BinaryCache/foundation/cmake/modules";
               'XCTest_INSTALL_NESTED_SUBDIR' = "YES";
-              'SwiftTesting_DIR' = "${{ github.workspace }}/BinaryCache/testing/cmake/modules";
+              'SwiftTesting_DIR' = "${{ github.workspace }}/BinaryCache/Testing/cmake/modules";
             }
       - name: Build XCTest
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/xctest
+          cmake --build ${{ github.workspace }}/BinaryCache/XCTest
 
       - name: Install Testing
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/testing --target install
+          cmake --build ${{ github.workspace }}/BinaryCache/Testing --target install
       - name: Install xctest
         if: matrix.os != 'Android' || inputs.build_android
         run: |
-          cmake --build ${{ github.workspace }}/BinaryCache/xctest --target install
+          cmake --build ${{ github.workspace }}/BinaryCache/XCTest --target install
       - name: Install foundation
         if: matrix.os != 'Android' || inputs.build_android
         run: |
@@ -3519,6 +3610,11 @@ jobs:
           setup-vs-dev-env: true
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        with:
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
+
       - name: Compute workspace hash
         id: workspace_hash
         run: |
@@ -3739,7 +3835,7 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-argument-parser
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("Swift")'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";
@@ -3765,7 +3861,8 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-collections
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("C", "Swift")'
+          c-compiler: 'Stage1.C'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";
@@ -3789,7 +3886,7 @@ jobs:
           src-dir: ${{ github.workspace }}/SourceCache/swift-asn1
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-asn1
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("Swift")'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "NO";
@@ -3814,7 +3911,10 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-crypto
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("ASM", "C", "CXX", "Swift")'
+          assembler: 'Stage1'
+          c-compiler: 'Stage1.C'
+          cxx-compiler: 'Stage1.CXX'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "NO";
@@ -3840,9 +3940,9 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-llbuild
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          msvc-compilers: ${{ inputs.use_host_toolchain && '@("CXX")' || '@()' }}
-          pinned-compilers: ${{ inputs.use_host_toolchain && '@()' || '@("CXX")' }}
-          built-compilers: '@("Swift")'
+          c-compiler: 'Stage1.C'
+          cxx-compiler: 'Stage1.CXX'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";
@@ -3869,7 +3969,8 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-system
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("C", "Swift")'
+          c-compiler: 'Stage1.C'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "NO";
@@ -3894,7 +3995,8 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-subprocess
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("C", "Swift")'
+          c-compiler: 'Stage1.C'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "NO";
@@ -3923,7 +4025,8 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-tools-support-core
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("C", "Swift")'
+          c-compiler: 'Stage1.C'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";
@@ -3950,7 +4053,9 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-driver
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("C", "CXX", "Swift")'
+          c-compiler: 'Stage1.C'
+          cxx-compiler: 'Stage1.CXX'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";
@@ -3983,7 +4088,7 @@ jobs:
           src-dir: ${{ github.workspace }}/SourceCache/swift-certificates
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-certificates
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("Swift")'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "NO";
@@ -4010,7 +4115,9 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-tools-protocols
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("C", "CXX", "Swift")'
+          c-compiler: 'Stage1.C'
+          cxx-compiler: 'Stage1.CXX'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";
@@ -4034,7 +4141,9 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-build
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("C", "CXX", "Swift")'
+          c-compiler: 'Stage1.C'
+          cxx-compiler: 'Stage1.CXX'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";
@@ -4074,7 +4183,8 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-package-manager
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("C", "Swift")'
+          c-compiler: 'Stage1.C'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";
@@ -4114,7 +4224,8 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-markdown
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("C", "Swift")'
+          c-compiler: 'Stage1.C'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "NO";
@@ -4141,9 +4252,8 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-format
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          msvc-compilers: ${{ inputs.use_host_toolchain && '@("C")' || '@()' }}
-          pinned-compilers: ${{ inputs.use_host_toolchain && '@()' || '@("C")' }}
-          built-compilers: '@("Swift")'
+          c-compiler: 'Stage1.C'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";
@@ -4171,8 +4281,7 @@ jobs:
           src-dir: ${{ github.workspace }}/SourceCache/swift-lmdb
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-lmdb
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          msvc-compilers: ${{ inputs.use_host_toolchain && '@("C")' || '@()' }}
-          pinned-compilers: ${{ inputs.use_host_toolchain && '@()' || '@("C")' }}
+          c-compiler: 'Stage1.C'
           cmake-defines: |
             @{
               'CMAKE_C_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
@@ -4195,7 +4304,9 @@ jobs:
           src-dir: ${{ github.workspace }}/SourceCache/indexstore-db
           bin-dir: ${{ github.workspace }}/BinaryCache/indexstore-db
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("C", "CXX", "Swift")'
+          c-compiler: 'Stage1.C'
+          cxx-compiler: 'Stage1.CXX'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "NO";
@@ -4227,7 +4338,9 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/sourcekit-lsp
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("C", "Swift")'
+          c-compiler: 'Stage1.C'
+          cxx-compiler: 'Stage1.CXX'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'CMAKE_STATIC_LIBRARY_PREFIX_Swift' = "lib";
@@ -4264,7 +4377,8 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-docc-symbolkit
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("C", "Swift")'
+          c-compiler: 'Stage1.C'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "NO";
@@ -4290,7 +4404,8 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/swift-docc
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("C", "Swift")'
+          c-compiler: 'Stage1.C'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";
@@ -4437,6 +4552,11 @@ jobs:
         with:
           setup-vs-dev-env: true
           host-arch: ${{ matrix.arch }}
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        with:
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
+
       - name: Compute workspace hash
         id: workspace_hash
         run: |
@@ -4502,6 +4622,7 @@ jobs:
           name: Windows-${{ inputs.build_arch }}-sdk
           path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/Windows.platform
 
+      # build.ps1: Build-Inspect
       - name: Configure swift-inspect
         uses: ./SourceCache/ci-build/.github/actions/configure-cmake-project
         with:
@@ -4517,7 +4638,7 @@ jobs:
           bin-dir: ${{ github.workspace }}/BinaryCache/${{ matrix.arch }}/swift-inspect
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
           swift-sdk-path: ${{ github.workspace }}/BinaryCache/Library/Developer/Platforms/${{ matrix.os }}.platform/Developer/SDKs/${{ matrix.os }}.sdk
-          built-compilers: '@("Swift")'
+          swift-compiler: 'Stage1.Swift'
           cmake-defines: |
             @{
               'CMAKE_Swift_FLAGS' =  @(
@@ -6545,6 +6666,10 @@ jobs:
           setup-vs-dev-env: true
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
+      - name: Install CMake ${{ env.CMAKE_VERSION }}
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3 # v4.4.0
+        with:
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
 
       - name: Compute workspace hash
         id: workspace_hash
@@ -6713,9 +6838,9 @@ jobs:
           src-dir: ${{ github.workspace }}/SourceCache/llvm-project/llvm
           bin-dir: ${{ github.workspace }}/BinaryCache/1
           install-dir: ${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr
-          swift-sdk-path: ${{ steps.setup-context.outputs.sdkroot }}
-          msvc-compilers: ${{ inputs.use_host_toolchain && '@("C", "CXX")' || '@()' }}
-          pinned-compilers: ${{ inputs.use_host_toolchain && '@("Swift")' || '@("C", "CXX", "Swift")' }}
+          c-compiler: 'Stage1.C'
+          cxx-compiler: 'Stage1.CXX'
+          swift-compiler: 'Stage1.Swift'
           cache-script: ${{ github.workspace }}/SourceCache/swift/cmake/caches/${{ matrix.os }}-${{ matrix.cpu }}.cmake
           cmake-defines: |
             @{


### PR DESCRIPTION
This brings in the latest changes from upstream build.ps1 into the configure-cmake-project action. This is a needed step to bring in the bootstrapping changes into GHA. While the call sites have been updated to match the new parameters for the action, it is a known expectation that these changes will break the build. Though, due to the bootstrapping changes in upstream Swift, the build is already broken. In particular, the changes will now reference non-existent compilers, until the bootstrapping changes are brought into GHA.

* Bring in all of the latest changes from upstream build.ps1.
* Use CMake 4.4 everywhere.
* Split the action PowerShell into a separate file as there is a character limit in the GHA yaml files.
* Update call sites to roughly match the new format.