### PR TITLE
Filter nulls and empty collections in Add-FlagsDefine

### DIFF
--- a/.github/actions/configure-cmake-project/action.ps1
+++ b/.github/actions/configure-cmake-project/action.ps1
@@ -49,6 +49,11 @@ function Add-KeyValueIfNew([hashtable]$Hashtable, [string]$Key, [string]$Value) 
 }
 
 function Add-FlagsDefine([hashtable]$Defines, [string]$Name, [string[]]$Value) {
+    $Value = @($Value | Where-Object { $null -ne $_ })
+    if ($Value.Count -eq 0) {
+        return
+    }
+
     if ($Defines.Contains($Name)) {
         $Defines[$name] = @($Defines[$name]) + $Value
     } else {


### PR DESCRIPTION
`debug_info: true` with host toolchain, `DebugFlags` is an empty array, which causes problems down the line