### PR TITLE
Standardize CMake install

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -552,9 +552,9 @@ jobs:
           host-arch: ${{ matrix.arch }}
           swift-version: ${{ env.PINNED_BOOTSTRAP_TOOLCHAIN_VERSION }}
       - name: Install CMake ${{ env.CMAKE_VERSION }}
-        uses: ssrobins/install-cmake@da13ba26f50a41d3b03cfe8ca7265903f04a8932 # v1
+        uses: lukka/get-cmake@4a7d025fc60f00db0c7b44ebf783d19b52444830 # v4.4.1
         with:
-          version: ${{ env.CMAKE_VERSION }}
+          cmakeVersion: ${{ env.CMAKE_VERSION }}
 
       - name: Compute workspace hash
         id: workspace_hash


### PR DESCRIPTION
We use `lukka/get-cmake` everywhere but the sqlite job. `ssrobins/install-cmake` doesn't seem like a widely used action and it's buggy (dies from an exception from running `cmake --version` if `cmake` isn't already installed). 

Not sure if Fabrice has a real reason to use it or if it was just accidental, but I think we're safe to harmonize on `lukka/get-cmake`.